### PR TITLE
Implement LightpackCommandLineParser class.

### DIFF
--- a/Software/src/LightpackCommandLineParser.cpp
+++ b/Software/src/LightpackCommandLineParser.cpp
@@ -1,0 +1,137 @@
+#include "LightpackCommandLineParser.hpp"
+
+LightpackCommandLineParser::LightpackCommandLineParser()
+    : m_noGUIOption("nogui", "no GUI (console mode)")
+    , m_wizardOption("wizard", "run settings wizard first")
+    , m_backlightOffOption("off", "send 'off leds' command to the device or running instance")
+    , m_backlightOnOption("on", "send 'on leds' command to running instance, if any")
+    , m_debugLevelOption("debug", "verbosity level of debug output (high, mid, low, zero)", "debug")
+    , m_debugLevelHighOption("debug-high", "sets application debug level to high.")
+    , m_debugLevelMidOption("debug-mid", "sets application debug level to mid.")
+    , m_debugLevelLowOption("debug-low", "sets application debug level to low.")
+    , m_debugLevelZeroOption("debug-zero", "sets application debug level to zero.")
+    , m_versionOption(m_parser.addVersionOption())
+    , m_helpOption(m_parser.addHelpOption())
+    , m_optionSetProfile("set-profile", "switch to another profile in already running instance", "profile")
+{
+    m_parser.setApplicationDescription("Prismatik of Lightpack");
+    m_parser.addOption(m_noGUIOption);
+    m_parser.addOption(m_wizardOption);
+    m_parser.addOption(m_backlightOffOption);
+    m_parser.addOption(m_backlightOnOption);
+    m_parser.addOption(m_debugLevelOption);
+    m_parser.addOption(m_debugLevelHighOption);
+    m_parser.addOption(m_debugLevelMidOption);
+    m_parser.addOption(m_debugLevelLowOption);
+    m_parser.addOption(m_debugLevelZeroOption);
+    m_parser.addOption(m_optionSetProfile);
+}
+
+bool LightpackCommandLineParser::isSetNoGUI() const
+{
+    return m_parser.isSet(m_noGUIOption);
+}
+
+bool LightpackCommandLineParser::isSetWizard() const
+{
+    return m_parser.isSet(m_wizardOption);
+}
+
+bool LightpackCommandLineParser::isSetBacklightOff() const
+{
+    return m_parser.isSet(m_backlightOffOption);
+}
+
+bool LightpackCommandLineParser::isSetBacklightOn() const
+{
+    return m_parser.isSet(m_backlightOnOption);
+}
+
+bool LightpackCommandLineParser::isSetVersion() const
+{
+    return m_parser.isSet(m_versionOption);
+}
+
+bool LightpackCommandLineParser::isSetHelp() const
+{
+    return m_parser.isSet(m_helpOption);
+}
+
+bool LightpackCommandLineParser::isSetDebuglevel() const
+{
+    return m_parser.isSet(m_debugLevelOption) ||
+        m_parser.isSet(m_debugLevelHighOption) ||
+        m_parser.isSet(m_debugLevelMidOption) ||
+        m_parser.isSet(m_debugLevelLowOption) ||
+        m_parser.isSet(m_debugLevelZeroOption);
+}
+
+bool LightpackCommandLineParser::isSetProfile() const
+{
+    return m_parser.isSet(m_optionSetProfile);
+}
+
+Debug::DebugLevels LightpackCommandLineParser::debugLevel() const
+{
+    Q_ASSERT(isSetDebuglevel());
+    return m_debugLevel;
+}
+
+QString LightpackCommandLineParser::profileName() const {
+    Q_ASSERT(isSetProfile());
+    return m_profileName;
+}
+
+QString LightpackCommandLineParser::helpText() const {
+    return m_parser.helpText();
+}
+
+QString LightpackCommandLineParser::errorText() const {
+    if (isSetBacklightOff() && isSetBacklightOn())
+        return "Bad options specified!";
+    return m_parser.errorText();
+}
+
+// static
+Debug::DebugLevels LightpackCommandLineParser::parseDebugLevel(const QString& levelValue)
+{
+    if (levelValue == "high")
+        return Debug::HighLevel;
+    else if (levelValue == "mid")
+        return Debug::MidLevel;
+    else if (levelValue == "low")
+        return Debug::LowLevel;
+    else if (levelValue == "zero")
+        return Debug::ZeroLevel;
+
+    Q_ASSERT(false);
+    return Debug::ZeroLevel;
+}
+
+bool LightpackCommandLineParser::parse(const QStringList &arguments)
+{
+    if (!m_parser.parse(arguments))
+        return false;
+
+    if (m_parser.isSet(m_optionSetProfile))
+        m_profileName = m_parser.value(m_optionSetProfile);
+
+    if (m_parser.isSet(m_debugLevelOption))
+    {
+        const QString levelValue(m_parser.value(m_debugLevelOption));
+        m_debugLevel = parseDebugLevel(levelValue);
+    }
+    else if (m_parser.isSet(m_debugLevelHighOption))
+        m_debugLevel = Debug::HighLevel;
+    else if (m_parser.isSet(m_debugLevelMidOption))
+        m_debugLevel = Debug::MidLevel;
+    else if (m_parser.isSet(m_debugLevelLowOption))
+        m_debugLevel = Debug::LowLevel;
+    else if (m_parser.isSet(m_debugLevelZeroOption))
+        m_debugLevel = Debug::ZeroLevel;
+
+    if (isSetBacklightOff() && isSetBacklightOn())
+        return false;
+
+    return true;
+}

--- a/Software/src/LightpackCommandLineParser.hpp
+++ b/Software/src/LightpackCommandLineParser.hpp
@@ -1,0 +1,88 @@
+/*
+ * LightpackCommandLineParser.hpp
+ *
+ *  Created on: 08.08.2014
+ *     Project: Lightpack
+ *
+ *  Lightpack is very simple implementation of the backlight for a laptop
+ *
+ *  Copyright (c) 2014 Woodenshark LLC
+ *
+ *  Lightpack is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Lightpack is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef LIGHTPACKCOMMANDLINEPARSER_H
+#define LIGHTPACKCOMMANDLINEPARSER_H
+
+#include "debug.h"
+#include <QCoreApplication>
+#include <QCommandLineParser>
+
+class LightpackCommandLineParser {
+public:
+    LightpackCommandLineParser();
+
+    bool isSetVersion() const;
+    bool isSetHelp() const;
+    bool isSetNoGUI() const;
+    bool isSetWizard() const;
+    bool isSetBacklightOff() const;
+    bool isSetBacklightOn() const;
+    bool isSetDebuglevel() const;
+    bool isSetProfile() const;
+    // Valid only if isSetDebuglevel() is true.
+    Debug::DebugLevels debugLevel() const;
+
+    // Valid only if isSetProfile() is true.
+    QString profileName() const;
+
+    QString helpText() const;
+    QString errorText() const;
+
+    bool parse(const QStringList& arguments = QCoreApplication::arguments());
+
+private:
+    static Debug::DebugLevels parseDebugLevel(const QString& levelValue);
+
+    QCommandLineParser m_parser;
+    // Options
+    // --nogui
+    const QCommandLineOption m_noGUIOption;
+    // --wizard
+    const QCommandLineOption m_wizardOption;
+    // --off
+    const QCommandLineOption m_backlightOffOption;
+    // --on
+    const QCommandLineOption m_backlightOnOption;
+    // --debug=[high | mid | low | zero]
+    const QCommandLineOption m_debugLevelOption;
+
+    // Keep this for a while for backward compatibility
+    // TODO: remove those options.
+    const QCommandLineOption m_debugLevelHighOption;
+    const QCommandLineOption m_debugLevelMidOption;
+    const QCommandLineOption m_debugLevelLowOption;
+    const QCommandLineOption m_debugLevelZeroOption;
+
+    const QCommandLineOption m_versionOption;
+    const QCommandLineOption m_helpOption;
+    const QCommandLineOption m_optionSetProfile;
+
+    // Values from command line.
+    Debug::DebugLevels m_debugLevel;
+    QString m_profileName;
+};
+
+#endif // LIGHTPACKCOMMANDLINEPARSER_H

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -236,7 +236,8 @@ SOURCES += \
     wizard/SelectDevicePage.cpp \
     wizard/CustomDistributor.cpp \
     systrayicon/SysTrayIcon.cpp \
-    UpdatesProcessor.cpp
+    UpdatesProcessor.cpp \
+    LightpackCommandLineParser.cpp
 
 HEADERS += \
     LightpackApplication.hpp \
@@ -287,7 +288,8 @@ HEADERS += \
     wizard/CustomDistributor.hpp \
     systrayicon/SysTrayIcon.hpp \
     systrayicon/SysTrayIcon_p.hpp \
-    UpdatesProcessor.hpp
+    UpdatesProcessor.hpp \
+    LightpackCommandLineParser.hpp
 
 !contains(DEFINES,UNITY_DESKTOP) {
     HEADERS += systrayicon/SysTrayIcon_qt_p.hpp

--- a/Software/tests/LightpackCommandLineParserTest.cpp
+++ b/Software/tests/LightpackCommandLineParserTest.cpp
@@ -1,0 +1,104 @@
+#include "LightpackCommandLineParserTest.hpp"
+#include "LightpackCommandLineParser.hpp"
+#include <QtTest/QtTest>
+
+LightpackCommandLineParserTest::LightpackCommandLineParserTest(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void LightpackCommandLineParserTest::initTestCase() {}
+void LightpackCommandLineParserTest::init() {}
+void LightpackCommandLineParserTest::cleanup() {}
+
+void LightpackCommandLineParserTest::testCase_parseVersion()
+{
+    LightpackCommandLineParser parser;
+    const QStringList arguments = QStringList() << "app.binary" << "--version";
+
+    QVERIFY(parser.parse(arguments));
+    QVERIFY(parser.isSetVersion());
+
+    const QStringList arguments2 = QStringList() << "app.binary" << "-v";
+    QVERIFY(parser.parse(arguments2));
+    QVERIFY(parser.isSetVersion());
+}
+
+void LightpackCommandLineParserTest::testCase_parseHelp()
+{
+    LightpackCommandLineParser parser;
+    const QStringList arguments = QStringList() << "app.binary" << "--help";
+
+    QVERIFY(parser.parse(arguments));
+    QVERIFY(parser.isSetHelp());
+
+    const QStringList arguments2 = QStringList() << "app.binary" << "-h";
+    QVERIFY(parser.parse(arguments2));
+    QVERIFY(parser.isSetHelp());
+}
+
+void LightpackCommandLineParserTest::testCase_parseWizard()
+{
+    LightpackCommandLineParser parser;
+    const QStringList arguments = QStringList() << "app.binary" << "--wizard";
+
+    QVERIFY(parser.parse(arguments));
+    QVERIFY(parser.isSetWizard());
+}
+
+void LightpackCommandLineParserTest::testCase_parseBacklightOff()
+{
+    LightpackCommandLineParser parser;
+    const QStringList arguments = QStringList() << "app.binary" << "--off";
+
+    QVERIFY(parser.parse(arguments));
+    QVERIFY(parser.isSetBacklightOff());
+}
+
+void LightpackCommandLineParserTest::testCase_parseBacklightOn()
+{
+    LightpackCommandLineParser parser;
+    const QStringList arguments = QStringList() << "app.binary" << "--on";
+
+    QVERIFY(parser.parse(arguments));
+    QVERIFY(parser.isSetBacklightOn());
+}
+
+void LightpackCommandLineParserTest::testCase_parseBacklightOnAndOff()
+{
+    LightpackCommandLineParser parser;
+    const QStringList arguments = QStringList() << "app.binary" << "--on" << "--off";
+
+    QVERIFY(!parser.parse(arguments));
+    QVERIFY(parser.isSetBacklightOn());
+    QVERIFY(parser.isSetBacklightOff());
+}
+
+void LightpackCommandLineParserTest::testCase_parseDebuglevel()
+{
+    const QString levelNames[] = {
+        QString("high"), QString("mid"), QString("low"), QString("zero")
+    };
+    const Debug::DebugLevels levelValues[] = {
+        Debug::HighLevel, Debug::MidLevel, Debug::LowLevel, Debug::ZeroLevel
+    };
+
+    QCOMPARE(sizeof(levelNames)/sizeof(levelNames[0]), sizeof(levelValues)/sizeof(levelValues[0]));
+    for (size_t i = 0; i < sizeof(levelNames)/sizeof(levelNames[0]); ++i)
+    {
+        LightpackCommandLineParser parser;
+        QStringList arguments = QStringList() << "app.binary" << QString("--debug=") + levelNames[i];
+        QVERIFY(parser.parse(arguments));
+        QVERIFY(parser.isSetDebuglevel());
+        QCOMPARE(parser.debugLevel(), levelValues[i]);
+    }
+
+    for (size_t i = 0; i < sizeof(levelNames)/sizeof(levelNames[0]); ++i)
+    {
+        LightpackCommandLineParser parser;
+        QStringList arguments = QStringList() << "app.binary" << QString("--debug-") + levelNames[i];
+        QVERIFY(parser.parse(arguments));
+        QVERIFY(parser.isSetDebuglevel());
+        QCOMPARE(parser.debugLevel(), levelValues[i]);
+    }
+}

--- a/Software/tests/LightpackCommandLineParserTest.hpp
+++ b/Software/tests/LightpackCommandLineParserTest.hpp
@@ -1,0 +1,52 @@
+/*
+ * LightpackCommandLineParserTest.hpp
+ *
+ *  Created on: 08.08.2014
+ *     Project: Lightpack
+ *
+ *  Lightpack is very simple implementation of the backlight for a laptop
+ *
+ *  Copyright (c) 2014 Woodenshark LLC
+ *
+ *  Lightpack is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Lightpack is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef LIGHTPACKCOMMANDLINEPARSERTEST_H
+#define LIGHTPACKCOMMANDLINEPARSERTEST_H
+
+#include <QtTest/QtTest>
+
+class LightpackCommandLineParserTest : public QObject
+{
+    Q_OBJECT
+public:
+    explicit LightpackCommandLineParserTest(QObject *parent = 0);
+
+private slots:
+    void initTestCase();
+
+    void init();
+    void cleanup();
+
+    void testCase_parseVersion();
+    void testCase_parseHelp();
+    void testCase_parseWizard();
+    void testCase_parseBacklightOff();
+    void testCase_parseBacklightOn();
+    void testCase_parseBacklightOnAndOff();
+    void testCase_parseDebuglevel();
+};
+
+#endif // LIGHTPACKCOMMANDLINEPARSERTEST_H

--- a/Software/tests/TestsMain.cpp
+++ b/Software/tests/TestsMain.cpp
@@ -1,4 +1,3 @@
-
 #include <QtTest/QtTest>
 #include "LightpackApiTest.hpp"
 #include "GrabCalculationTest.hpp"
@@ -7,6 +6,7 @@
 #ifdef Q_OS_WIN
 #include "HooksTest.h"
 #endif
+#include "LightpackCommandLineParserTest.hpp"
 #include "debug.h"
 
 #include <iostream>
@@ -32,9 +32,7 @@ int main(int argc, char *argv[])
     tests.append(new LightpackMathTest());
     tests.append(new LightpackApiTest());
     tests.append(new AppVersionTest());
-
-
-
+    tests.append(new LightpackCommandLineParserTest());
 
     for(int i=0; i < tests.size(); i++) {
         if (QTest::qExec(tests[i], argc, argv)) {

--- a/Software/tests/tests.pro
+++ b/Software/tests/tests.pro
@@ -15,6 +15,10 @@ CONFIG     -= app_bundle
 include(../build-config.prf)
 
 CONFIG(gcc):QMAKE_CXXFLAGS += -std=c++11
+CONFIG(clang) {
+    QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++
+    LIBS += -stdlib=libc++
+}
 
 # QMake and GCC produce a lot of stuff
 OBJECTS_DIR = stuff

--- a/Software/tests/tests.pro
+++ b/Software/tests/tests.pro
@@ -49,6 +49,7 @@ HEADERS += \
     ../src/Settings.hpp \
     ../src/Plugin.hpp \
     ../src/LightpackPluginInterface.hpp \
+    ../src/LightpackCommandLineParser.hpp \
     ../grab/include/calculations.hpp \
     ../math/include/PrismatikMath.hpp \
     SettingsWindowMockup.hpp \
@@ -56,7 +57,8 @@ HEADERS += \
     LightpackApiTest.hpp \
     lightpackmathtest.hpp \
     AppVersionTest.hpp \
-    ../src/UpdatesProcessor.hpp
+    ../src/UpdatesProcessor.hpp \
+    LightpackCommandLineParserTest.hpp
 
 SOURCES += \
     ../src/ApiServerSetColorTask.cpp \
@@ -64,13 +66,15 @@ SOURCES += \
     ../src/Settings.cpp \
     ../src/Plugin.cpp \
     ../src/LightpackPluginInterface.cpp \
+    ../src/LightpackCommandLineParser.cpp \
     LightpackApiTest.cpp \
     SettingsWindowMockup.cpp \
     GrabCalculationTest.cpp \
     lightpackmathtest.cpp \
     TestsMain.cpp \
     AppVersionTest.cpp \
-    ../src/UpdatesProcessor.cpp
+    ../src/UpdatesProcessor.cpp \
+    LightpackCommandLineParserTest.cpp
 
 win32{
     HEADERS += \


### PR DESCRIPTION
Hi!
Here is a part of my fork, it does the following things:
- Add alternate way to set debug level (--debug=level).
- Handle --help and --version command switches.
- Add unit-tests for LightpackCommandLineParser class.

Also I enabled C++11 mode for tests.
PTAL.