### PR TITLE
night light support (clean)

### DIFF
--- a/Software/build-vars.prf.default
+++ b/Software/build-vars.prf.default
@@ -15,6 +15,10 @@ win32: {
 	BASS_DIR = "C:\\bass"
 	BASSWASAPI_DIR = "C:\\bass\\wasapi"
 
+	# optional: Night Light support, x86_64 only (https://github.com/zomfg/NightLightLibrary/releases)
+	DEFINES += NIGHTLIGHT_SUPPORT
+	NIGHTLIGHT_DIR = C:\\NightLightLibrary
+
     # Set this to x86 to compile 32-bit
     TARGET_ARCH = x86_64
 }

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -237,7 +237,7 @@ void GrabManager::onGrabApplyGammaRampChanged(bool state)
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << state;
 	m_isApplyGammaRamp = state;
 #ifdef Q_OS_WIN
-	if (m_isApplyGammaRamp && NightLightLibrary::NightLight::isSupported(true))
+	if (m_isApplyGammaRamp && NightLightLibrary::NightLightWrapper::isSupported(true))
 		startNightLight();
 	else
 		stopNightLight();
@@ -249,7 +249,7 @@ void GrabManager::startNightLight()
 {
 	if (m_nightLight)
 		return;
-	m_nightLight = std::make_unique<NightLightLibrary::NightLight>();
+	m_nightLight = std::make_unique<NightLightLibrary::NightLightWrapper>();
 	m_nightLight->startWatching();
 }
 

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -414,7 +414,7 @@ void GrabManager::handleGrabbedColors()
 	else if (m_isApplyGammaRamp)
 	{
 #ifdef NIGHTLIGHT_SUPPORT
-		if (m_nightLight && (m_nightLight->isEnabled() || m_nightLight->isRunning())) {
+		if (m_nightLight) {
 			PrismatikMath::applyColorTemperature(m_colorsProcessing,
 				m_nightLight->getSmoothenedColorTemperature(), // CAVEAT: depends on grabbing framerate
 				SettingsScope::Profile::Grab::GammaDefault); // TODO: actual setting?

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -42,8 +42,12 @@
 #include "GrabManager.hpp"
 #ifdef Q_OS_WIN
 #include "WinUtils.hpp"
+
+#ifdef NIGHTLIGHT_SUPPORT
 #include "NightLightLibrary.h"
-#endif
+#endif // NIGHTLIGHT_SUPPORT
+
+#endif // Q_OS_WIN
 
 using namespace SettingsScope;
 
@@ -236,15 +240,15 @@ void GrabManager::onGrabApplyGammaRampChanged(bool state)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << state;
 	m_isApplyGammaRamp = state;
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && defined(NIGHTLIGHT_SUPPORT)
 	if (m_isApplyGammaRamp && NightLightLibrary::NightLightWrapper::isSupported(true))
 		startNightLight();
 	else
 		stopNightLight();
-#endif
+#endif // NIGHTLIGHT_SUPPORT
 }
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && defined(NIGHTLIGHT_SUPPORT)
 void GrabManager::startNightLight()
 {
 	if (m_nightLight)
@@ -261,7 +265,7 @@ void GrabManager::stopNightLight()
 		m_nightLight.reset();
 	}
 }
-#endif
+#endif // NIGHTLIGHT_SUPPORT
 
 void GrabManager::onGrabApplyColorTemperatureChanged(bool state)
 {
@@ -409,15 +413,17 @@ void GrabManager::handleGrabbedColors()
 #ifdef Q_OS_WIN
 	else if (m_isApplyGammaRamp)
 	{
+#ifdef NIGHTLIGHT_SUPPORT
 		if (m_nightLight && (m_nightLight->isEnabled() || m_nightLight->isRunning())) {
 			PrismatikMath::applyColorTemperature(m_colorsProcessing,
 				m_nightLight->getSmoothenedColorTemperature(), // CAVEAT: depends on grabbing framerate
 				SettingsScope::Profile::Grab::GammaDefault); // TODO: actual setting?
 		}
 		else
+#endif // NIGHTLIGHT_SUPPORT
 			WinUtils::ApplyPrimaryGammaRamp(m_colorsProcessing);
 	}
-#endif
+#endif // Q_OS_WIN
 
 	if (m_avgColorsOnAllLeds)
 	{

--- a/Software/src/GrabManager.hpp
+++ b/Software/src/GrabManager.hpp
@@ -30,6 +30,10 @@
 #include "GrabberBase.hpp"
 #include "enums.hpp"
 
+#ifdef Q_OS_WIN
+namespace NightLightLibrary { class NightLight; };
+#endif
+
 class GrabberContext;
 class TimeEvaluations;
 class D3D10Grabber;
@@ -107,6 +111,12 @@ private:
 
 #ifdef D3D10_GRAB_SUPPORT
 	D3D10Grabber *m_d3d10Grabber;
+#endif
+
+#ifdef Q_OS_WIN
+	std::unique_ptr<NightLightLibrary::NightLight> m_nightLight;
+	void startNightLight();
+	void stopNightLight();
 #endif
 
 	QTimer *m_timerUpdateFPS;

--- a/Software/src/GrabManager.hpp
+++ b/Software/src/GrabManager.hpp
@@ -30,9 +30,9 @@
 #include "GrabberBase.hpp"
 #include "enums.hpp"
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && defined(NIGHTLIGHT_SUPPORT)
 namespace NightLightLibrary { class NightLightWrapper; };
-#endif
+#endif // NIGHTLIGHT_SUPPORT
 
 class GrabberContext;
 class TimeEvaluations;
@@ -113,11 +113,11 @@ private:
 	D3D10Grabber *m_d3d10Grabber;
 #endif
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && defined(NIGHTLIGHT_SUPPORT)
 	std::unique_ptr<NightLightLibrary::NightLightWrapper> m_nightLight;
 	void startNightLight();
 	void stopNightLight();
-#endif
+#endif // NIGHTLIGHT_SUPPORT
 
 	QTimer *m_timerUpdateFPS;
 	QTimer *m_timerFakeGrab;

--- a/Software/src/GrabManager.hpp
+++ b/Software/src/GrabManager.hpp
@@ -31,7 +31,7 @@
 #include "enums.hpp"
 
 #ifdef Q_OS_WIN
-namespace NightLightLibrary { class NightLight; };
+namespace NightLightLibrary { class NightLightWrapper; };
 #endif
 
 class GrabberContext;
@@ -114,7 +114,7 @@ private:
 #endif
 
 #ifdef Q_OS_WIN
-	std::unique_ptr<NightLightLibrary::NightLight> m_nightLight;
+	std::unique_ptr<NightLightLibrary::NightLightWrapper> m_nightLight;
 	void startNightLight();
 	void stopNightLight();
 #endif

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -129,19 +129,19 @@ win32 {
     } else {
         warning("unsupported setup - update src.pro to copy dependencies")
     }
-	
+
 	contains(DEFINES,BASS_SOUND_SUPPORT) {
 		INCLUDEPATH += $${BASS_DIR}/c/ \
 			$${BASSWASAPI_DIR}/c/
-		
+
 		contains(QMAKE_TARGET.arch, x86_64) {
 			LIBS += -L$${BASS_DIR}/c/x64/ -L$${BASSWASAPI_DIR}/c/x64/
 		} else {
-			LIBS += -L$${BASS_DIR}/c/ -L$${BASSWASAPI_DIR}/c/		
+			LIBS += -L$${BASS_DIR}/c/ -L$${BASSWASAPI_DIR}/c/
 		}
-		
+
 		LIBS	+= -lbass -lbasswasapi
-		
+
 		contains(QMAKE_TARGET.arch, x86_64) {
 			QMAKE_POST_LINK += cd $(TargetDir) $$escape_expand(\r\n)\
 				copy /y \"$${BASS_DIR}\\x64\\bass.dll\" .\ $$escape_expand(\r\n)\
@@ -149,7 +149,20 @@ win32 {
 		} else {
 			QMAKE_POST_LINK += cd $(TargetDir) $$escape_expand(\r\n)\
 				copy /y \"$${BASS_DIR}\\bass.dll\" .\ $$escape_expand(\r\n)\
-				copy /y \"$${BASSWASAPI_DIR}\\basswasapi.dll\" .\	
+				copy /y \"$${BASSWASAPI_DIR}\\basswasapi.dll\" .\
+		}
+	}
+
+	contains(DEFINES,NIGHTLIGHT_SUPPORT) {
+		contains(QMAKE_TARGET.arch, x86_64) {
+
+			Release:INCLUDEPATH += $${NIGHTLIGHT_DIR}/Release/
+			Release:LIBS += -L$${NIGHTLIGHT_DIR}/Release/
+
+			Debug:INCLUDEPATH += $${NIGHTLIGHT_DIR}/Debug/
+			Debug:LIBS += -L$${NIGHTLIGHT_DIR}/Debug/
+
+			LIBS += -lNightLightLibrary
 		}
 	}
 }


### PR DESCRIPTION
Clone of #214:

I think we are ok to try building this.
I did the qmake bits (`build-vars` and `src.pro`) and `GrabManager`'s `#ifdefs`.
I [re-released](https://github.com/zomfg/NightLightLibrary/releases/tag/v1.1) NightLight library without external includes and with debug/release builds.
I'm able to build first try after (re-)generating the `sln` (but my VS knows about bond and boost so that's the doubt I have at the moment).

Now, as you can see this branch too, has a ton of stray merge commits, this dates from a while ago and it's based on the color-temperature branch that had them, sorry :(
Files of interest are:

- `src/src.pro`
- `src/GrabManager.[ch]pp`
- `build-vars.prf.default`
- `src/SettingsWindow.ui` (help text)