### PR TITLE
macos cg grabber fix

### DIFF
--- a/Software/grab/GrabberBase.cpp
+++ b/Software/grab/GrabberBase.cpp
@@ -27,6 +27,7 @@
 #include "GrabWidget.hpp"
 #include "GrabberBase.hpp"
 #include "src/debug.h"
+#include <cmath>
 
 namespace
 {

--- a/Software/grab/GrabberBase.cpp
+++ b/Software/grab/GrabberBase.cpp
@@ -165,8 +165,18 @@ void GrabberBase::grab()
 			// Convert coordinates from "Main" desktop coord-system to capture-monitor coord-system
 			QRect preparedRect = clippedRect.translated(-monitorRect.x(), -monitorRect.y());
 
+			// grabbed screen was scaled => scale the widget
+			if (grabbedScreen->scale != 1.0)
+				preparedRect.setCoords(
+					std::floor(grabbedScreen->scale * preparedRect.left()),
+					std::floor(grabbedScreen->scale * preparedRect.top()),
+					std::floor(grabbedScreen->scale * preparedRect.right()),
+					std::floor(grabbedScreen->scale * preparedRect.bottom())
+				);
+
 			// Align width by 4 for accelerated calculations
 			preparedRect.setWidth(preparedRect.width() - (preparedRect.width() % 4));
+
 
 			if( !preparedRect.isValid() ){
 				qWarning() << Q_FUNC_INFO << " preparedRect is not valid:" << Debug::toString(preparedRect);
@@ -183,7 +193,7 @@ void GrabberBase::grab()
 				Q_ASSERT(grabbedScreen->imgData);
 				Calculations::calculateAvgColor(
 					&avgColor, grabbedScreen->imgData, grabbedScreen->imgFormat,
-					grabbedScreen->screenInfo.rect.width() * bytesPerPixel,
+					grabbedScreen->bytesPerRow > 0 ? grabbedScreen->bytesPerRow : grabbedScreen->screenInfo.rect.width() * bytesPerPixel,
 					preparedRect);
 				_context->grabResult->append(avgColor);
 			} else {

--- a/Software/grab/MacOSGrabber.cpp
+++ b/Software/grab/MacOSGrabber.cpp
@@ -121,6 +121,7 @@ void toGrabbedScreen(CGImageRef imageRef, GrabbedScreen *screen)
 		((MacOSScreenData*)screen->associatedData)->displayImageRef = imageRef;
 		((MacOSScreenData*)screen->associatedData)->imageDataRef = CGDataProviderCopyData(provider);
 	}
+	screen->scale = ((QGuiApplication*)QCoreApplication::instance())->devicePixelRatio();
 	screen->bytesPerRow = CGImageGetBytesPerRow(imageRef);
 	screen->imgData = CFDataGetBytePtr(((MacOSScreenData*)screen->associatedData)->imageDataRef);
 }

--- a/Software/grab/MacOSGrabber.cpp
+++ b/Software/grab/MacOSGrabber.cpp
@@ -51,14 +51,13 @@ struct MacOSScreenData
 };
 
 bool allocateScreenBuffer(const ScreenInfo& screen,
-                          const qreal pixelRatio,
                           GrabbedScreen& grabScreen)
 {
     CGDirectDisplayID screenId = reinterpret_cast<intptr_t>(screen.handle);
-    const size_t width = CGDisplayPixelsWide(screenId) * pixelRatio;
-    const size_t height = CGDisplayPixelsHigh(screenId) * pixelRatio;
+    const size_t width = CGDisplayPixelsWide(screenId);
+    const size_t height = CGDisplayPixelsHigh(screenId);
 
-    DEBUG_HIGH_LEVEL << "dimensions " << width << "x" << height << pixelRatio << screen.handle;
+    DEBUG_HIGH_LEVEL << "dimensions " << width << "x" << height << screen.handle;
     grabScreen.imgData = nullptr;
     grabScreen.imgFormat = BufferFormatArgb;
     grabScreen.screenInfo = screen;
@@ -172,11 +171,10 @@ QList< ScreenInfo > * MacOSGrabber::screensWithWidgets(
 
 bool MacOSGrabber::reallocate(const QList<ScreenInfo> &screens)
 {
-    const qreal pixelRatio = ((QGuiApplication*)QCoreApplication::instance())->devicePixelRatio();
     freeScreens();
     for (int i = 0; i < screens.size(); ++i) {
         GrabbedScreen grabScreen;
-        if (!allocateScreenBuffer(screens[i], pixelRatio, grabScreen)) {
+        if (!allocateScreenBuffer(screens[i], grabScreen)) {
             qCritical() << "couldn't allocate image buffer";
             freeScreens();
             return false;

--- a/Software/grab/MacOSGrabber.cpp
+++ b/Software/grab/MacOSGrabber.cpp
@@ -121,7 +121,7 @@ void toGrabbedScreen(CGImageRef imageRef, GrabbedScreen *screen)
 		((MacOSScreenData*)screen->associatedData)->displayImageRef = imageRef;
 		((MacOSScreenData*)screen->associatedData)->imageDataRef = CGDataProviderCopyData(provider);
 	}
-
+	screen->bytesPerRow = CGImageGetBytesPerRow(imageRef);
 	screen->imgData = CFDataGetBytePtr(((MacOSScreenData*)screen->associatedData)->imageDataRef);
 }
 

--- a/Software/grab/include/GrabberBase.hpp
+++ b/Software/grab/include/GrabberBase.hpp
@@ -60,6 +60,9 @@ struct GrabbedScreen {
 	BufferFormat imgFormat = BufferFormatUnknown;
 	ScreenInfo screenInfo;
 	void * associatedData = nullptr;
+
+	double scale = 1.0; // if grabber has ability to scale frames
+	size_t bytesPerRow = 0; // some grabbing methods won't return values equal to (width * bytesPerPixel) because of alignment / padding
 };
 
 #define DECLARE_GRABBER_NAME(grabber_name) \


### PR DESCRIPTION
Current macOS grabber uses the raw image buffer without cropping to the actual width, so in some conditions `(width * bytesPerPixel) != bytesPerRow` so `Calculations::calculateAvgColor` is looping out of alignment and returning wrong colors, `GrabbedScreen.bytesPerRow` override fixes this and adds a tiny performance boost thanks to the proper memory alignment.

#79 In HiDPI situations screen dimensions and coords are scaled to whatever, but the image is at full size so widget rects are misplaced when passed to `Calculations::calculateAvgColor`. Using `pixelRatio` as `GrabbedScreen.scale` to resize rects fixes this...
...and increases the performance hit!...or actually brings to what it should've been. I'm thinking maybe we can pass `pixelRatio` to `Calculations::calculateAvgColor` and use it as a multiplier for `pixelsPerStep` as a cheap downscale, but I'm not sure of what kind of `pixelRatio`s exist and if they will keep the loop aligned.
But a better grabber is WIP.

I cherry picked 19547a9 and 819cfe3 from #224 