### PR TITLE
leds off on exit

### DIFF
--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -62,7 +62,7 @@ LightpackApplication::LightpackApplication(int &argc, char **argv)
 
 LightpackApplication::~LightpackApplication()
 {
-
+	getLightpackApp()->settingsWnd()->switchOffLeds();
 	m_moodlampManager->start(false);
 	m_grabManager->start(false);
 	m_pluginManager->StopPlugins();


### PR DESCRIPTION
So when the app closes, the LEDs are left on forever with whatever last "frame" was, which is not very practical.
I'm using an arduino with a minimalistic firmware and that's the behavior I'm experiencing.
Maybe it already works with a legit Lightpack, I don't know, haven't investigated that far.
This fixes it and works fine on my system so far, but I'm not 100% sure about these calls
`QApplication::processEvents(QEventLoop::AllEvents, 500);`

on `SessionChangeDetector::SessionChange::Ending` the `switchOffLeds()` call is surrounded with those
however in the destructor `~LightpackApplication()` there is only one call (with same total maxtime). I don't know what's the reason behind that difference and if we need to replicate those double calls in the destructor... but it works with one it seems.