### PR TITLE
Baud Rate Warning Text Fix

### DIFF
--- a/Software/src/wizard/ConfigureDevicePage.ui
+++ b/Software/src/wizard/ConfigureDevicePage.ui
@@ -136,8 +136,17 @@
        </item>
        <item row="6" column="1">
         <widget class="QLabel" name="label">
+         <property name="minimumSize">
+          <size>
+           <width>195</width>
+           <height>26</height>
+          </size>
+         </property>
          <property name="text">
           <string>Warning: Values larger than 115200  are entirely untested. Use at your own risk.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/Software/src/wizard/ConfigureDevicePage.ui
+++ b/Software/src/wizard/ConfigureDevicePage.ui
@@ -143,7 +143,7 @@
           </size>
          </property>
          <property name="text">
-          <string>Warning: Values larger than 115200  are entirely untested. Use at your own risk.</string>
+          <string>Warning: Values larger than 115200 are entirely untested. Use at your own risk.</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>


### PR DESCRIPTION
In the setup wizard, the baud rate warning text can be vertically truncated by resizing the window. This PR sets a minimum size and aligns it so it's always visible.