### PR TITLE
soundviz types

### DIFF
--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -735,6 +735,7 @@ void LightpackApplication::initGrabManager()
 	if (m_soundManager)
 	{
 		connect(settings(), SIGNAL(soundVisualizerDeviceChanged(int)),				m_soundManager,		SLOT(setDevice(int)));
+		connect(settings(), SIGNAL(soundVisualizerVisualizerChanged(int)),			m_soundManager,		SLOT(setVisualizer(int)));
 		connect(settings(), SIGNAL(soundVisualizerMaxColorChanged(QColor)),			m_soundManager,		SLOT(setMaxColor(QColor)));
 		connect(settings(), SIGNAL(soundVisualizerMinColorChanged(QColor)),			m_soundManager,		SLOT(setMinColor(QColor)));
 		connect(settings(), SIGNAL(soundVisualizerLiquidSpeedChanged(int)),			m_soundManager,		SLOT(setLiquidModeSpeed(int)));
@@ -767,6 +768,9 @@ void LightpackApplication::initGrabManager()
 		if (m_soundManager) {
 			connect(m_settingsWindow, SIGNAL(requestSoundVizDevices()), m_soundManager, SLOT(requestDeviceList()));
 			connect(m_soundManager, SIGNAL(deviceList(const QList<SoundManagerDeviceInfo> &, int)), m_settingsWindow, SLOT(updateAvailableSoundVizDevices(const QList<SoundManagerDeviceInfo> &, int)));
+
+			connect(m_settingsWindow, SIGNAL(requestSoundVizVisualizers()), m_soundManager, SLOT(requestVisualizerList()));
+			connect(m_soundManager, SIGNAL(visualizerList(const QList<SoundManagerVisualizerInfo> &, int)), m_settingsWindow, SLOT(updateAvailableSoundVizVisualizers(const QList<SoundManagerVisualizerInfo> &, int)));
 		}
 #endif
 	}

--- a/Software/src/MacOSSoundManager.mm
+++ b/Software/src/MacOSSoundManager.mm
@@ -725,7 +725,6 @@ void MacOSSoundManager::start(bool isEnabled)
 			}
 		}
 
-		m_frames = 0;
 		if (device)
 		{
 			if (![_capture setCaptureDevice:device])
@@ -741,8 +740,8 @@ void MacOSSoundManager::start(bool isEnabled)
 		[_capture stop];
 	}
 
-	if (m_isEnabled && m_isLiquidMode)
-		m_generator.start();
+	if (m_isEnabled)
+		m_visualizer->start();
 	else
-		m_generator.stop();
+		m_visualizer->stop();
 }

--- a/Software/src/MacOSSoundManager.mm
+++ b/Software/src/MacOSSoundManager.mm
@@ -740,6 +740,8 @@ void MacOSSoundManager::start(bool isEnabled)
 		[_capture stop];
 	}
 
+	if (m_visualizer == nullptr)
+		return;
 	if (m_isEnabled)
 		m_visualizer->start();
 	else

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -172,6 +172,7 @@ static const QString Speed = "MoodLamp/Speed";
 namespace SoundVisualizer
 {
 static const QString Device = "SoundVisualizer/Device";
+static const QString Visualizer = "SoundVisualizer/Visualizer";
 static const QString MinColor = "SoundVisualizer/MinColor";
 static const QString MaxColor = "SoundVisualizer/MaxColor";
 static const QString IsLiquidMode = "SoundVisualizer/LiquidMode";
@@ -1397,6 +1398,18 @@ void Settings::setSoundVisualizerDevice(int value)
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value;
 	setValue(Profile::Key::SoundVisualizer::Device, value);
 	m_this->soundVisualizerDeviceChanged(value);
+}
+
+int Settings::getSoundVisualizerVisualizer()
+{
+	return value(Profile::Key::SoundVisualizer::Visualizer).toInt();
+}
+
+void Settings::setSoundVisualizerVisualizer(int value)
+{
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value;
+	setValue(Profile::Key::SoundVisualizer::Visualizer, value);
+	m_this->soundVisualizerVisualizerChanged(value);
 }
 
 QColor Settings::getSoundVisualizerMinColor()

--- a/Software/src/Settings.hpp
+++ b/Software/src/Settings.hpp
@@ -200,6 +200,8 @@ public:
 #ifdef SOUNDVIZ_SUPPORT
 	static int getSoundVisualizerDevice();
 	static void setSoundVisualizerDevice(int value);
+	static int getSoundVisualizerVisualizer();
+	static void setSoundVisualizerVisualizer(int value);
 	static QColor getSoundVisualizerMinColor();
 	static void setSoundVisualizerMinColor(QColor color);
 	static QColor getSoundVisualizerMaxColor();
@@ -321,6 +323,7 @@ signals:
 	void moodLampSpeedChanged(int value);
 #ifdef SOUNDVIZ_SUPPORT
 	void soundVisualizerDeviceChanged(int value);
+	void soundVisualizerVisualizerChanged(int value);
 	void soundVisualizerMinColorChanged(const QColor color);
 	void soundVisualizerMaxColorChanged(const QColor color);
 	void soundVisualizerLiquidModeChanged(bool isLiquidMode);

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -250,6 +250,7 @@ void SettingsWindow::connectSignalsSlots()
 	connect(ui->pushButton_SelectColorMoodLamp, SIGNAL(colorChanged(QColor)), this, SLOT(onMoodLampColor_changed(QColor)));
 #ifdef SOUNDVIZ_SUPPORT
 	connect(ui->comboBox_SoundVizDevice, SIGNAL(currentIndexChanged(int)), this, SLOT(onSoundVizDevice_currentIndexChanged(int)));
+	connect(ui->comboBox_SoundVizVisualizer, SIGNAL(currentIndexChanged(int)), this, SLOT(onSoundVizVisualizer_currentIndexChanged(int)));
 	connect(ui->pushButton_SelectColorSoundVizMin, SIGNAL(colorChanged(QColor)), this, SLOT(onSoundVizMinColor_changed(QColor)));
 	connect(ui->pushButton_SelectColorSoundVizMax, SIGNAL(colorChanged(QColor)), this, SLOT(onSoundVizMaxColor_changed(QColor)));
 	connect(ui->radioButton_SoundVizLiquidMode, SIGNAL(toggled(bool)), this, SLOT(onSoundVizLiquidMode_Toggled(bool)));
@@ -493,6 +494,7 @@ void SettingsWindow::onPostInit() {
 	this->requestFirmwareVersion();
 #ifdef SOUNDVIZ_SUPPORT
 	this->requestSoundVizDevices();
+	this->requestSoundVizVisualizers();
 #endif
 
 	if (m_trayIcon) {
@@ -955,6 +957,23 @@ void SettingsWindow::updateAvailableSoundVizDevices(const QList<SoundManagerDevi
 	ui->comboBox_SoundVizDevice->setCurrentIndex(selectIndex);
 	ui->comboBox_SoundVizDevice->blockSignals(false);
 }
+
+void SettingsWindow::updateAvailableSoundVizVisualizers(const QList<SoundManagerVisualizerInfo> & visualizers, int recommended)
+{
+	ui->comboBox_SoundVizVisualizer->blockSignals(true);
+	ui->comboBox_SoundVizVisualizer->clear();
+	int selectedDevice = Settings::getSoundVisualizerVisualizer();
+	if (selectedDevice == -1) selectedDevice = recommended;
+	int selectIndex = -1;
+	for (int i = 0; i < visualizers.size(); i++) {
+		ui->comboBox_SoundVizVisualizer->addItem(visualizers[i].name, visualizers[i].id);
+		if (visualizers[i].id == selectedDevice) {
+			selectIndex = i;
+		}
+	}
+	ui->comboBox_SoundVizVisualizer->setCurrentIndex(selectIndex);
+	ui->comboBox_SoundVizVisualizer->blockSignals(false);
+}
 #endif
 
 // ----------------------------------------------------------------------------
@@ -1363,6 +1382,14 @@ void SettingsWindow::onSoundVizDevice_currentIndexChanged(int index)
 	if (!updatingFromSettings) {
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << index << ui->comboBox_SoundVizDevice->currentData().toInt();
 		Settings::setSoundVisualizerDevice(ui->comboBox_SoundVizDevice->currentData().toInt());
+	}
+}
+
+void SettingsWindow::onSoundVizVisualizer_currentIndexChanged(int index)
+{
+	if (!updatingFromSettings) {
+		DEBUG_MID_LEVEL << Q_FUNC_INFO << index << ui->comboBox_SoundVizVisualizer->currentData().toInt();
+		Settings::setSoundVisualizerVisualizer(ui->comboBox_SoundVizVisualizer->currentData().toInt());
 	}
 }
 
@@ -1778,6 +1805,16 @@ void SettingsWindow::updateUiFromSettings()
 			break;
 		}
 	}
+
+	for (int i = 0; i < ui->comboBox_SoundVizVisualizer->count(); i++) {
+		if (ui->comboBox_SoundVizVisualizer->itemData(i).toInt() == Settings::getSoundVisualizerVisualizer()) {
+			ui->comboBox_SoundVizVisualizer->setCurrentIndex(i);
+			break;
+		}
+	}
+
+	// TODO visu
+
 	ui->pushButton_SelectColorSoundVizMin->setColor					(Settings::getSoundVisualizerMinColor());
 	ui->pushButton_SelectColorSoundVizMax->setColor					(Settings::getSoundVisualizerMaxColor());
 	ui->radioButton_SoundVizConstantMode->setChecked					(!Settings::isSoundVisualizerLiquidMode());

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -1813,8 +1813,6 @@ void SettingsWindow::updateUiFromSettings()
 		}
 	}
 
-	// TODO visu
-
 	ui->pushButton_SelectColorSoundVizMin->setColor					(Settings::getSoundVisualizerMinColor());
 	ui->pushButton_SelectColorSoundVizMax->setColor					(Settings::getSoundVisualizerMaxColor());
 	ui->radioButton_SoundVizConstantMode->setChecked					(!Settings::isSoundVisualizerLiquidMode());

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -962,12 +962,12 @@ void SettingsWindow::updateAvailableSoundVizVisualizers(const QList<SoundManager
 {
 	ui->comboBox_SoundVizVisualizer->blockSignals(true);
 	ui->comboBox_SoundVizVisualizer->clear();
-	int selectedDevice = Settings::getSoundVisualizerVisualizer();
-	if (selectedDevice == -1) selectedDevice = recommended;
+	int selectedVisualizer = Settings::getSoundVisualizerVisualizer();
+	if (selectedVisualizer == -1) selectedVisualizer = recommended;
 	int selectIndex = -1;
 	for (int i = 0; i < visualizers.size(); i++) {
 		ui->comboBox_SoundVizVisualizer->addItem(visualizers[i].name, visualizers[i].id);
-		if (visualizers[i].id == selectedDevice) {
+		if (visualizers[i].id == selectedVisualizer) {
 			selectIndex = i;
 		}
 	}

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -76,6 +76,7 @@ signals:
 	void requestFirmwareVersion();
 #ifdef SOUNDVIZ_SUPPORT
 	void requestSoundVizDevices();
+	void requestSoundVizVisualizers();
 #endif
 	void recreateLedDevice();
 	void resultBacklightStatus(Backlight::Status);
@@ -112,6 +113,7 @@ public slots:
 
 #ifdef SOUNDVIZ_SUPPORT
 	void updateAvailableSoundVizDevices(const QList<SoundManagerDeviceInfo> & devices, int recommended);
+	void updateAvailableSoundVizVisualizers(const QList<SoundManagerVisualizerInfo> & visualizers, int default);
 #endif
 
 	void updatePlugin(QList<Plugin*> plugins);
@@ -135,6 +137,7 @@ private slots:
 	void onMoodLampLiquidMode_Toggled(bool isLiquidMode);
 #ifdef SOUNDVIZ_SUPPORT
 	void onSoundVizDevice_currentIndexChanged(int index);
+	void onSoundVizVisualizer_currentIndexChanged(int index);
 	void onSoundVizMinColor_changed(QColor color);
 	void onSoundVizMaxColor_changed(QColor color);
 	void onSoundVizLiquidMode_Toggled(bool isLiquidMode);

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -113,7 +113,7 @@ public slots:
 
 #ifdef SOUNDVIZ_SUPPORT
 	void updateAvailableSoundVizDevices(const QList<SoundManagerDeviceInfo> & devices, int recommended);
-	void updateAvailableSoundVizVisualizers(const QList<SoundManagerVisualizerInfo> & visualizers, int default);
+	void updateAvailableSoundVizVisualizers(const QList<SoundManagerVisualizerInfo> & visualizers, int recommended);
 #endif
 
 	void updatePlugin(QList<Plugin*> plugins);

--- a/Software/src/SettingsWindow.ui
+++ b/Software/src/SettingsWindow.ui
@@ -889,6 +889,9 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
              </layout>
             </item>
             <item>
+             <widget class="QComboBox" name="comboBox_SoundVizVisualizer"/>
+            </item>
+            <item>
              <layout class="QHBoxLayout" name="horizontalLayout_11">
               <item>
                <widget class="QRadioButton" name="radioButton_SoundVizConstantMode">

--- a/Software/src/SoundManagerBase.cpp
+++ b/Software/src/SoundManagerBase.cpp
@@ -51,8 +51,8 @@ SoundManagerBase* SoundManagerBase::create(int hWnd, QObject* parent)
 SoundManagerBase::SoundManagerBase(QObject *parent) : QObject(parent)
 {
 	SoundVisualizerBase::populateFactoryList(m_visualizerList);
-	initFromSettings();
 	m_fft = (float *)calloc(fftSize(), sizeof(*m_fft));
+	initFromSettings();
 }
 
 SoundManagerBase::~SoundManagerBase()

--- a/Software/src/SoundManagerBase.cpp
+++ b/Software/src/SoundManagerBase.cpp
@@ -215,6 +215,7 @@ void SoundManagerBase::setVisualizer(int value)
 		m_visualizer->setMaxColor(Settings::getSoundVisualizerMaxColor());
 		m_visualizer->setLiquidMode(Settings::isSoundVisualizerLiquidMode());
 		m_visualizer->setSpeed(Settings::getSoundVisualizerLiquidSpeed());
+		m_visualizer->clear(m_colors.size());
 		if (running)
 			m_visualizer->start();
 	}

--- a/Software/src/SoundManagerBase.cpp
+++ b/Software/src/SoundManagerBase.cpp
@@ -1,5 +1,5 @@
 /*
- * SoundManager.cpp
+ * SoundManagerBase.cpp
  *
  *	Created on: 11.12.2011
  *		Project: Lightpack

--- a/Software/src/SoundManagerBase.cpp
+++ b/Software/src/SoundManagerBase.cpp
@@ -50,7 +50,6 @@ SoundManagerBase* SoundManagerBase::create(int hWnd, QObject* parent)
 
 SoundManagerBase::SoundManagerBase(QObject *parent) : QObject(parent)
 {
-	SoundVisualizerBase::populateFactoryList(m_visualizerList);
 	m_fft = (float *)calloc(fftSize(), sizeof(*m_fft));
 	initFromSettings();
 }
@@ -200,16 +199,13 @@ void SoundManagerBase::initColors(int numberOfLeds)
 
 void SoundManagerBase::setVisualizer(int value)
 {
-	if (value >= m_visualizerList.size() || value < 0)
-		return;
-
 	bool running = false;
 	if (m_visualizer) {
 		running = m_visualizer->isRunning();
 		delete m_visualizer;
 		m_visualizer = nullptr;
 	}
-	m_visualizer = m_visualizerList[value]();
+	m_visualizer = SoundVisualizerBase::createWithID(value);
 	if (m_visualizer) {
 		m_visualizer->setMinColor(Settings::getSoundVisualizerMinColor());
 		m_visualizer->setMaxColor(Settings::getSoundVisualizerMaxColor());

--- a/Software/src/SoundManagerBase.cpp
+++ b/Software/src/SoundManagerBase.cpp
@@ -50,7 +50,7 @@ SoundManagerBase* SoundManagerBase::create(int hWnd, QObject* parent)
 
 SoundManagerBase::SoundManagerBase(QObject *parent) : QObject(parent)
 {
-	SoundVisualizerBase::populateFactoryList(m_visulizerList);
+	SoundVisualizerBase::populateFactoryList(m_visualizerList);
 	initFromSettings();
 	m_fft = (float *)calloc(fftSize(), sizeof(*m_fft));
 }
@@ -200,7 +200,7 @@ void SoundManagerBase::initColors(int numberOfLeds)
 
 void SoundManagerBase::setVisualizer(int value)
 {
-	if (value >= m_visulizerList.size())
+	if (value >= m_visualizerList.size() || value < 0)
 		return;
 
 	bool running = false;
@@ -209,7 +209,7 @@ void SoundManagerBase::setVisualizer(int value)
 		delete m_visualizer;
 		m_visualizer = nullptr;
 	}
-	m_visualizer = m_visulizerList[value]();
+	m_visualizer = m_visualizerList[value]();
 	if (m_visualizer) {
 		m_visualizer->setMinColor(Settings::getSoundVisualizerMinColor());
 		m_visualizer->setMaxColor(Settings::getSoundVisualizerMaxColor());

--- a/Software/src/SoundManagerBase.cpp
+++ b/Software/src/SoundManagerBase.cpp
@@ -216,7 +216,7 @@ void SoundManagerBase::setVisualizer(int value)
 		m_visualizer->setLiquidMode(Settings::isSoundVisualizerLiquidMode());
 		m_visualizer->setSpeed(Settings::getSoundVisualizerLiquidSpeed());
 		m_visualizer->clear(m_colors.size());
-		if (running)
+		if (running || m_isEnabled)
 			m_visualizer->start();
 	}
 }

--- a/Software/src/SoundManagerBase.hpp
+++ b/Software/src/SoundManagerBase.hpp
@@ -49,7 +49,7 @@ public:
 signals:
 	void updateLedsColors(const QList<QRgb> & colors);
 	void deviceList(const QList<SoundManagerDeviceInfo> & devices, int recommended);
-	void visualizerList(const QList<SoundManagerVisualizerInfo>& visualizers, int default);
+	void visualizerList(const QList<SoundManagerVisualizerInfo>& visualizers, int recommended);
 
 public:
 	virtual void start(bool isEnabled) { Q_UNUSED(isEnabled); Q_ASSERT(("Not implemented", false)); };
@@ -92,5 +92,5 @@ protected:
 	
 	float*	m_fft{nullptr};
 
-	QList<VisualizerFactory> m_visulizerList;
+	QList<VisualizerFactory> m_visualizerList;
 };

--- a/Software/src/SoundManagerBase.hpp
+++ b/Software/src/SoundManagerBase.hpp
@@ -91,6 +91,4 @@ protected:
 	bool	m_isSendDataOnlyIfColorsChanged{false};
 	
 	float*	m_fft{nullptr};
-
-	QList<VisualizerFactory> m_visualizerList;
 };

--- a/Software/src/SoundManagerBase.hpp
+++ b/Software/src/SoundManagerBase.hpp
@@ -1,5 +1,5 @@
 /*
- * MoodLampManager.hpp
+ * SoundManagerBase.hpp
  *
  *	Created on: 11.12.2011
  *		Project: Lightpack

--- a/Software/src/SoundManagerBase.hpp
+++ b/Software/src/SoundManagerBase.hpp
@@ -27,8 +27,7 @@
 
 #include <QObject>
 #include <QColor>
-#include "LiquidColorGenerator.hpp"
-
+#include "SoundVisualizer.hpp"
 
 struct SoundManagerDeviceInfo {
 	SoundManagerDeviceInfo(){ this->name = ""; this->id = -1; }
@@ -50,6 +49,7 @@ public:
 signals:
 	void updateLedsColors(const QList<QRgb> & colors);
 	void deviceList(const QList<SoundManagerDeviceInfo> & devices, int recommended);
+	void visualizerList(const QList<SoundManagerVisualizerInfo>& visualizers, int default);
 
 public:
 	virtual void start(bool isEnabled) { Q_UNUSED(isEnabled); Q_ASSERT(("Not implemented", false)); };
@@ -65,11 +65,13 @@ public slots:
 	void settingsProfileChanged(const QString &profileName);
 	void setNumberOfLeds(int value);
 	void setDevice(int value);
+	void setVisualizer(int value);
 	void setMinColor(QColor color);
 	void setMaxColor(QColor color);
 	void setLiquidMode(bool isEnabled);
 	void setLiquidModeSpeed(int value);
 	void requestDeviceList();
+	void requestVisualizerList();
 	void updateColors();
 
 protected:
@@ -77,22 +79,18 @@ protected:
 	void initColors(int numberOfLeds);
 	virtual void populateDeviceList(QList<SoundManagerDeviceInfo>& devices, int& recommended) = 0;
 	virtual void updateFft() {};
-	bool applyFft();
 
 protected:
-	LiquidColorGenerator m_generator;
+	SoundVisualizerBase* m_visualizer{nullptr};
 
 	QList<QRgb> m_colors;
-	QList<int> m_peaks;
-	int 	m_frames{0};
 
 	bool	m_isEnabled{false};
 	bool	m_isInited{false};
-	bool	m_isLiquidMode{false};
-	QColor 	m_minColor;
-	QColor 	m_maxColor;
 	int		m_device{-1};
 	bool	m_isSendDataOnlyIfColorsChanged{false};
 	
 	float*	m_fft{nullptr};
+
+	QList<VisualizerFactory> m_visulizerList;
 };

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -79,8 +79,8 @@ const bool PrismatikSoundVisualizer::visualize(const float* const fftData, const
 			color = rgb.rgb();
 		}
 
-		changed |= (colors[i] != color);
-		colors[i] = Settings::isLedEnabled(i) ? color : 0;
+		changed = changed || (colors[i] != color);
+		colors[i] = color;
 	}
 	m_frames++;
 	return changed;
@@ -128,12 +128,14 @@ const bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const
 		}
 			
 		// peak A
-		changed |= (colors[i] != color);
-		colors[i] = Settings::isLedEnabled(i) ? color : 0;
+		QRgb colorA = Settings::isLedEnabled(i) ? color : 0;
+		changed = changed || (colors[i] != colorA);
+		colors[i] = colorA;
 
 		// peak B
-		changed |= (colors[colors.size() - i - 1] != color);
-		colors[colors.size() - i - 1] = Settings::isLedEnabled(colors.size() - i - 1) ? color : 0;
+		QRgb colorB = Settings::isLedEnabled(colors.size() - i - 1) ? color : 0;
+		changed = changed || (colors[colors.size() - i - 1] != colorB);
+		colors[colors.size() - i - 1] = colorB;
 	}
 	if (currentPeak == 0.0f)
 		m_previousPeak = currentPeak;

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -48,8 +48,8 @@ _BODY_\
 };\
 struct _OBJ_NAME_ ## Register {\
 _OBJ_NAME_ ## Register(){\
-	factoryList.append(_OBJ_NAME_ ## SoundVisualizer::create);\
-	infoList.append(SoundManagerVisualizerInfo(_OBJ_NAME_ ## SoundVisualizer::name(), (vizID++)));\
+	visualizerMap.insert(vizID, SoundManagerVisualizerInfo(_OBJ_NAME_ ## SoundVisualizer::name(), _OBJ_NAME_ ## SoundVisualizer::create, vizID));\
+	++vizID;\
 }\
 };\
 _OBJ_NAME_ ## Register _OBJ_NAME_ ## Reg;
@@ -57,22 +57,25 @@ _OBJ_NAME_ ## Register _OBJ_NAME_ ## Reg;
 using namespace SettingsScope;
 
 namespace {
-	static QList<VisualizerFactory> factoryList;
-	static QList<SoundManagerVisualizerInfo> infoList;
+	static QMap<int, SoundManagerVisualizerInfo> visualizerMap;
 	static int vizID = 0;
 }
 
-void SoundVisualizerBase::populateFactoryList(QList<VisualizerFactory>& list)
+SoundVisualizerBase* SoundVisualizerBase::createWithID(const int id)
 {
-	list = factoryList;
+	QMap<int, SoundManagerVisualizerInfo>::const_iterator i = visualizerMap.find(id);
+	if (i != visualizerMap.end())
+		return i.value().factory();
+	qWarning() << Q_FUNC_INFO << "failed to find visualizer ID: " << id;
+	return nullptr;
 }
 
 void SoundVisualizerBase::populateNameList(QList<SoundManagerVisualizerInfo>& list, int& recommended)
 {
-	list = infoList;
+	list = visualizerMap.values();
 
-	if (infoList.size() > 0)
-		recommended = infoList[0].id;
+	if (list.size() > 0)
+		recommended = list[0].id;
 }
 
 #pragma region Prismatik

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -71,12 +71,7 @@ const bool PrismatikSoundVisualizer::visualize(const float* const fftData, const
 		if (Settings::isLedEnabled(i)) {
 			QColor from = m_isLiquidMode ? QColor(0, 0, 0) : m_minColor;
 			QColor to = m_isLiquidMode ? m_generator.current() : m_maxColor;
-			QColor rgb;
-			rgb.setRed(from.red() + (to.red() - from.red()) * (val / (double)SpecHeight));
-			rgb.setGreen(from.green() + (to.green() - from.green()) * (val / (double)SpecHeight));
-			rgb.setBlue(from.blue() + (to.blue() - from.blue()) * (val / (double)SpecHeight));
-
-			color = rgb.rgb();
+			interpolateColor(color, from, to, val, SpecHeight);
 		}
 
 		changed = changed || (colors[i] != color);
@@ -118,13 +113,7 @@ const bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const
 				from.setHsl(from.hue(), from.saturation(), 120);
 				to.setHsl(to.hue() + 180, to.saturation(), 120);
 			}
-
-			QColor rgb;
-			rgb.setRed(from.red() + (to.red() - from.red()) * (i / (double)middleLed));
-			rgb.setGreen(from.green() + (to.green() - from.green()) * (i / (double)middleLed));
-			rgb.setBlue(from.blue() + (to.blue() - from.blue()) * (i / (double)middleLed));
-
-			color = rgb.rgb();
+			interpolateColor(color, from, to, i, middleLed);
 		}
 			
 		// peak A

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -26,6 +26,7 @@
 #include <QTime>
 #include "Settings.hpp"
 #include "SoundVisualizer.hpp"
+#include <cmath>
 
 using namespace SettingsScope;
 

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -1,5 +1,5 @@
 /*
- * SoundManager.cpp
+ * SoundVisualizer.cpp
  *
  *	Created on: 11.12.2011
  *		Project: Lightpack

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -28,7 +28,12 @@
 #include "SoundVisualizer.hpp"
 #include <cmath>
 
-#define DECLARE_VISUALIZER(_OBJ_NAME_,_LABEL_,_ID_,_BODY_) \
+/*
+	_OBJ_NAME_	: class name prefix
+	_LABEL_		: name string to be displayed
+	_BODY_		: class declaration body
+*/
+#define DECLARE_VISUALIZER(_OBJ_NAME_,_LABEL_,_BODY_) \
 class _OBJ_NAME_ ## SoundVisualizer : public SoundVisualizerBase \
 {\
 public:\
@@ -44,7 +49,7 @@ _BODY_\
 struct _OBJ_NAME_ ## Register {\
 _OBJ_NAME_ ## Register(){\
 	factoryList.append(_OBJ_NAME_ ## SoundVisualizer::create);\
-	infoList.append(SoundManagerVisualizerInfo(_OBJ_NAME_ ## SoundVisualizer::name(), _ID_));\
+	infoList.append(SoundManagerVisualizerInfo(_OBJ_NAME_ ## SoundVisualizer::name(), (vizID++)));\
 }\
 };\
 _OBJ_NAME_ ## Register _OBJ_NAME_ ## Reg;
@@ -54,6 +59,7 @@ using namespace SettingsScope;
 namespace {
 	static QList<VisualizerFactory> factoryList;
 	static QList<SoundManagerVisualizerInfo> infoList;
+	static int vizID = 0;
 }
 
 void SoundVisualizerBase::populateFactoryList(QList<VisualizerFactory>& list)
@@ -66,11 +72,11 @@ void SoundVisualizerBase::populateNameList(QList<SoundManagerVisualizerInfo>& li
 	list = infoList;
 
 	if (infoList.size() > 0)
-		recommended = 0;
+		recommended = infoList[0].id;
 }
 
 #pragma region Prismatik
-DECLARE_VISUALIZER(Prismatik, "Prismatik (default)", 0,
+DECLARE_VISUALIZER(Prismatik, "Prismatik (default)",
 public:
 	void clear(const int numberOfLeds);
 private:
@@ -124,7 +130,7 @@ void PrismatikSoundVisualizer::clear(const int numberOfLeds) {
 
 
 #pragma region TwinPeaks
-DECLARE_VISUALIZER(TwinPeaks, "Twin Peaks", 1,
+DECLARE_VISUALIZER(TwinPeaks, "Twin Peaks",
 public:
 private:
 	float m_previousPeak{ 0.0f };

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -108,10 +108,10 @@ const bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const
 	if (m_previousPeak < currentPeak)
 		m_previousPeak = currentPeak;
 
-	const size_t thresholdLed = middleLed * (currentPeak / m_previousPeak);
+	const size_t thresholdLed = m_previousPeak != 0.0f ? middleLed * (currentPeak / m_previousPeak) : 0;
 	for (size_t i = 0; i < middleLed; ++i) {
 		QRgb color = 0;
-		if (i <= thresholdLed) {
+		if (i < thresholdLed) {
 			QColor from = m_isLiquidMode ? m_generator.current() : m_minColor;
 			QColor to = m_isLiquidMode ? from : m_maxColor;
 			if (m_isLiquidMode) {

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -1,0 +1,141 @@
+/*
+ * SoundManager.cpp
+ *
+ *	Created on: 11.12.2011
+ *		Project: Lightpack
+ *
+ *	Copyright (c) 2011 Mike Shatohin, mikeshatohin [at] gmail.com
+ *
+ *	Lightpack a USB content-driving ambient lighting system
+ *
+ *	Lightpack is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Lightpack is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program.	If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <QTime>
+#include "Settings.hpp"
+#include "SoundVisualizer.hpp"
+
+using namespace SettingsScope;
+
+void SoundVisualizerBase::populateFactoryList(QList<VisualizerFactory>& list)
+{
+	list.append(PrismatikSoundVisualizer::create);
+	list.append(TwinPeaksSoundVisualizer::create);
+}
+
+void SoundVisualizerBase::populateNameList(QList<SoundManagerVisualizerInfo>& list, int& recommended)
+{
+	list.append(SoundManagerVisualizerInfo(PrismatikSoundVisualizer::name(), 0));
+	list.append(SoundManagerVisualizerInfo(TwinPeaksSoundVisualizer::name(), 1));
+
+	recommended = 0;
+}
+
+#pragma region Prismatik
+const bool PrismatikSoundVisualizer::visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors)
+{
+	size_t b0 = 0;
+	bool changed = false;
+	for (int i = 0; i < colors.size(); i++)
+	{
+		float peak = 0;
+		size_t b1 = pow(2, i*9.0 / (colors.size() - 1)); // 9 was 10, but the last bucket rarely saw any action
+		if (b1 > fftSize - 1) b1 = fftSize - 1;
+		if (b1 <= b0) b1 = b0 + 1; // make sure it uses at least 1 FFT bin
+		for (; b0 < b1; b0++)
+			if (peak < fftData[1 + b0]) peak = fftData[1 + b0];
+		int val = sqrt(peak) * /* 3 * */ SpecHeight - 4; // scale it (sqrt to make low values more visible)
+		if (val > SpecHeight) val = SpecHeight; // cap it
+		if (val < 0) val = 0; // cap it
+
+		if (m_frames % 5 == 0) m_peaks[i] -= 1;
+		if (m_peaks[i] < 0) m_peaks[i] = 0;
+		if (val > m_peaks[i]) m_peaks[i] = val;
+		if (val < m_peaks[i] - 5)
+			val = (val * SpecHeight) / m_peaks[i]; // scale val according to peak
+
+		QRgb color = 0;
+		if (Settings::isLedEnabled(i)) {
+			QColor from = m_isLiquidMode ? QColor(0, 0, 0) : m_minColor;
+			QColor to = m_isLiquidMode ? m_generator.current() : m_maxColor;
+			QColor rgb;
+			rgb.setRed(from.red() + (to.red() - from.red()) * (val / (double)SpecHeight));
+			rgb.setGreen(from.green() + (to.green() - from.green()) * (val / (double)SpecHeight));
+			rgb.setBlue(from.blue() + (to.blue() - from.blue()) * (val / (double)SpecHeight));
+
+			color = rgb.rgb();
+		}
+
+		changed |= (colors[i] != color);
+		colors[i] = Settings::isLedEnabled(i) ? color : 0;
+	}
+	m_frames++;
+	return changed;
+}
+
+void PrismatikSoundVisualizer::clear(const int numberOfLeds) {
+	m_peaks.clear();
+	for (int i = 0; i < numberOfLeds; ++i)
+		m_peaks << 0;
+}
+#pragma endregion Prismatik
+
+
+
+#pragma region TwinPeaks
+const bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors)
+{
+	bool changed = false;
+	const size_t middleLed = std::floor(colors.size() / 2);
+
+	float currentPeak = 0.0f;
+	for (size_t i = 0; i < fftSize; ++i)
+		currentPeak += fftData[i];
+
+	if (m_previousPeak < currentPeak)
+		m_previousPeak = currentPeak;
+
+	const size_t thresholdLed = middleLed * (currentPeak / m_previousPeak);
+	for (size_t i = 0; i < middleLed; ++i) {
+		QRgb color = 0;
+		if (i <= thresholdLed) {
+			QColor from = m_isLiquidMode ? m_generator.current() : m_minColor;
+			QColor to = m_isLiquidMode ? from : m_maxColor;
+			if (m_isLiquidMode) {
+				from.setHsl(from.hue(), from.saturation(), 120);
+				to.setHsl(to.hue() + 180, to.saturation(), 120);
+			}
+
+			QColor rgb;
+			rgb.setRed(from.red() + (to.red() - from.red()) * (i / (double)middleLed));
+			rgb.setGreen(from.green() + (to.green() - from.green()) * (i / (double)middleLed));
+			rgb.setBlue(from.blue() + (to.blue() - from.blue()) * (i / (double)middleLed));
+
+			color = rgb.rgb();
+		}
+			
+		// peak A
+		changed |= (colors[i] != color);
+		colors[i] = Settings::isLedEnabled(i) ? color : 0;
+
+		// peak B
+		changed |= (colors[colors.size() - i - 1] != color);
+		colors[colors.size() - i - 1] = Settings::isLedEnabled(colors.size() - i - 1) ? color : 0;
+	}
+	if (currentPeak == 0.0f)
+		m_previousPeak = currentPeak;
+	return changed;
+}
+#pragma endregion TwinPeaks

--- a/Software/src/SoundVisualizer.hpp
+++ b/Software/src/SoundVisualizer.hpp
@@ -111,17 +111,17 @@ protected:
 
 #define DECLARE_VISUALIZER(_OBJ_NAME_,_LABEL_) \
 public:\
-_OBJ_NAME_##SoundVisualizer() = default;\
-~##_OBJ_NAME_##SoundVisualizer() = default;\
+_OBJ_NAME_ ## SoundVisualizer() = default;\
+~_OBJ_NAME_ ## SoundVisualizer() = default;\
 \
 static const char* const name() { return _LABEL_; };\
-static SoundVisualizerBase* create() { return new _OBJ_NAME_##SoundVisualizer(); };\
+static SoundVisualizerBase* create() { return new _OBJ_NAME_ ## SoundVisualizer(); };\
 \
 const bool visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors);
 
 class PrismatikSoundVisualizer : public SoundVisualizerBase
 {
-	DECLARE_VISUALIZER(Prismatik, "Prismatik (default)");
+	DECLARE_VISUALIZER(Prismatik,"Prismatik (default)");
 	void clear(const int numberOfLeds);
 private:
 	QList<int> m_peaks;
@@ -130,7 +130,7 @@ private:
 
 class TwinPeaksSoundVisualizer : public SoundVisualizerBase
 {
-	DECLARE_VISUALIZER(TwinPeaks, "Twin Peaks");
+	DECLARE_VISUALIZER(TwinPeaks,"Twin Peaks");
 private:
 	float m_previousPeak{ 0.0f };
 };

--- a/Software/src/SoundVisualizer.hpp
+++ b/Software/src/SoundVisualizer.hpp
@@ -1,5 +1,5 @@
 /*
- * MoodLampManager.hpp
+ * SoundVisualizer.hpp
  *
  *	Created on: 11.12.2011
  *		Project: Lightpack

--- a/Software/src/SoundVisualizer.hpp
+++ b/Software/src/SoundVisualizer.hpp
@@ -99,6 +99,13 @@ public:
 	virtual void clear(const int /*numberOfLeds*/) {};
 
 	virtual const bool visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors) = 0;
+	void interpolateColor(QRgb& outColor, const QColor& from, const QColor& to, const double value, const double maxValue) {
+		QColor rgb;
+		rgb.setRed(from.red() + (to.red() - from.red()) * (value / maxValue));
+		rgb.setGreen(from.green() + (to.green() - from.green()) * (value / maxValue));
+		rgb.setBlue(from.blue() + (to.blue() - from.blue()) * (value / maxValue));
+		outColor = rgb.rgb();
+	}
 
 protected:
 	QColor 	m_minColor;

--- a/Software/src/SoundVisualizer.hpp
+++ b/Software/src/SoundVisualizer.hpp
@@ -115,29 +115,3 @@ protected:
 	bool	m_isRunning{ false };
 	size_t  m_frames{ 0 };
 };
-
-#define DECLARE_VISUALIZER(_OBJ_NAME_,_LABEL_) \
-public:\
-_OBJ_NAME_ ## SoundVisualizer() = default;\
-~_OBJ_NAME_ ## SoundVisualizer() = default;\
-\
-static const char* const name() { return _LABEL_; };\
-static SoundVisualizerBase* create() { return new _OBJ_NAME_ ## SoundVisualizer(); };\
-\
-const bool visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors);
-
-class PrismatikSoundVisualizer : public SoundVisualizerBase
-{
-	DECLARE_VISUALIZER(Prismatik,"Prismatik (default)");
-	void clear(const int numberOfLeds);
-private:
-	QList<int> m_peaks;
-	const int SpecHeight = 1000;
-};
-
-class TwinPeaksSoundVisualizer : public SoundVisualizerBase
-{
-	DECLARE_VISUALIZER(TwinPeaks,"Twin Peaks");
-private:
-	float m_previousPeak{ 0.0f };
-};

--- a/Software/src/SoundVisualizer.hpp
+++ b/Software/src/SoundVisualizer.hpp
@@ -1,0 +1,136 @@
+/*
+ * MoodLampManager.hpp
+ *
+ *	Created on: 11.12.2011
+ *		Project: Lightpack
+ *
+ *	Copyright (c) 2011 Mike Shatohin, mikeshatohin [at] gmail.com
+ *
+ *	Lightpack a USB content-driving ambient lighting system
+ *
+ *	Lightpack is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Lightpack is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program.	If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <QColor>
+#include "LiquidColorGenerator.hpp"
+
+struct SoundManagerVisualizerInfo {
+	SoundManagerVisualizerInfo() { this->name = ""; this->id = -1; }
+	SoundManagerVisualizerInfo(QString name, int id) { this->name = name; this->id = id; }
+	QString name;
+	int id;
+};
+Q_DECLARE_METATYPE(SoundManagerVisualizerInfo);
+
+class SoundVisualizerBase;
+
+typedef SoundVisualizerBase* (*VisualizerFactory)();
+
+class SoundVisualizerBase
+{
+public:
+	static const char* const name() { return "NO_NAME"; };
+	static SoundVisualizerBase* create() { Q_ASSERT_X(false, "SoundVisualizerBase::create()", "not implemented"); return nullptr; };
+	static void populateFactoryList(QList<VisualizerFactory>&);
+	static void populateNameList(QList<SoundManagerVisualizerInfo>&, int& recommended);
+
+	SoundVisualizerBase() = default;
+	virtual ~SoundVisualizerBase() {
+		stop();
+	};
+
+	void setMinColor(const QColor& color) {
+		m_minColor = color;
+	}
+
+	void setMaxColor(const QColor& color) {
+		m_maxColor = color;
+	}
+
+	void setLiquidMode(const bool liquid) {
+		m_isLiquidMode = liquid;
+
+		if (m_isLiquidMode && m_isRunning)
+			m_generator.start();
+		else
+			m_generator.stop();
+	}
+
+	void setSpeed(const int speed) {
+		m_generator.setSpeed(speed);
+	}
+
+	const bool isRunning() const {
+		return m_isRunning;
+	}
+
+	virtual void start() {
+		m_isRunning = true;
+
+		if (m_isLiquidMode)
+			m_generator.start();
+		else
+			m_generator.stop();
+	}
+
+	virtual void stop() {
+		m_isRunning = false;
+		m_generator.stop();
+	}
+
+	virtual void reset() {
+		m_generator.reset();
+	}
+
+	virtual void clear(const int /*numberOfLeds*/) {};
+
+	virtual const bool visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors) = 0;
+
+protected:
+	QColor 	m_minColor;
+	QColor 	m_maxColor;
+	LiquidColorGenerator m_generator;
+	bool	m_isLiquidMode{ false };
+	bool	m_isRunning{ false };
+	size_t  m_frames{ 0 };
+};
+
+#define DECLARE_VISUALIZER(_OBJ_NAME_,_LABEL_) \
+public:\
+_OBJ_NAME_##SoundVisualizer() = default;\
+~##_OBJ_NAME_##SoundVisualizer() = default;\
+\
+static const char* const name() { return _LABEL_; };\
+static SoundVisualizerBase* create() { return new _OBJ_NAME_##SoundVisualizer(); };\
+\
+const bool visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors);
+
+class PrismatikSoundVisualizer : public SoundVisualizerBase
+{
+	DECLARE_VISUALIZER(Prismatik, "Prismatik (default)");
+	void clear(const int numberOfLeds);
+private:
+	QList<int> m_peaks;
+	const int SpecHeight = 1000;
+};
+
+class TwinPeaksSoundVisualizer : public SoundVisualizerBase
+{
+	DECLARE_VISUALIZER(TwinPeaks, "Twin Peaks");
+private:
+	float m_previousPeak{ 0.0f };
+};

--- a/Software/src/SoundVisualizer.hpp
+++ b/Software/src/SoundVisualizer.hpp
@@ -28,25 +28,26 @@
 #include <QColor>
 #include "LiquidColorGenerator.hpp"
 
-struct SoundManagerVisualizerInfo {
-	SoundManagerVisualizerInfo() { this->name = ""; this->id = -1; }
-	SoundManagerVisualizerInfo(QString name, int id) { this->name = name; this->id = id; }
-	QString name;
-	int id;
-};
-Q_DECLARE_METATYPE(SoundManagerVisualizerInfo);
-
 class SoundVisualizerBase;
 
 typedef SoundVisualizerBase* (*VisualizerFactory)();
+
+struct SoundManagerVisualizerInfo {
+	SoundManagerVisualizerInfo() { this->name = ""; this->id = -1; this->factory = nullptr; }
+	SoundManagerVisualizerInfo(QString name, VisualizerFactory factory, int id) { this->name = name; this->id = id; this->factory = factory; }
+	QString name;
+	VisualizerFactory factory;
+	int id;
+};
+Q_DECLARE_METATYPE(SoundManagerVisualizerInfo);
 
 class SoundVisualizerBase
 {
 public:
 	static const char* const name() { return "NO_NAME"; };
 	static SoundVisualizerBase* create() { Q_ASSERT_X(false, "SoundVisualizerBase::create()", "not implemented"); return nullptr; };
-	static void populateFactoryList(QList<VisualizerFactory>&);
 	static void populateNameList(QList<SoundManagerVisualizerInfo>&, int& recommended);
+	static SoundVisualizerBase* createWithID(const int id);
 
 	SoundVisualizerBase() = default;
 	virtual ~SoundVisualizerBase() {

--- a/Software/src/WindowsSoundManager.cpp
+++ b/Software/src/WindowsSoundManager.cpp
@@ -154,6 +154,8 @@ void WindowsSoundManager::start(bool isEnabled)
 		BASS_WASAPI_Free();
 	}
 
+	if (m_visualizer == nullptr)
+		return;
 	if (m_isEnabled)
 		m_visualizer->start();
 	else

--- a/Software/src/WindowsSoundManager.cpp
+++ b/Software/src/WindowsSoundManager.cpp
@@ -147,7 +147,6 @@ void WindowsSoundManager::start(bool isEnabled)
 		// setup update timer (40hz)
 		//m_timer = timeSetEvent(25, 25, (LPTIMECALLBACK)&UpdateSpectrum, 0, TIME_PERIODIC);
 		m_timer.start(25);
-		m_frames = 0;
 	}
 	else
 	{
@@ -155,10 +154,10 @@ void WindowsSoundManager::start(bool isEnabled)
 		BASS_WASAPI_Free();
 	}
 
-	if (m_isEnabled && m_isLiquidMode)
-		m_generator.start();
+	if (m_isEnabled)
+		m_visualizer->start();
 	else
-		m_generator.stop();
+		m_visualizer->stop();
 }
 
 void WindowsSoundManager::updateFft()

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -328,8 +328,8 @@ HEADERS += \
     LightpackCommandLineParser.hpp
 
 contains(DEFINES,SOUNDVIZ_SUPPORT) {
-    SOURCES += SoundManagerBase.cpp
-    HEADERS += SoundManagerBase.hpp
+    SOURCES += SoundManagerBase.cpp SoundVisualizer.cpp
+    HEADERS += SoundManagerBase.hpp SoundVisualizer.hpp
 }
 
 win32 {


### PR DESCRIPTION
just some fun stuff..
the objective was to extract the visualization part from `SoundManager` into its own class
...and while at it, make it simple to add other variants: all you have to do is copy an existing declaration in `SoundVisualizer.cpp` and change name and content to your taste and it should magically appear in the list on the soundviz page