### PR TITLE
Extract GrabbedArea class from src/GrabWidget

### DIFF
--- a/Software/common/DebugOut.hpp
+++ b/Software/common/DebugOut.hpp
@@ -1,5 +1,5 @@
 /*
- * debug.h
+ *  DebugOut.hpp
  *
  *  Created on: 22.03.2011
  *      Author: Mike Shatohin (brunql)
@@ -26,11 +26,8 @@
 
 #pragma once
 
-#ifndef NO_QT
 #include <QtDebug>
-#include <QString>
-#include <QRect>
-#endif
+
 // Set and store in main.cpp file
 extern unsigned g_debugLevel;
 
@@ -49,14 +46,6 @@ namespace Debug
         LowLevel  = 1,
         ZeroLevel = 0
     };
-#ifndef NO_QT
-    inline const QString toString(QRect rect) {
-        return QString("x=%1, y=%2, width=%3, height=%4").arg(QString::number(rect.x())
-                                                              , QString::number(rect.y())
-                                                              , QString::number(rect.width())
-                                                              , QString::number(rect.height()));
-    }
-#endif
 }
 
 #define DEBUG_HIGH_LEVEL    DEBUG_OUT_FUNC_INFO( 3 )

--- a/Software/common/PrintHelpers.hpp
+++ b/Software/common/PrintHelpers.hpp
@@ -1,0 +1,49 @@
+/*
+ *  Printhelpers.hpp
+ *
+ *  Project: Lightpack
+ *
+ *  Lightpack is very simple implementation of the backlight for a laptop
+ *
+ *  Copyright (c) 2014 Dreamer Dead, dreamer.dead@gmail.com
+ *
+ *  Lightpack is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Lightpack is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <qglobal.h>
+
+#define DEBUG_OUT_RGB( RGB_VALUE ) \
+    qDebug() << #RGB_VALUE << "=" << qRed(RGB_VALUE) << qGreen(RGB_VALUE) << qBlue(RGB_VALUE)
+
+namespace Debug
+{
+inline const QString toString(const QRgb color) {
+    return QString("r=%1, g=%2, b=%3, a=%4").arg(
+        QString::number(qRed(color)),
+        QString::number(qGreen(color)),
+        QString::number(qBlue(color)),
+        QString::number(qAlpha(color)));
+}
+
+inline const QString toString(const QRect& rect) {
+    return QString("x=%1, y=%2, width=%3, height=%4").arg(
+        QString::number(rect.x()),
+        QString::number(rect.y()),
+        QString::number(rect.width()),
+        QString::number(rect.height()));
+}
+}

--- a/Software/common/WinDXUtils.cpp
+++ b/Software/common/WinDXUtils.cpp
@@ -29,13 +29,13 @@
 #include <QtGlobal>
 #include <QString>
 #endif
-#include "../src/debug.h"
-
-#include "msvcstub.h"
 #include <DXGI.h>
 #include <D3D10_1.h>
 #include <D3D10.h>
 #include <d3d9.h>
+
+#include "common/DebugOut.hpp"
+#include "common/msvcstub.h"
 
 #define DXGI_PRESENT_FUNC_ORD 8
 #define D3D9_SCPRESENT_FUNC_ORD 3

--- a/Software/common/defs.h
+++ b/Software/common/defs.h
@@ -26,11 +26,6 @@
 
 #pragma once
 
-#include <qglobal.h>
-
-#define DEBUG_OUT_RGB( RGB_VALUE ) \
-    qDebug() << #RGB_VALUE << "=" << qRed(RGB_VALUE) << qGreen(RGB_VALUE) << qBlue(RGB_VALUE)
-
 // http://msdn.microsoft.com/ru-ru/library/b0084kay.aspx
 // In MSVS2013 round() function was added to CRT.
 #if !defined _MSC_VER || _MSC_VER >= 1700

--- a/Software/grab/D3D10Grabber.cpp
+++ b/Software/grab/D3D10Grabber.cpp
@@ -35,6 +35,7 @@
 #include <QThread>
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QMessageBox>
 #include <D3D10_1.h>
 #include <D3D10.h>
 #include <cstdlib>

--- a/Software/grab/D3D10Grabber.cpp
+++ b/Software/grab/D3D10Grabber.cpp
@@ -35,19 +35,18 @@
 #include <QThread>
 #include <QApplication>
 #include <QDesktopWidget>
-#include <QMessageBox>
-#include <cstdlib>
-#include <stdio.h>
-#include "calculations.hpp"
-#include "WinUtils.hpp"
-#include "../common/WinDXUtils.hpp"
-#include "../../common/D3D10GrabberDefs.hpp"
-#include "../src/debug.h"
-#include "../libraryinjector/ILibraryInjector.h"
-
-#include "../common/msvcstub.h"
 #include <D3D10_1.h>
 #include <D3D10.h>
+#include <cstdlib>
+#include <stdio.h>
+
+#include "common/DebugOut.hpp"
+#include "common/D3D10GrabberDefs.hpp"
+#include "common/msvcstub.h"
+#include "common/WinDXUtils.hpp"
+#include "calculations.hpp"
+#include "WinUtils.hpp"
+#include "../libraryinjector/ILibraryInjector.h"
 
 #define SIZEOF_ARRAY(a) (sizeof(a)/sizeof(a[0]))
 

--- a/Software/grab/DDuplGrabber.cpp
+++ b/Software/grab/DDuplGrabber.cpp
@@ -25,7 +25,7 @@
 
 #include "DDuplGrabber.hpp"
 #include "SessionChangeDetector.hpp"
-#include "debug.h"
+#include "common/DebugOut.hpp"
 
 #ifdef DDUPL_GRAB_SUPPORT
 #include <comdef.h>

--- a/Software/grab/GrabberBase.cpp
+++ b/Software/grab/GrabberBase.cpp
@@ -23,10 +23,11 @@
  *
  */
 
-#include "GrabberContext.hpp"
-#include "GrabWidget.hpp"
 #include "GrabberBase.hpp"
-#include "src/debug.h"
+
+#include "common/DebugOut.hpp"
+#include "common/PrintHelpers.hpp"
+#include "GrabberContext.hpp"
 
 namespace
 {

--- a/Software/grab/GrabberBase.cpp
+++ b/Software/grab/GrabberBase.cpp
@@ -25,8 +25,10 @@
 
 #include "GrabberBase.hpp"
 
+#include "calculations.hpp"
 #include "common/DebugOut.hpp"
 #include "common/PrintHelpers.hpp"
+#include "GrabbedArea.hpp"
 #include "GrabberContext.hpp"
 
 namespace
@@ -134,7 +136,7 @@ void GrabberBase::grab()
         _context->grabResult->clear();
 
         for (int i = 0; i < _context->grabWidgets->size(); ++i) {
-            QRect widgetRect = _context->grabWidgets->at(i)->frameGeometry();
+            QRect widgetRect = _context->grabWidgets->at(i)->geometry();
             getValidRect(widgetRect);
 
             const GrabbedScreen *grabbedScreen = screenOfRect(widgetRect);
@@ -174,7 +176,7 @@ void GrabberBase::grab()
             using namespace Grab;
             const int bytesPerPixel = 4;
             QRgb avgColor;
-            if (_context->grabWidgets->at(i)->isAreaEnabled()) {
+            if (_context->grabWidgets->at(i)->isEnabled()) {
                 Calculations::calculateAvgColor(&avgColor, grabbedScreen->imgData, grabbedScreen->imgFormat, grabbedScreen->screenInfo.rect.width() * bytesPerPixel, preparedRect );
                 _context->grabResult->append(avgColor);
             } else {

--- a/Software/grab/MacOSGrabber.cpp
+++ b/Software/grab/MacOSGrabber.cpp
@@ -23,15 +23,16 @@
  *
  */
 
-#include <QGuiApplication>
 #include"MacOSGrabber.hpp"
 
 #ifdef MAC_OS_CG_GRAB_SUPPORT
 
-#include <CoreGraphics/CoreGraphics.h>
 #include <ApplicationServices/ApplicationServices.h>
+#include <CoreGraphics/CoreGraphics.h>
+#include <QGuiApplication>
+
 #include "calculations.hpp"
-#include "debug.h"
+#include "common/DebugOut.hpp"
 
 const uint32_t kMaxDisplaysCount = 10;
 

--- a/Software/grab/MacOSGrabber.cpp
+++ b/Software/grab/MacOSGrabber.cpp
@@ -23,7 +23,7 @@
  *
  */
 
-#include"MacOSGrabber.hpp"
+#include "MacOSGrabber.hpp"
 
 #ifdef MAC_OS_CG_GRAB_SUPPORT
 
@@ -31,6 +31,7 @@
 #include <CoreGraphics/CoreGraphics.h>
 #include <QGuiApplication>
 
+#include "GrabbedArea.hpp"
 #include "calculations.hpp"
 #include "common/DebugOut.hpp"
 
@@ -59,7 +60,7 @@ void MacOSGrabber::freeScreens()
     _screensWithWidgets.clear();
 }
 
-QList< ScreenInfo > * MacOSGrabber::screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets)
+QList< ScreenInfo > * MacOSGrabber::screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabbedArea *> &grabWidgets)
 {
     CGDirectDisplayID displays[kMaxDisplaysCount];
     uint32_t displayCount;
@@ -72,7 +73,7 @@ QList< ScreenInfo > * MacOSGrabber::screensWithWidgets(QList< ScreenInfo > * res
         for (unsigned int i = 0; i < displayCount; ++i) {
             CGRect cgScreenRect = CGDisplayBounds(displays[i]);
             for (int k = 0; k < grabWidgets.size(); ++k) {
-                QRect rect = grabWidgets[k]->frameGeometry();
+                QRect rect = grabWidgets[k]->geometry();
                 CGPoint widgetCenter = CGPointMake(rect.x() + rect.width() / 2, rect.y() + rect.height() / 2);
                 if (CGRectContainsPoint(cgScreenRect, widgetCenter)) {
                     ScreenInfo screenInfo;
@@ -123,10 +124,6 @@ bool MacOSGrabber::reallocate(const QList<ScreenInfo> &screens)
     const size_t kBytesPerPixel = 4;
     freeScreens();
     for (int i = 0; i < screens.size(); ++i) {
-
-
-        //MacOSScreenData *d = new MacOSScreenData();
-
         int screenid = reinterpret_cast<intptr_t>(screens[i].handle);
 
         qreal pixelRatio = ((QGuiApplication*)QCoreApplication::instance())->devicePixelRatio();
@@ -146,7 +143,6 @@ bool MacOSGrabber::reallocate(const QList<ScreenInfo> &screens)
         grabScreen.imgData = buf;
         grabScreen.imgFormat = BufferFormatArgb;
         grabScreen.screenInfo = screens[i];
-        //grabScreen.associatedData = d;
         _screensWithWidgets.append(grabScreen);
 
     }

--- a/Software/grab/WinAPIGrabber.cpp
+++ b/Software/grab/WinAPIGrabber.cpp
@@ -27,10 +27,11 @@
 
 #ifdef WINAPI_GRAB_SUPPORT
 
-#include "../src/debug.h"
 #include <cmath>
+
+#include "common/DebugOut.hpp"
 #include "calculations.hpp"
-#include "../src/enums.hpp"
+#include "../prismatic/enums.hpp"
 
 struct WinAPIScreenData
 {

--- a/Software/grab/WinAPIGrabber.cpp
+++ b/Software/grab/WinAPIGrabber.cpp
@@ -31,7 +31,6 @@
 
 #include "common/DebugOut.hpp"
 #include "calculations.hpp"
-#include "../prismatic/enums.hpp"
 
 struct WinAPIScreenData
 {

--- a/Software/grab/WinUtils.cpp
+++ b/Software/grab/WinUtils.cpp
@@ -29,7 +29,7 @@
 #include <tlhelp32.h>
 #include <shlwapi.h>
 
-#include "../src/debug.h"
+#include "common/DebugOut.hpp"
 
 #define SIZEOF_ARRAY(a) (sizeof(a)/sizeof(a[0]))
 

--- a/Software/grab/X11Grabber.cpp
+++ b/Software/grab/X11Grabber.cpp
@@ -36,6 +36,8 @@
 #include <errno.h>
 #include <inttypes.h>
 
+#include "common/DebugOut.hpp"
+
 struct X11GrabberData
 {
     X11GrabberData()

--- a/Software/grab/grab.pro
+++ b/Software/grab/grab.pro
@@ -4,8 +4,6 @@
 #
 #-------------------------------------------------
 
-QT       += widgets
-
 DESTDIR = ../lib
 TARGET = grab
 TEMPLATE = lib
@@ -19,7 +17,6 @@ include(configure-grabbers.prf)
 LIBS += -lprismatik-math
 
 INCLUDEPATH += ./include \
-               ../src \
                ../math/include \
                ..
 
@@ -66,6 +63,7 @@ win32 {
 
 HEADERS += \
     include/calculations.hpp \
+    include/GrabbedArea.hpp \
     include/GrabberBase.hpp \
     include/ColorProvider.hpp \
     include/GrabberContext.hpp \

--- a/Software/grab/grab.pro
+++ b/Software/grab/grab.pro
@@ -3,7 +3,6 @@
 # Project created by QtCreator 2013-06-11T16:47:52
 #
 #-------------------------------------------------
-
 DESTDIR = ../lib
 TARGET = grab
 TEMPLATE = lib

--- a/Software/grab/include/GrabbedArea.hpp
+++ b/Software/grab/include/GrabbedArea.hpp
@@ -1,0 +1,38 @@
+/*
+ * GrabbedArea.hpp
+ *
+ *     Project: Prismatik
+ *
+ *  Copyright (c) 2014 dreamer.dead@gmail.com
+ *
+ *  Lightpack is an open-source, USB content-driving ambient lighting
+ *  hardware.
+ *
+ *  Prismatik is a free, open-source software: you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License as published
+ *  by the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Prismatik and Lightpack files is distributed in the hope that it will be
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef GRABBEDAREA_HPP
+#define GRABBEDAREA_HPP
+
+#include <QRect>
+
+class GrabbedArea {
+public:
+    virtual ~GrabbedArea() {}
+    virtual bool isEnabled() const { return false; }
+    virtual QRect geometry() const { return QRect(); }
+};
+
+#endif // GRABBEDAREA_HPP

--- a/Software/grab/include/GrabberBase.hpp
+++ b/Software/grab/include/GrabberBase.hpp
@@ -25,13 +25,16 @@
 
 #pragma once
 
-#include <QSharedPointer>
 #include <QColor>
+#include <QList>
+#include <QRect>
+#include <QScopedPointer>
 #include <QTimer>
-#include "src/GrabWidget.hpp"
-#include "calculations.hpp"
+
+#include "common/BufferFormat.h"
 
 class GrabberContext;
+class GrabbedArea;
 
 enum GrabResult {
     GrabResultOk,
@@ -80,7 +83,7 @@ public:
     /*!
      \param parent standart Qt-specific owner
      \param grabResult \code QList \endcode to write results of grabbing to
-     \param grabWidgets List of GrabWidgets
+     \param grabWidgets List of GrabbedArea
     */
     GrabberBase(QObject * parent, GrabberContext * grabberContext);
     virtual ~GrabberBase() {}
@@ -116,7 +119,7 @@ protected slots:
      * \param grabWidgets
      * \return
      */
-    virtual QList< ScreenInfo > * screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets) = 0;
+    virtual QList< ScreenInfo > * screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabbedArea *> &grabWidgets) = 0;
 
     virtual bool isReallocationNeeded(const QList< ScreenInfo > &grabScreens) const;
 

--- a/Software/grab/include/GrabberContext.hpp
+++ b/Software/grab/include/GrabberContext.hpp
@@ -30,7 +30,7 @@
 #include <QList>
 #include <QRgb>
 
-class GrabWidget;
+class GrabbedArea;
 
 struct AllocatedBuf {
     AllocatedBuf()
@@ -95,7 +95,7 @@ public:
         }
     }
 public:
-    QList<GrabWidget *> *grabWidgets;
+    QList<GrabbedArea *> *grabWidgets;
     QList<QRgb> *grabResult;
 
 

--- a/Software/grab/include/MacOSGrabber.hpp
+++ b/Software/grab/include/MacOSGrabber.hpp
@@ -25,16 +25,15 @@
 
 #pragma once
 
-#include "../common/defs.h"
+#include "common/defs.h"
 
 #ifdef MAC_OS_CG_GRAB_SUPPORT
-
-#include "GrabberBase.hpp"
 
 #include <CoreGraphics/CGColorSpace.h>
 #include <CoreGraphics/CGContext.h>
 #include <CoreGraphics/CGImage.h>
 
+#include "GrabberBase.hpp"
 
 class MacOSGrabber : public GrabberBase
 {
@@ -48,7 +47,7 @@ protected slots:
     virtual GrabResult grabScreens();
     virtual bool reallocate(const QList< ScreenInfo > &grabScreens);
 
-    virtual QList< ScreenInfo > * screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets);
+    virtual QList< ScreenInfo > * screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabbedArea *> &grabWidgets);
 private:
     void freeScreens();
     void toGrabbedScreen(CGImageRef, GrabbedScreen *);

--- a/Software/grab/include/X11Grabber.hpp
+++ b/Software/grab/include/X11Grabber.hpp
@@ -31,7 +31,6 @@
 #ifdef X11_GRAB_SUPPORT
 
 #include <QScopedPointer>
-#include "../src/debug.h"
 
 struct X11GrabberData;
 struct _XDisplay;

--- a/Software/math/PrismatikMath.cpp
+++ b/Software/math/PrismatikMath.cpp
@@ -24,8 +24,9 @@
  */
 
 #include "PrismatikMath.hpp"
+
 #include <algorithm>
-#include "../src/debug.h"
+#include "common/DebugOut.hpp"
 
 namespace PrismatikMath
 {

--- a/Software/math/math.pro
+++ b/Software/math/math.pro
@@ -11,7 +11,8 @@ CONFIG += staticlib
 
 include(../build-config.prf)
 
-INCLUDEPATH += ./include
+INCLUDEPATH += ./include \
+               ../ \
 
 SOURCES += \
     PrismatikMath.cpp

--- a/Software/offsetfinder/main.cpp
+++ b/Software/offsetfinder/main.cpp
@@ -1,7 +1,6 @@
 #include "windows.h"
-#define HOOKSGRABBER_SYSWOW64_DESC
-#include "../common/D3D10GrabberDefs.hpp"
-#include "../common/WinDXUtils.hpp"
+#include "common/D3D10GrabberDefs.hpp"
+#include "common/WinDXUtils.hpp"
 
 LPCWSTR g_szClassName = L"{B0262869-ADE9-4B0A-A4D7-159A80428536}";
 

--- a/Software/offsetfinder/offsetfinder.pro
+++ b/Software/offsetfinder/offsetfinder.pro
@@ -12,9 +12,11 @@ LIBS += -ldxguid
 RC_FILE  = ../res/Libs.rc
 
 QMAKE_LIBS_QT_ENTRY =
-DEFINES += NO_QT
+DEFINES += NO_QT HOOKSGRABBER_SYSWOW64_DESC
 
 include(../build-config.prf)
+
+INCLUDEPATH += ../
 
 # The offsetfinder is used to get the x86 offsets when running as x64
 QMAKE_TARGET.arch = x86

--- a/Software/src/ApiServer.hpp
+++ b/Software/src/ApiServer.hpp
@@ -34,10 +34,11 @@
 #include <QSet>
 #include <QRgb>
 #include <QTime>
+
+#include "common/DebugOut.hpp"
 #include "SettingsWindow.hpp"
 #include "LightpackPluginInterface.hpp"
 #include "ApiServerSetColorTask.hpp"
-#include "debug.h"
 #include "enums.hpp"
 
 struct ClientInfo

--- a/Software/src/ApiServerSetColorTask.cpp
+++ b/Software/src/ApiServerSetColorTask.cpp
@@ -24,10 +24,11 @@
  *
  */
 #include <QThread>
-#include "debug.h"
+#include <cmath>
+
+#include "common/DebugOut.hpp"
 #include "ApiServerSetColorTask.hpp"
 #include "Settings.hpp"
-#include <cmath>
 #include "PrismatikMath.hpp"
 
 ApiServerSetColorTask::ApiServerSetColorTask(QObject *parent) :

--- a/Software/src/ApiServerSetColorTask.hpp
+++ b/Software/src/ApiServerSetColorTask.hpp
@@ -28,7 +28,6 @@
 
 #include <QObject>
 #include <QRgb>
-#include "debug.h"
 
 class ApiServerSetColorTask : public QObject
 {

--- a/Software/src/ColorButton.cpp
+++ b/Software/src/ColorButton.cpp
@@ -1,8 +1,10 @@
-#include "../common/defs.h"
 #include "ColorButton.hpp"
-#include "debug.h"
+
 #include <QPainter>
 #include <QColorDialog>
+
+#include "common/DebugOut.hpp"
+#include "common/defs.h"
 
 #define COLOR_LABEL_SPACING 5
 

--- a/Software/src/GrabConfigWidget.cpp
+++ b/Software/src/GrabConfigWidget.cpp
@@ -24,11 +24,13 @@
  */
 
 #include "GrabConfigWidget.hpp"
-#include "ui_GrabConfigWidget.h"
+
 #include <QPainter>
 #include <QBitmap>
 #include <QDesktopWidget>
-#include "debug.h"
+
+#include "common/DebugOut.hpp"
+#include "ui_GrabConfigWidget.h"
 
 const unsigned GrabConfigWidget::MarginArrow = 20;
 const unsigned GrabConfigWidget::Margin = 10;

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -28,7 +28,7 @@
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QDesktopWidget>
 
-#include "debug.h"
+#include "common/DebugOut.hpp"
 #include "PrismatikMath.hpp"
 #include "Settings.hpp"
 #include "GrabWidget.hpp"

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -119,6 +119,7 @@ GrabManager::~GrabManager()
     }
 
     m_ledWidgets.clear();
+    m_ledWidgetsToGrabbedArea.clear();
 
     for (int i = 0; i < m_grabbers.size(); i++)
         if (m_grabbers[i]){
@@ -519,7 +520,11 @@ void GrabManager::initGrabbers()
 {
     DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 
-    m_grabberContext->grabWidgets = &m_ledWidgets;
+    // TODO: remove this ugly hack.
+    for (int i = 0; i < m_ledWidgets.size(); ++i) {
+        m_ledWidgetsToGrabbedArea << m_ledWidgets[i];
+    }
+    m_grabberContext->grabWidgets = &m_ledWidgetsToGrabbedArea;
     m_grabberContext->grabResult = &m_colorsNew;
 
     for (int i = 0; i < Grab::GrabbersCount; i++)
@@ -643,6 +648,7 @@ void GrabManager::initLedWidgets(int numberOfLeds)
     DEBUG_LOW_LEVEL << Q_FUNC_INFO << numberOfLeds;
 	int widgetFlags = SyncSettings | AllowCoefAndEnableConfig | AllowColorCycle;
 
+    if (m_ledWidgets.size() == 0)
     if (m_ledWidgets.size() == 0)
     {
         DEBUG_LOW_LEVEL << Q_FUNC_INFO << "First widget initialization";

--- a/Software/src/GrabManager.hpp
+++ b/Software/src/GrabManager.hpp
@@ -31,6 +31,8 @@
 #include "enums.hpp"
 
 class GrabberContext;
+class GrabbedArea;
+class GrabWidget;
 class TimeEvaluations;
 class D3D10Grabber;
 
@@ -109,6 +111,7 @@ private:
     QTimer *m_timerFakeGrab;
     QWidget *m_parentWidget;
     QList<GrabWidget *> m_ledWidgets;
+    QList<GrabbedArea *> m_ledWidgetsToGrabbedArea;
     QList<QRgb> m_grabResult;
     const static QColor m_backgroundAndTextColors[10][2];
     TimeEvaluations *m_timeEval;

--- a/Software/src/GrabWidget.cpp
+++ b/Software/src/GrabWidget.cpp
@@ -556,28 +556,28 @@ void GrabWidget::paintEvent(QPaintEvent *)
 }
 
 
-double GrabWidget::getCoefRed()
+double GrabWidget::getCoefRed() const
 {
     DEBUG_HIGH_LEVEL << Q_FUNC_INFO;
 
     return m_coefRed;
 }
 
-double GrabWidget::getCoefGreen()
+double GrabWidget::getCoefGreen() const
 {
     DEBUG_HIGH_LEVEL << Q_FUNC_INFO;
 
     return m_coefGreen;
 }
 
-double GrabWidget::getCoefBlue()
+double GrabWidget::getCoefBlue() const
 {
     DEBUG_HIGH_LEVEL << Q_FUNC_INFO;
 
     return m_coefBlue;
 }
 
-bool GrabWidget::isAreaEnabled()
+bool GrabWidget::isAreaEnabled() const
 {
     DEBUG_HIGH_LEVEL << Q_FUNC_INFO;
 

--- a/Software/src/GrabWidget.cpp
+++ b/Software/src/GrabWidget.cpp
@@ -24,14 +24,15 @@
  *
  */
 
+#include "GrabWidget.hpp"
 
 #include <QtGui>
 #include <QtWidgets/QDesktopWidget>
 #include <QTextItem>
-#include "GrabWidget.hpp"
+ 
 #include "ui_GrabWidget.h"
 #include "Settings.hpp"
-#include "debug.h"
+#include "common/DebugOut.hpp"
 
 using namespace SettingsScope;
 

--- a/Software/src/GrabWidget.hpp
+++ b/Software/src/GrabWidget.hpp
@@ -26,41 +26,47 @@
 
 #pragma once
 
-#include "GrabConfigWidget.hpp"
 #include <functional>
+
+#include "GrabConfigWidget.hpp"
+#include "GrabbedArea.hpp"
 
 namespace Ui {
     class GrabWidget;
 }
 
 enum GrabWidgetFeature : int {
-	SyncSettings = 0x1,
-	AllowCoefAndEnableConfig = 0x10,
-	AllowColorCycle = 0x100,
-	DimUntilInteractedWith = 0x1000
+    SyncSettings = 0x1,
+    AllowCoefAndEnableConfig = 0x10,
+    AllowColorCycle = 0x100,
+    DimUntilInteractedWith = 0x1000
 };
 
-class GrabWidget : public QWidget
+class GrabWidget : public QWidget, public GrabbedArea
 {
     Q_OBJECT
 public:
-	GrabWidget(int id, int features = 0x11, QList<GrabWidget*> *fellows = NULL, QWidget *parent = 0);
+    GrabWidget(int id, int features = 0x11, QList<GrabWidget*> *fellows = NULL, QWidget *parent = 0);
     virtual ~GrabWidget();
 
     void saveSizeAndPosition();
 
-    double getCoefRed();
-    double getCoefGreen();
-    double getCoefBlue();
-    bool isAreaEnabled();
+    double getCoefRed() const;
+    double getCoefGreen() const;
+    double getCoefBlue() const;
+    bool isAreaEnabled() const;
     void fillBackgroundWhite();
     void fillBackgroundColored();
+
+    // GrabbedArea methods
+    virtual bool isEnabled() const { return isAreaEnabled(); }
+    virtual QRect geometry() const { return frameGeometry(); }
 
 private:
     void fillBackground(int index);
 
 signals:
-	void resizeOrMoveStarted(int id);
+    void resizeOrMoveStarted(int id);
     void resizeOrMoveCompleted(int id);
     void mouseRightButtonClicked(int selfId);
     void sizeAndPositionChanged(int w, int h, int x, int y);
@@ -83,13 +89,13 @@ private:
     void setTextColor(QColor color);
     void setOpenConfigButtonBackground(const QColor &color);
 
-	QRect resizeAccordingly(QMouseEvent *pe);
-	bool snapEdgeToScreenOrClosestFellow(
-		QRect& newRect,
-		const QRect& screen,
-		std::function<void(QRect&,int)> setter,
-		std::function<int(const QRect&)> getter,
-		std::function<int(const QRect&)> oppositeGetter);
+    QRect resizeAccordingly(QMouseEvent *pe);
+    bool snapEdgeToScreenOrClosestFellow(
+        QRect& newRect,
+        const QRect& screen,
+        std::function<void(QRect&,int)> setter,
+        std::function<int(const QRect&)> getter,
+        std::function<int(const QRect&)> oppositeGetter);
 
 public:
     static const int ColorIndexWhite = 11;
@@ -133,12 +139,12 @@ private:
     GrabConfigWidget *m_configWidget;
 
     QColor m_textColor;
-	QColor m_backgroundColor;
+    QColor m_backgroundColor;
     QString m_selfIdString;
     QString m_widthHeight;
 
-	int m_features;
-	QList<GrabWidget*> *m_fellows;
+    int m_features;
+    QList<GrabWidget*> *m_fellows;
 
 protected:
     virtual void mousePressEvent(QMouseEvent *pe);

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -25,11 +25,13 @@
  */
 
 #include "LedDeviceAdalight.hpp"
+
+#include <stdio.h>
+#include <QtSerialPort/QSerialPortInfo>
+
+#include "common/DebugOut.hpp"
 #include "PrismatikMath.hpp"
 #include "Settings.hpp"
-#include "debug.h"
-#include "stdio.h"
-#include <QtSerialPort/QSerialPortInfo>
 
 using namespace SettingsScope;
 

--- a/Software/src/LedDeviceAlienFx.cpp
+++ b/Software/src/LedDeviceAlienFx.cpp
@@ -37,9 +37,9 @@
 #endif
 
 #include "LedDeviceAlienFx.hpp"
+
+#include "common/DebugOut.hpp"
 #include "Settings.hpp"
-#include <QtDebug>
-#include "debug.h"
 #include "../alienfx/LFX2.h"
 #include <windows.h>
 

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -25,11 +25,13 @@
  */
 
 #include "LedDeviceArdulight.hpp"
+
+#include <QtSerialPort/QSerialPortInfo>
+#include <stdio.h>
+
 #include "PrismatikMath.hpp"
 #include "Settings.hpp"
-#include "debug.h"
-#include "stdio.h"
-#include <QtSerialPort/QSerialPortInfo>
+#include "common/DebugOut.hpp"
 
 using namespace SettingsScope;
 

--- a/Software/src/LedDeviceLightpack.cpp
+++ b/Software/src/LedDeviceLightpack.cpp
@@ -27,10 +27,11 @@
 #include "LedDeviceLightpack.hpp"
 
 #include <algorithm>
-#include <QtDebug>
-#include "debug.h"
-#include "Settings.hpp"
 #include <QApplication>
+#include <QtDebug>
+
+#include "common/DebugOut.hpp"
+#include "Settings.hpp"
 
 using namespace SettingsScope;
 

--- a/Software/src/LedDeviceVirtual.cpp
+++ b/Software/src/LedDeviceVirtual.cpp
@@ -25,10 +25,11 @@
  */
 
 #include "LedDeviceVirtual.hpp"
+
+#include "common/DebugOut.hpp"
 #include "PrismatikMath.hpp"
 #include "Settings.hpp"
 #include "enums.hpp"
-#include "debug.h"
 
 using namespace SettingsScope;
 

--- a/Software/src/LightpackPluginInterface.cpp
+++ b/Software/src/LightpackPluginInterface.cpp
@@ -1,10 +1,12 @@
+#include "LightpackPluginInterface.hpp"
+
 #include <QtGui>
 #include <QtWidgets/QApplication>
-#include "LightpackPluginInterface.hpp"
+
+#include "common/DebugOut.hpp"
 #include "Plugin.hpp"
 #include "Settings.hpp"
 #include "version.h"
-#include "debug.h"
 
 using namespace SettingsScope;
 

--- a/Software/src/Plugin.hpp
+++ b/Software/src/Plugin.hpp
@@ -2,7 +2,8 @@
 
 #include <QObject>
 #include <QProcess>
-#include "debug.h"
+
+#include "common/DebugOut.hpp"
 
 class Plugin : public QObject
 {

--- a/Software/src/SessionChangeDetector.cpp
+++ b/Software/src/SessionChangeDetector.cpp
@@ -1,5 +1,5 @@
 #include "SessionChangeDetector.hpp"
-#include "debug.h"
+#include "common/DebugOut.hpp"
 #include "LightpackApplication.hpp"
 
 #include <exception>

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -34,7 +34,7 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QUuid>
-#include "debug.h"
+#include "common/DebugOut.hpp"
 
 #define MAIN_CONFIG_FILE_VERSION    "4.0"
 

--- a/Software/src/Settings.hpp
+++ b/Software/src/Settings.hpp
@@ -30,11 +30,12 @@
 #include <QVariant>
 #include <QMutex>
 #include <QColor>
+#include <QPoint>
 
 #include "SettingsDefaults.hpp"
 #include "enums.hpp"
-#include "../common/defs.h"
-#include "debug.h"
+#include "common/defs.h"
+#include "common/DebugOut.hpp"
 #include "types.h"
 
 namespace SettingsScope

--- a/Software/src/SettingsDefaults.hpp
+++ b/Software/src/SettingsDefaults.hpp
@@ -27,8 +27,9 @@
 
 #include <QSize>
 #include <QString>
-#include "debug.h"
-#include "../common/defs.h"
+
+#include "common/DebugOut.hpp"
+#include "common/defs.h"
 #include "enums.hpp"
 
 #ifdef ALIEN_FX_SUPPORTED

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -24,26 +24,26 @@
  *
  */
 
+#include "SettingsWindow.hpp"
+
 #include <QtAlgorithms>
+#include <QScrollBar>
+#include <QMessageBox>
+#include <QStringBuilder>
 #include <QtWidgets/QStatusBar>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QDesktopWidget>
-#include "LightpackApplication.hpp"
 
-#include "SettingsWindow.hpp"
-#include "ui_SettingsWindow.h"
-
-#include "Settings.hpp"
 #include "ColorButton.hpp"
 #include "LedDeviceManager.hpp"
-#include "enums.hpp"
-#include "debug.h"
+#include "LightpackApplication.hpp"
 #include "Plugin.hpp"
+#include "Settings.hpp"
+#include "SettingsDefaults.hpp"
+#include "common/DebugOut.hpp"
+#include "enums.hpp"
 #include "systrayicon/SysTrayIcon.hpp"
-#include <QStringBuilder>
-#include <QScrollBar>
-#include <QMessageBox>
-
+#include "ui_SettingsWindow.h"
 
 using namespace SettingsScope;
 

--- a/Software/src/UpdatesProcessor.cpp
+++ b/Software/src/UpdatesProcessor.cpp
@@ -27,7 +27,7 @@
 #include <QXmlStreamReader>
 #include <QNetworkReply>
 #include "version.h"
-#include "debug.h"
+#include "common/DebugOut.hpp"
 #include "UpdatesProcessor.hpp"
 
 //#define UPDATE_CHECK_URL "https://psieg.de/lightpack/update.xml"

--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -28,9 +28,9 @@
 #include <QMetaType>
 #include <iostream>
 
+#include "common/DebugOut.hpp"
 #include "LightpackApplication.hpp"
 #include "Settings.hpp"
-#include "debug.h"
 #include "LogWriter.hpp"
 #include "SettingsWizard.hpp"
 

--- a/Software/src/wizard/MonitorConfigurationPage.cpp
+++ b/Software/src/wizard/MonitorConfigurationPage.cpp
@@ -24,12 +24,14 @@
  *
  */
 
+#include "MonitorConfigurationPage.hpp"
+
 #include <QDesktopWidget>
 #include <QRadioButton>
-#include "MonitorConfigurationPage.hpp"
+
+#include "common/DebugOut.hpp"
 #include "ui_MonitorConfigurationPage.h"
 #include "MonitorIdForm.hpp"
-#include "debug.h"
 
 MonitorConfigurationPage::MonitorConfigurationPage(bool isInitFromSettings, TransientSettings *ts, QWidget *parent) :
     QWizardPage(parent),

--- a/Software/src/wizard/SelectProfilePage.cpp
+++ b/Software/src/wizard/SelectProfilePage.cpp
@@ -23,11 +23,14 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include <QLineEdit>
+
 #include "SelectProfilePage.hpp"
+
+#include <QLineEdit>
+
+#include "common/DebugOut.hpp"
 #include "ui_SelectProfilePage.h"
 #include "Settings.hpp"
-#include "debug.h"
 
 using namespace SettingsScope;
 

--- a/Software/tests/LightpackApiTest.cpp
+++ b/Software/tests/LightpackApiTest.cpp
@@ -23,20 +23,21 @@
  *
  */
 
+#include "LightpackApiTest.hpp"
+
 #include <QString>
 #include <QtWidgets/QApplication>
 #include <QTest>
+#include <stdlib.h>
+#include <iostream>
 
-#include "debug.h"
 #include "ApiServer.hpp"
 #include "LightpackPluginInterface.hpp"
 #include "Settings.hpp"
-#include "enums.hpp"
 #include "SettingsWindowMockup.hpp"
-
-#include <stdlib.h>
-#include <iostream>
-#include "LightpackApiTest.hpp"
+#include "common/DebugOut.hpp"
+#include "common/PrintHelpers.hpp"
+#include "enums.hpp"
 
 using namespace std;
 using namespace SettingsScope;

--- a/Software/tests/TestsMain.cpp
+++ b/Software/tests/TestsMain.cpp
@@ -1,5 +1,8 @@
 
 #include <QtTest/QtTest>
+#include <iostream>
+
+#include "common/DebugOut.hpp"
 #include "LightpackApiTest.hpp"
 #include "GrabCalculationTest.hpp"
 #include "lightpackmathtest.hpp"
@@ -7,9 +10,6 @@
 #ifdef Q_OS_WIN
 #include "HooksTest.h"
 #endif
-#include "debug.h"
-
-#include <iostream>
 
 using namespace std;
 


### PR DESCRIPTION
The main goal of this PR is to remove dependency QtWidgets from grab/
Also grab/ submodule now doesn't use files from main src/ project.
