### PR TITLE
Updated Python API

### DIFF
--- a/Software/apiexamples/pyLightpack/lightpack.py
+++ b/Software/apiexamples/pyLightpack/lightpack.py
@@ -17,34 +17,34 @@ class lightpack:
 		total_data=[]
 		data = self.connection.recv(8192)
 		total_data.append(data)
-		return b"".join(total_data)
+		return b"".join(total_data).decode()
 		
 	def getProfiles(self):
 		self.connection.send(b"getprofiles\n")
-		profiles = self.__readResult().decode()
+		profiles = self.__readResult()
 		return profiles.split(':')[1].rstrip(';\n\r').split(';')		
 		
 	def getProfile(self):
 		self.connection.send(b"getprofile\n")
-		profile = self.__readResult().decode()
+		profile = self.__readResult()
 		profile = profile.split(':')[1]
 		return profile
 		
 	def getStatus(self):
 		self.connection.send(b"getstatus\n")
-		status = self.__readResult().decode()
+		status = self.__readResult()
 		status = status.split(':')[1]
 		return status
 
 	def getCountLeds(self):
 		self.connection.send(b"getcountleds\n")
-		count = self.__readResult().decode()
+		count = self.__readResult()
 		count = count.split(':')[1]
 		return int(count)
 		
 	def getAPIStatus(self):
 		self.connection.send(b"getstatusapi\n")
-		status = self.__readResult().decode()
+		status = self.__readResult()
 		status = status.split(':')[1]
 		return status
 		
@@ -65,7 +65,7 @@ class lightpack:
 	def setColor(self, n, r, g, b): 	# Set color to the define LED		
 		cmd = 'setcolor:{0}-{1},{2},{3}\n'.format(self.ledMap[n-1], r, g, b)
 		self.connection.send(str.encode(cmd))
-		return self.__readResult().decode()
+		return self.__readResult()
 		
 	def setColorToAll(self, r, g, b): 	# Set one color to all LEDs
 		cmdstr = ''
@@ -74,7 +74,7 @@ class lightpack:
 		cmd = 'setcolor:%s\n' % cmdstr
 		#print("cmd: " + cmd, self.ledMap);
 		self.connection.send(str.encode(cmd))
-		return self.__readResult().decode()
+		return self.__readResult()
 
 	def setGamma(self, g):
 		cmd = 'setgamma:{0}\n'.format(g)
@@ -106,11 +106,11 @@ class lightpack:
 	
 	def turnOn(self):
 		self.connection.send(b"setstatus:on\n")
-		return self.__readResult().decode()
+		return self.__readResult()
 	
 	def turnOff(self):
 		self.connection.send(b"setstatus:off\n")
-		return self.__readResult().decode()
+		return self.__readResult()
 
 	def disconnect(self):
 		self.unlock()

--- a/Software/apiexamples/pyLightpack/lightpack.py
+++ b/Software/apiexamples/pyLightpack/lightpack.py
@@ -10,7 +10,7 @@ class lightpack:
 	def __init__(self, _host, _port, _ledMap = None, _apikey = None):
 		self.host = _host
 		self.port = _port
-		self.ledMap = _ledMap
+		self.ledMap = _ledMap if _ledMap is not None else []
 		self.apikey = _apikey		
 	
 	def __readResult(self):	# Return last-command API answer  (call in every local method)

--- a/Software/apiexamples/pyLightpack/lightpack.py
+++ b/Software/apiexamples/pyLightpack/lightpack.py
@@ -104,6 +104,14 @@ class lightpack:
 		self.connection.send(str.encode(cmd))
 		return self.__readResult()
 	
+	def setFrame(self, leds):
+		cmdstr = ''
+		for i, led in enumerate(leds):
+			cmdstr = str(cmdstr) + '{0}-{1},{2},{3};'.format(self.ledMap[i], led[0], led[1], led[2])
+		cmd = 'setcolor:' + cmdstr + '\n'
+		self.connection.send(str.encode(cmd))
+		self.__readResult()
+	
 	def setGamma(self, g):
 		cmd = 'setgamma:{0}\n'.format(g)
 		self.connection.send(str.encode(cmd))

--- a/Software/apiexamples/pyLightpack/lightpack.py
+++ b/Software/apiexamples/pyLightpack/lightpack.py
@@ -7,7 +7,7 @@ class lightpack:
 #	apikey = 'key'		  # Secure API key which generates by Lightpack software on Dev tab
 #	ledMap = [1,2,3,4,5,6,7,8,9,10] 	#mapped LEDs
 	
-	def __init__(self, _host, _port, _ledMap, _apikey = None):
+	def __init__(self, _host, _port, _ledMap = None, _apikey = None):
 		self.host = _host
 		self.port = _port
 		self.ledMap = _ledMap

--- a/Software/apiexamples/pyLightpack/lightpack.py
+++ b/Software/apiexamples/pyLightpack/lightpack.py
@@ -3,9 +3,9 @@ import socket
 class lightpack:
 
 #	host = '127.0.0.1'    # The remote host
-#	port = 3636              # The same port as used by the server
-#	apikey = 'key'		  # Secure API key which generates by Lightpack software on Dev tab
-#	ledMap = [1,2,3,4,5,6,7,8,9,10] 	#mapped LEDs
+#	port = 3636           # The same port as used by the server
+#	apikey = 'key'        # Secure API key which generates by Lightpack software on Dev tab
+#	ledMap = [1,2,3,4,5,6,7,8,9,10]  # Mapped LEDs
 	
 	def __init__(self, _host, _port, _ledMap = None, _apikey = None):
 		self.host = _host
@@ -13,17 +13,17 @@ class lightpack:
 		self.ledMap = _ledMap if _ledMap is not None else []
 		self.apikey = _apikey		
 	
-	def __readResult(self):	# Return last-command API answer  (call in every local method)
-		total_data=[]
+	def __readResult(self):  # Return last-command API answer (call in every local method)
+		total_data = []
 		data = self.connection.recv(8192)
 		total_data.append(data)
 		return b"".join(total_data).decode()
-		
+	
 	def getProfiles(self):
 		self.connection.send(b"getprofiles\n")
 		profiles = self.__readResult()
-		return profiles.split(':')[1].rstrip(';\n\r').split(';')		
-		
+		return profiles.split(':')[1].rstrip(';\n\r').split(';')
+	
 	def getProfile(self):
 		self.connection.send(b"getprofile\n")
 		profile = self.__readResult()
@@ -35,7 +35,7 @@ class lightpack:
 		status = self.__readResult()
 		status = status.split(':')[1]
 		return status
-
+	
 	def getCountLeds(self):
 		self.connection.send(b"getcountleds\n")
 		count = self.__readResult()
@@ -47,15 +47,15 @@ class lightpack:
 		self.connection.send(str.encode(cmd))
 		leds = self.__readResult()
 		leds = leds.split(':')[1].split(';')
-		leds2=[]
+		leds2 = []
 		self.ledMap[:] = []
 		for led in leds:
 			if led.isspace():
 				continue
-			leds2.append(str(int(led.split('-')[0])+1) + '-' + led.split('-')[1]) # LED #, indexed at 1
+			leds2.append(str(int(led.split('-')[0])+1) + '-' + led.split('-')[1])  # LED #, indexed at 1
 			self.ledMap.append(int(led.split('-')[0])+1)
 		return leds2
-		
+	
 	def getLedMap(self):
 		cmd = 'getleds\n'
 		self.connection.send(str.encode(cmd))
@@ -67,20 +67,20 @@ class lightpack:
 				continue
 			self.ledMap.append(int(led.split('-')[0])+1)
 		return self.ledMap
-		
+	
 	def getAPIStatus(self):
 		self.connection.send(b"getstatusapi\n")
 		status = self.__readResult()
 		status = status.split(':')[1]
 		return status
-		
-	def connect (self):
-		try: 	#Try to connect to the server API
+	
+	def connect(self):
+		try:  # Try to connect to the server API
 			self.connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-			self.connection.connect((self.host, self.port))			
+			self.connection.connect((self.host, self.port))
 			self.__readResult()
 			if self.apikey is not None:	
-				cmd = 'apikey:' + self.apikey + '\n'			
+				cmd = 'apikey:' + self.apikey + '\n'
 				self.connection.send(str.encode(cmd))
 				self.__readResult()
 			self.getLedMap()
@@ -88,47 +88,46 @@ class lightpack:
 		except:
 			print('Lightpack API server is missing')
 			return -1
-		
-	def setColor(self, n, r, g, b): 	# Set color to the define LED
+	
+	def setColor(self, n, r, g, b):  # Set color to the defined LED
 		if n == 0 or n > len(self.ledMap):
 			return 'out of range\n'
 		cmd = 'setcolor:{0}-{1},{2},{3}\n'.format(self.ledMap[n-1], r, g, b)
 		self.connection.send(str.encode(cmd))
 		return self.__readResult()
-		
-	def setColorToAll(self, r, g, b): 	# Set one color to all LEDs
+	
+	def setColorToAll(self, r, g, b):  # Set one color to all LEDs
 		cmdstr = ''
 		for i in self.ledMap:
-			cmdstr = str(cmdstr) + str(i) + '-{0},{1},{2};'.format(r,g,b)
+			cmdstr = str(cmdstr) + str(i) + '-{0},{1},{2};'.format(r, g, b)
 		cmd = 'setcolor:%s\n' % cmdstr
-		#print("cmd: " + cmd, self.ledMap);
 		self.connection.send(str.encode(cmd))
 		return self.__readResult()
-
+	
 	def setGamma(self, g):
 		cmd = 'setgamma:{0}\n'.format(g)
 		self.connection.send(str.encode(cmd))
 		return self.__readResult()
-		
+	
 	def setSmooth(self, s):
 		cmd = 'setsmooth:{0}\n'.format(s)
 		self.connection.send(str.encode(cmd))
 		return self.__readResult()
-
+	
 	def setBrightness(self, s):
 		cmd = 'setbrightness:{0}\n'.format(s)
 		self.connection.send(str.encode(cmd))
 		return self.__readResult()
-
+	
 	def setProfile(self, p):
 		cmd = 'setprofile:%s\n' % p
 		self.connection.send(str.encode(cmd))
 		return self.__readResult()
-		
+	
 	def lock(self):
 		self.connection.send(b"lock\n")
 		return self.__readResult()
-		
+	
 	def unlock(self):
 		self.connection.send(b"unlock\n")
 		return self.__readResult()
@@ -140,7 +139,7 @@ class lightpack:
 	def turnOff(self):
 		self.connection.send(b"setstatus:off\n")
 		return self.__readResult()
-
+	
 	def disconnect(self):
 		self.unlock()
 		self.connection.close()

--- a/Software/apiexamples/pyLightpack/lightpack.py
+++ b/Software/apiexamples/pyLightpack/lightpack.py
@@ -55,7 +55,7 @@ class lightpack:
 			self.__readResult()
 			if self.apikey is not None:	
 				cmd = 'apikey:' + self.apikey + '\n'			
-				self.connection.send(cmd)
+				self.connection.send(str.encode(cmd))
 				self.__readResult()
 			return 0
 		except:

--- a/Software/apiexamples/pyLightpack/lightpack.py
+++ b/Software/apiexamples/pyLightpack/lightpack.py
@@ -41,6 +41,32 @@ class lightpack:
 		count = self.__readResult()
 		count = count.split(':')[1]
 		return int(count)
+	
+	def getLeds(self):
+		cmd = 'getleds\n'
+		self.connection.send(str.encode(cmd))
+		leds = self.__readResult()
+		leds = leds.split(':')[1].split(';')
+		leds2=[]
+		self.ledMap[:] = []
+		for led in leds:
+			if led.isspace():
+				continue
+			leds2.append(str(int(led.split('-')[0])+1) + '-' + led.split('-')[1]) # LED #, indexed at 1
+			self.ledMap.append(int(led.split('-')[0])+1)
+		return leds2
+		
+	def getLedMap(self):
+		cmd = 'getleds\n'
+		self.connection.send(str.encode(cmd))
+		leds = self.__readResult()
+		leds = leds.split(':')[1].split(';')
+		self.ledMap[:] = []
+		for led in leds:
+			if led.isspace():
+				continue
+			self.ledMap.append(int(led.split('-')[0])+1)
+		return self.ledMap
 		
 	def getAPIStatus(self):
 		self.connection.send(b"getstatusapi\n")
@@ -57,6 +83,7 @@ class lightpack:
 				cmd = 'apikey:' + self.apikey + '\n'			
 				self.connection.send(str.encode(cmd))
 				self.__readResult()
+			self.getLedMap()
 			return 0
 		except:
 			print('Lightpack API server is missing')

--- a/Software/apiexamples/pyLightpack/lightpack.py
+++ b/Software/apiexamples/pyLightpack/lightpack.py
@@ -89,7 +89,9 @@ class lightpack:
 			print('Lightpack API server is missing')
 			return -1
 		
-	def setColor(self, n, r, g, b): 	# Set color to the define LED		
+	def setColor(self, n, r, g, b): 	# Set color to the define LED
+		if n == 0 or n > len(self.ledMap):
+			return 'out of range\n'
 		cmd = 'setcolor:{0}-{1},{2},{3}\n'.format(self.ledMap[n-1], r, g, b)
 		self.connection.send(str.encode(cmd))
 		return self.__readResult()

--- a/Software/apiexamples/pyLightpack/lightpack.py
+++ b/Software/apiexamples/pyLightpack/lightpack.py
@@ -1,4 +1,4 @@
-import socket, time, imaplib, re, sys
+import socket
 
 class lightpack:
 

--- a/Software/apiexamples/pyLightpack/lightpack.py
+++ b/Software/apiexamples/pyLightpack/lightpack.py
@@ -40,7 +40,7 @@ class lightpack:
 		self.connection.send(b"getcountleds\n")
 		count = self.__readResult().decode()
 		count = count.split(':')[1]
-		return count
+		return int(count)
 		
 	def getAPIStatus(self):
 		self.connection.send(b"getstatusapi\n")

--- a/Software/apiexamples/pyLightpack/testall.py
+++ b/Software/apiexamples/pyLightpack/testall.py
@@ -3,7 +3,9 @@ lpack = lightpack.lightpack('127.0.0.1', 3636, [2,3,6,7,1,1,1,4,5,1] )
 lpack.connect()
 
 print("Lock: %s" % lpack.lock())
-print("turnOn: %s" % lpack.turnOn());
+print("turnOn: %s" % lpack.turnOn())
+
+print("LED map: %s" % lpack.getLeds())
 
 num = int(lpack.getCountLeds())
 print("Num leds: %s" % num)
@@ -13,14 +15,15 @@ print("Profile: %s" % lpack.getProfile())
 print("Profiles: %s" % lpack.getProfiles())
 print("getAPIStatus: %s" % lpack.getAPIStatus())
 
-for i in range(0, num-1):
+for i in range(1, num+1):
     print("setColor%d: %s" % (i, lpack.setColor(i, 255, 0, 0)))
     time.sleep(0.1)
 time.sleep(1)
 
-print("setColorToAll: %s" % lpack.setColorToAll(0, 0, 0))
+print("setColorToAll: %s" % lpack.setColorToAll(127, 127, 127))
 time.sleep(1)
 
+print("setColorToAll: %s" % lpack.setColorToAll(0, 0, 0))
 print("turnOff: %s" % lpack.turnOff());
 
 lpack.disconnect()


### PR DESCRIPTION
I updated the Python API library:

- Added `getLeds` and `getLedMap` functions to automatically update the LED list from Prismatik.
- Added `setFrame` function to push an entire frame of color data to the LEDs.
- `_ledMap` now has a default in the constructor, as the map is updated automatically from Prismatik.
- Encoded API key for using key authorized API in Python 3.
- LED count is now returned as an integer.
- Moved string decoding to `__readResult()` function, which should also fix the few functions that were missing it.
- Added range check to `setColor` which should prevent accidentally writing to the n-1 LED in place of 0.

I also cleaned up the whitespace and modified the `testall.py` example to index at 1 (#143) I tested this with Python 2.7 and 3.6.