### PR TITLE
macos device wizard dimensions

### DIFF
--- a/Software/src/wizard/Wizard.ui
+++ b/Software/src/wizard/Wizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>640</width>
-    <height>331</height>
+    <width>750</width>
+    <height>420</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
The UI elements are bigger than on Windows so some parts are squished (especially White Coef page)

And just in case: there seems to be an issue on Qt's side with dark mode
https://bugreports.qt.io/browse/QTBUG-71696
The rest of the app looks good though.