### PR TITLE
small fixes to device configuration page

### DIFF
--- a/Software/src/wizard/ConfigureDevicePage.cpp
+++ b/Software/src/wizard/ConfigureDevicePage.cpp
@@ -47,10 +47,31 @@ ConfigureDevicePage::ConfigureDevicePage(bool isInitFromSettings, TransientSetti
 
 void ConfigureDevicePage::initializePage()
 {
-	ui->leSerialPortName->setText(SERIAL_PORT_DEFAULT);
 	ui->cbBaudRate->clear();
 	// NOTE: This line emit's signal currentIndex_Changed()
 	ui->cbBaudRate->addItems(Settings::getSupportedSerialPortBaudRates());
+	int currentBaudRate = 0;
+	QString currentSerialPort = NULL;
+	QString currentColorSequence = NULL;
+	if (field("isAdalight").toBool()) {
+		currentBaudRate = Settings::getAdalightSerialPortBaudRate();
+		currentSerialPort = Settings::getAdalightSerialPortName();
+		currentColorSequence = Settings::getColorSequence(SupportedDevices::DeviceTypeAdalight);
+	}
+	else if (field("isArdulight").toBool()) {
+		currentBaudRate = Settings::getArdulightSerialPortBaudRate();
+		currentSerialPort = Settings::getArdulightSerialPortName();
+		currentColorSequence = Settings::getColorSequence(SupportedDevices::DeviceTypeArdulight);
+	}
+	else
+		currentSerialPort = SERIAL_PORT_DEFAULT;
+
+	if (currentBaudRate > 0)
+		ui->cbBaudRate->setCurrentText(QString::number(currentBaudRate));
+	if (currentSerialPort != NULL && currentSerialPort.isEmpty() == false)
+		ui->leSerialPortName->setText(currentSerialPort);
+	if (currentColorSequence != NULL && currentColorSequence.isEmpty() == false)
+		ui->cbColorFormat->setCurrentText(currentColorSequence);
 
 	registerField("serialPort", ui->leSerialPortName);
 	registerField("baudRate", ui->cbBaudRate, "currentText");

--- a/Software/src/wizard/GlobalColorCoefPage.cpp
+++ b/Software/src/wizard/GlobalColorCoefPage.cpp
@@ -76,9 +76,9 @@ void GlobalColorCoefPage::initializePage()
 	this->activateWindow();
 
 	if (_isInitFromSettings) {
-		_ui->sbRed->setValue(SettingsScope::Settings::getLedCoefRed(1) * 100);
-		_ui->sbGreen->setValue(SettingsScope::Settings::getLedCoefGreen(1) * 100);
-		_ui->sbBlue->setValue(SettingsScope::Settings::getLedCoefBlue(1) * 100);
+		_ui->sbRed->setValue(SettingsScope::Settings::getLedCoefRed(1) * _ui->sbRed->maximum());
+		_ui->sbGreen->setValue(SettingsScope::Settings::getLedCoefGreen(1) * _ui->sbGreen->maximum());
+		_ui->sbBlue->setValue(SettingsScope::Settings::getLedCoefBlue(1) * _ui->sbBlue->maximum());
 	}
 
 	resetDeviceSettings();
@@ -118,9 +118,9 @@ bool GlobalColorCoefPage::validatePage()
 	for (int id : _transSettings->zonePositions.keys()) {
 		Settings::setLedPosition(id, _transSettings->zonePositions[id]);
 		Settings::setLedSize(id, _transSettings->zoneSizes[id]);
-		Settings::setLedCoefRed(id, _ui->sbRed->value() / 100.0);
-		Settings::setLedCoefGreen(id, _ui->sbGreen->value() / 100.0);
-		Settings::setLedCoefBlue(id, _ui->sbBlue->value() / 100.0);
+		Settings::setLedCoefRed(id, _ui->sbRed->value() / (double)_ui->sbRed->maximum());
+		Settings::setLedCoefGreen(id, _ui->sbGreen->value() / (double)_ui->sbGreen->maximum());
+		Settings::setLedCoefBlue(id, _ui->sbBlue->value() / (double)_ui->sbBlue->maximum());
 	}
 
 	cleanupMonitors();
@@ -138,9 +138,9 @@ void GlobalColorCoefPage::onCoefValueChanged()
 
 	for (int led = 0; led < _transSettings->ledCount; ++led) {
 		WBAdjustment wba;
-		wba.red = _ui->sbRed->value() / 100.0;
-		wba.green = _ui->sbGreen->value() / 100.0;
-		wba.blue = _ui->sbBlue->value() / 100.0;
+		wba.red = _ui->sbRed->value() / (double)_ui->sbRed->maximum();
+		wba.green = _ui->sbGreen->value() / (double)_ui->sbGreen->maximum();
+		wba.blue = _ui->sbBlue->value() / (double)_ui->sbBlue->maximum();
 		adjustments.append(wba);
 	}
 


### PR DESCRIPTION
The configuration page wasn't reading current settings to prefill baud rate / serial port / color sequence, so you had to redo those manually every time.
And for RGB coefs, I switched to the actual maximum value of the UI element to scale them before reading from / saving to settings instead of hardcoded values.