### PR TITLE
mood lamps

### DIFF
--- a/Software/math/include/PrismatikMath.hpp
+++ b/Software/math/include/PrismatikMath.hpp
@@ -62,11 +62,6 @@ namespace PrismatikMath
 			return -1;
 	}
 
-	inline int rand(int val)
-	{
-		return qrand() % val;
-	}
-
 	inline double round(double number)
 	{
 #if defined HAVE_PLATFORM_ROUND_FUNC

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -730,6 +730,7 @@ void LightpackApplication::initGrabManager()
 	connect(settings(), SIGNAL(moodLampColorChanged(QColor)),					m_moodlampManager,	SLOT(setCurrentColor(QColor)));
 	connect(settings(), SIGNAL(moodLampSpeedChanged(int)),						m_moodlampManager,	SLOT(setLiquidModeSpeed(int)));
 	connect(settings(), SIGNAL(moodLampLiquidModeChanged(bool)),				m_moodlampManager,	SLOT(setLiquidMode(bool)));
+	connect(settings(), SIGNAL(moodLampLampChanged(int)),						m_moodlampManager,	SLOT(setCurrentLamp(int)));
 
 #ifdef SOUNDVIZ_SUPPORT
 	if (m_soundManager)
@@ -773,6 +774,9 @@ void LightpackApplication::initGrabManager()
 			connect(m_soundManager, SIGNAL(visualizerList(const QList<SoundManagerVisualizerInfo> &, int)), m_settingsWindow, SLOT(updateAvailableSoundVizVisualizers(const QList<SoundManagerVisualizerInfo> &, int)));
 		}
 #endif
+
+		connect(m_settingsWindow, SIGNAL(requestMoodLampLamps()), m_moodlampManager, SLOT(requestLampList()));
+		connect(m_moodlampManager, SIGNAL(lampList(const QList<MoodLampLampInfo> &, int)), m_settingsWindow, SLOT(updateAvailableMoodLampLamps(const QList<MoodLampLampInfo> &, int)));
 	}
 
 	connect(m_grabManager, SIGNAL(ambilightTimeOfUpdatingColors(double)), m_pluginInterface, SLOT(refreshAmbilightEvaluated(double)));
@@ -826,6 +830,7 @@ void LightpackApplication::settingsChanged()
 	m_moodlampManager->setCurrentColor(Settings::getMoodLampColor());
 	m_moodlampManager->setLiquidModeSpeed(Settings::getMoodLampSpeed());
 	m_moodlampManager->setLiquidMode(Settings::isMoodLampLiquidMode());
+	m_moodlampManager->setCurrentLamp(Settings::getMoodLampLamp());
 
 	bool isBacklightEnabled = Settings::isBacklightEnabled();
 	bool isCanStart = (isBacklightEnabled && m_deviceLockStatus == DeviceLocked::Unlocked);

--- a/Software/src/LiquidColorGenerator.cpp
+++ b/Software/src/LiquidColorGenerator.cpp
@@ -25,7 +25,6 @@
 
 
 #include "LiquidColorGenerator.hpp"
-#include "PrismatikMath.hpp"
 #include "Settings.hpp"
 #include <QTime>
 
@@ -40,7 +39,7 @@ const QColor LiquidColorGenerator::AvailableColors[LiquidColorGenerator::ColorsM
 
 LiquidColorGenerator::LiquidColorGenerator(QObject *parent) : QObject(parent)
 {
-	qsrand(QTime(0,0,0).secsTo(QTime::currentTime()));
+	m_rnd.seed(QTime(0,0,0).secsTo(QTime::currentTime()));
 
 	m_isEnabled = false;
 	m_timer.setTimerType(Qt::PreciseTimer);
@@ -116,7 +115,7 @@ void LiquidColorGenerator::updateColor()
 
 int LiquidColorGenerator::generateDelay()
 {
-	return 1000 / (m_speed + PrismatikMath::rand(25) + 1);
+	return 1000 / (m_speed + m_rnd.bounded(25) + 1);
 }
 
 QColor LiquidColorGenerator::generateColor()
@@ -127,7 +126,7 @@ QColor LiquidColorGenerator::generateColor()
 			m_unselectedColors << AvailableColors[i];
 	}
 
-	int randIndex = PrismatikMath::rand(m_unselectedColors.size());
+	int randIndex = m_rnd.bounded(m_unselectedColors.size());
 
 	return m_unselectedColors.takeAt(randIndex);
 }

--- a/Software/src/LiquidColorGenerator.hpp
+++ b/Software/src/LiquidColorGenerator.hpp
@@ -28,6 +28,7 @@
 #include <QObject>
 #include <QColor>
 #include <QTimer>
+#include <QRandomGenerator>
 
 class LiquidColorGenerator : public QObject
 {
@@ -72,4 +73,6 @@ private:
 	static const int ColorsMoodLampCount = 14;
 	static const QColor AvailableColors[ColorsMoodLampCount];
 	QList<QColor> m_unselectedColors;
+
+	QRandomGenerator m_rnd;
 };

--- a/Software/src/MoodLamp.cpp
+++ b/Software/src/MoodLamp.cpp
@@ -1,0 +1,192 @@
+/*
+ * MoodLamp.cpp
+ *
+ *	Created on: 11.12.2011
+ *		Project: Lightpack
+ *
+ *	Copyright (c) 2011 Mike Shatohin, mikeshatohin [at] gmail.com
+ *
+ *	Lightpack a USB content-driving ambient lighting system
+ *
+ *	Lightpack is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Lightpack is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program.	If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <QTime>
+#include <QRandomGenerator>
+#include <cmath>
+#include "MoodLamp.hpp"
+#include "Settings.hpp"
+
+ /*
+	 _OBJ_NAME_	: class name prefix
+	 _LABEL_	: name string to be displayed
+	 _BODY_		: class declaration body
+ */
+#define DECLARE_LAMP(_OBJ_NAME_,_LABEL_,_BODY_) \
+class _OBJ_NAME_ ## MoodLamp : public MoodLampBase \
+{\
+public:\
+_OBJ_NAME_ ## MoodLamp() : MoodLampBase() {};\
+~_OBJ_NAME_ ## MoodLamp() = default;\
+static const char* const name() { return _LABEL_; };\
+static MoodLampBase* create() { return new _OBJ_NAME_ ## MoodLamp(); };\
+\
+_BODY_\
+};\
+struct _OBJ_NAME_ ## Register {\
+_OBJ_NAME_ ## Register(){\
+	g_moodLampMap.insert(lampID, MoodLampLampInfo(_OBJ_NAME_ ## MoodLamp::name(), _OBJ_NAME_ ## MoodLamp::create, lampID));\
+	++lampID;\
+}\
+};\
+_OBJ_NAME_ ## Register _OBJ_NAME_ ## Reg;
+
+using namespace SettingsScope;
+
+namespace {
+	static QMap<int, MoodLampLampInfo> g_moodLampMap;
+	static int lampID = 0;
+}
+
+MoodLampBase* MoodLampBase::createWithID(const int id) {
+	QMap<int, MoodLampLampInfo>::const_iterator i = g_moodLampMap.find(id);
+	if (i != g_moodLampMap.end())
+		return i.value().factory();
+	qWarning() << Q_FUNC_INFO << "failed to find mood lamp ID: " << id;
+	return nullptr;
+}
+
+void MoodLampBase::populateNameList(QList<MoodLampLampInfo>& list, int& recommended)
+{
+	list = g_moodLampMap.values();
+
+	if (list.size() > 0)
+		recommended = list[0].id;
+}
+
+DECLARE_LAMP(Static, "Static (default)",
+public:
+	int interval() const { return 50; };
+
+	bool shine(const QColor& newColor, QList<QRgb>& colors)
+	{
+		bool changed = false;
+		for (int i = 0; i < colors.size(); i++)
+		{
+			QRgb rgb = Settings::isLedEnabled(i) ? newColor.rgb() : 0;
+			changed = changed || (colors[i] != rgb);
+			colors[i] = rgb;
+		}
+		return changed;
+	};
+);
+
+DECLARE_LAMP(Fire, "Fire",
+public:
+	void init() {
+		m_rnd.seed(QTime(0, 0, 0).secsTo(QTime::currentTime()));
+	};
+
+	bool shine(const QColor& newColor, QList<QRgb>& colors) {
+		if (colors.size() < 2)
+			return false;
+
+		if (colors.size() > m_lightness.size()) {
+			const size_t oldSize = m_lightness.size();
+			m_lightness.reserve(colors.size());
+			for (size_t i = oldSize; i < colors.size(); ++i)
+				m_lightness << 0;
+		}
+
+		// heavily inspired by FastLED Fire2012 demo
+		// https://github.com/FastLED/FastLED/blob/master/examples/Fire2012/Fire2012.ino
+		const int centerMax = colors.size() / 4;
+		const int middleLed = std::floor(colors.size() / 2);
+		const int sparkCount = colors.size() / 12;
+
+		m_center += m_rnd.bounded(2) ? -1 : 1;
+		m_center = std::max(-centerMax, std::min(centerMax, m_center));
+
+		for (int i = 0; i < middleLed + m_center; ++i) {
+			const int minLightnessReduction = Cooling * std::pow((double)i / (middleLed + m_center), 3);
+			const int maxLightnessReduction = minLightnessReduction * 2;
+			const int lightnessReduction = minLightnessReduction + m_rnd.bounded(maxLightnessReduction - minLightnessReduction) + Cooling / 3;
+			m_lightness[i] = std::max(0, m_lightness[i] - lightnessReduction);
+		}
+
+		for (int i = colors.size() - 1; i >= middleLed + m_center; --i) {
+			const int minLightnessReduction = Cooling * std::pow((double)(colors.size() - 1 - i) / (middleLed - m_center), 3);
+			const int maxLightnessReduction = minLightnessReduction * 2;
+			const int lightnessReduction = minLightnessReduction + m_rnd.bounded(maxLightnessReduction - minLightnessReduction) + Cooling / 3;
+			m_lightness[i] = std::max(0, m_lightness[i] - lightnessReduction);
+		}
+
+
+		for (int k = middleLed + m_center; k > 1; --k)
+			m_lightness[k] = (m_lightness[k - 1] + m_lightness[k - 2] * 2) / 3;
+
+		for (int k = middleLed + m_center; k < colors.size() - 2; ++k)
+			m_lightness[k] = (m_lightness[k + 1] + m_lightness[k + 2] * 2) / 3;
+
+
+		if (m_rnd.bounded(2) == 0) {
+			int y = m_rnd.bounded(sparkCount);
+			m_lightness[y] = std::max(SparkMax, (int)m_lightness[y] + (SparkMin + m_rnd.bounded(SparkMax - SparkMin)));
+		}
+		if (m_rnd.bounded(2) == 0) {
+			int z = colors.size() - 1 - m_rnd.bounded(sparkCount);
+			m_lightness[z] = std::max(SparkMax, (int)m_lightness[z] + (SparkMin + m_rnd.bounded(SparkMax - SparkMin)));
+		}
+
+		for (int i = 0; i < colors.size(); i++)
+		{
+			QColor color(newColor);
+			color.setHsl(color.hue(), color.saturation(), m_lightness[i]);
+			colors[i] = Settings::isLedEnabled(i) ? color.rgb() : 0;
+		}
+		return true;
+	};
+private:
+	QRandomGenerator m_rnd;
+	QList<quint8> m_lightness;
+	int m_center{ 0 };
+
+	static const size_t Cooling = 8;
+	static const int SparkMax = 160;
+	static const int SparkMin = 100;
+);
+
+DECLARE_LAMP(RGBLife, "RGB is Life",
+public:
+	bool shine(const QColor& newColor, QList<QRgb>& colors)
+	{
+		bool changed = false;
+		const int degrees = 360 / colors.size();
+		const int step = Speed * m_frames++;
+		for (int i = 0; i < colors.size(); i++)
+		{
+			QColor color(newColor);
+			color.setHsl(color.hue() + degrees * i + step, color.saturation(), color.lightness());
+			QRgb rgb = Settings::isLedEnabled(i) ? color.rgb() : 0;
+			changed = changed || (colors[i] != rgb);
+			colors[i] = rgb;
+		}
+		if (step > 360)
+			m_frames = 0;
+		return changed;
+	};
+private:
+	const double Speed = 1.5;
+);

--- a/Software/src/MoodLamp.hpp
+++ b/Software/src/MoodLamp.hpp
@@ -1,0 +1,62 @@
+/*
+ * MoodLamp.hpp
+ *
+ *	Created on: 11.12.2011
+ *		Project: Lightpack
+ *
+ *	Copyright (c) 2011 Mike Shatohin, mikeshatohin [at] gmail.com
+ *
+ *	Lightpack a USB content-driving ambient lighting system
+ *
+ *	Lightpack is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Lightpack is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program.	If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QColor>
+
+class MoodLampBase;
+
+typedef MoodLampBase* (*LampFactory)();
+
+struct MoodLampLampInfo {
+	MoodLampLampInfo() { this->name = ""; this->id = -1; this->factory = nullptr; }
+	MoodLampLampInfo(QString name, LampFactory factory, int id) { this->name = name; this->id = id; this->factory = factory; }
+	QString name;
+	LampFactory factory;
+	int id;
+};
+Q_DECLARE_METATYPE(MoodLampLampInfo);
+
+class MoodLampBase
+{
+public:
+	MoodLampBase() { init(); };
+	virtual ~MoodLampBase() = default;
+
+	static const char* const name() { return "NO_NAME"; };
+	static MoodLampBase* create() { Q_ASSERT_X(false, "MoodLampBase::create()", "not implemented"); return nullptr; };
+	static MoodLampBase* createWithID(const int id);
+	static void populateNameList(QList<MoodLampLampInfo>& list, int& recommended);
+
+	virtual void init() {};
+	virtual int interval() const { return DefaultInterval; };
+	virtual bool shine(const QColor& newColor, QList<QRgb>& colors) = 0;
+protected:
+	size_t m_frames{ 0 };
+private:
+	const int DefaultInterval = 33;
+};

--- a/Software/src/MoodLampManager.cpp
+++ b/Software/src/MoodLampManager.cpp
@@ -28,19 +28,23 @@
 #include "PrismatikMath.hpp"
 #include "Settings.hpp"
 #include <QTime>
+#include "MoodLamp.hpp"
 
 using namespace SettingsScope;
 
 MoodLampManager::MoodLampManager(QObject *parent) : QObject(parent)
 {
-	qsrand(QTime(0,0,0).secsTo(QTime::currentTime()));
-
 	m_isMoodLampEnabled = false;
-	m_rgbSaved = 0;
 
+	m_timer.setTimerType(Qt::PreciseTimer);
+	connect(&m_timer, SIGNAL(timeout()), this, SLOT(updateColors()));
 	initFromSettings();
+}
 
-	connect(&m_generator, SIGNAL(updateColor(QColor)), this, SLOT(updateColors()));
+MoodLampManager::~MoodLampManager()
+{
+	if (m_lamp)
+		delete m_lamp;
 }
 
 void MoodLampManager::start(bool isEnabled)
@@ -48,21 +52,22 @@ void MoodLampManager::start(bool isEnabled)
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << isEnabled;
 
 	m_isMoodLampEnabled = isEnabled;
-
+	
 	if (m_isMoodLampEnabled)
 	{
-		// Clear saved color for force emit signal after check m_rgbSaved != rgb in updateColors()
 		// This is usable if start is called after API unlock, and we should force set current color
-		m_rgbSaved = 0;
-		updateColors();
-
+		updateColors(true);
 	}
-	
+
 	if (m_isMoodLampEnabled && m_isLiquidMode)
 		m_generator.start();
 	else
 		m_generator.stop();
 
+	if (m_isMoodLampEnabled && m_lamp)
+		m_timer.start(m_lamp->interval());
+	else
+		m_timer.stop();
 }
 
 void MoodLampManager::setCurrentColor(QColor color)
@@ -71,11 +76,7 @@ void MoodLampManager::setCurrentColor(QColor color)
 
 	m_currentColor = color;
 
-	if (m_isMoodLampEnabled && !m_isLiquidMode)
-	{
-		fillColors(color.rgb());
-		emit updateLedsColors(m_colors);
-	}
+	updateColors();
 }
 
 void MoodLampManager::setLiquidMode(bool state)
@@ -108,12 +109,10 @@ void MoodLampManager::setNumberOfLeds(int numberOfLeds)
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << numberOfLeds;
 
 	initColors(numberOfLeds);
-	setCurrentColor(m_rgbSaved);
 }
 
 void MoodLampManager::reset()
 {
-	m_rgbSaved = 0;
 	m_generator.reset();
 }
 
@@ -132,30 +131,44 @@ void MoodLampManager::initFromSettings()
 	m_isSendDataOnlyIfColorsChanged = Settings::isSendDataOnlyIfColorsChanges();
 
 	initColors(Settings::getNumberOfLeds(Settings::getConnectedDevice()));
+	setCurrentLamp(Settings::getMoodLampLamp());
 }
 
-void MoodLampManager::updateColors()
+void MoodLampManager::setCurrentLamp(const int id)
+{
+	m_timer.stop();
+
+	if (m_lamp) {
+		delete m_lamp;
+		m_lamp = nullptr;
+	}
+
+	m_lamp = MoodLampBase::createWithID(id);
+
+	if (m_isMoodLampEnabled && m_lamp)
+		m_timer.start(m_lamp->interval());
+}
+
+void MoodLampManager::updateColors(const bool forceUpdate)
 {
 	DEBUG_HIGH_LEVEL << Q_FUNC_INFO << m_isLiquidMode;
 
-	QRgb rgb;
+	QColor newColor;
 
 	if (m_isLiquidMode)
 	{
-		rgb = m_generator.current().rgb();
+		newColor = m_generator.current();
 	}
 	else
 	{
-		rgb = m_currentColor.rgb();
+		newColor = m_currentColor;
 	}
 
-	if (m_rgbSaved != rgb || m_isSendDataOnlyIfColorsChanged == false)
-	{
-		fillColors(rgb);
+	DEBUG_MID_LEVEL << Q_FUNC_INFO << newColor.rgb();
+
+	bool changed = (m_lamp ? m_lamp->shine(newColor, m_colors) : false);
+	if (changed || !m_isSendDataOnlyIfColorsChanged || forceUpdate)
 		emit updateLedsColors(m_colors);
-	}
-
-	m_rgbSaved = rgb;
 }
 
 void MoodLampManager::initColors(int numberOfLeds)
@@ -168,15 +181,12 @@ void MoodLampManager::initColors(int numberOfLeds)
 		m_colors << 0;
 }
 
-void MoodLampManager::fillColors(QRgb rgb)
+void MoodLampManager::requestLampList()
 {
-	DEBUG_MID_LEVEL << Q_FUNC_INFO << rgb;
+	QList<MoodLampLampInfo> list;
+	int recommended = 0;
 
-	for (int i = 0; i < m_colors.size(); i++)
-	{
-		if (Settings::isLedEnabled(i))
-			m_colors[i] = rgb;
-		else
-			m_colors[i] = 0;
-	}
+	MoodLampBase::populateNameList(list, recommended);
+
+	emit lampList(list, recommended);
 }

--- a/Software/src/MoodLampManager.hpp
+++ b/Software/src/MoodLampManager.hpp
@@ -29,15 +29,18 @@
 #include <QColor>
 #include <QTimer>
 #include "LiquidColorGenerator.hpp"
+#include "MoodLamp.hpp"
 
 class MoodLampManager : public QObject
 {
 	Q_OBJECT
 public:
 	explicit MoodLampManager(QObject *parent = 0);
+	~MoodLampManager();
 
 signals:
 	void updateLedsColors(const QList<QRgb> & colors);
+	void lampList(const QList<MoodLampLampInfo> &, int);
 
 public:
 	void start(bool isMoodLampEnabled);
@@ -53,22 +56,25 @@ public slots:
 	void settingsProfileChanged(const QString &profileName);
 	void setNumberOfLeds(int value);
 	void setCurrentColor(QColor color);
+	void setCurrentLamp(const int id);
+	void requestLampList();
 
 private slots:
-	void updateColors();
+	void updateColors(const bool forceUpdate = false);
 
 private:
 	void initColors(int numberOfLeds);
-	void fillColors(QRgb rgb);
 
 private:
+	MoodLampBase* m_lamp{ nullptr };
+
 	LiquidColorGenerator m_generator;
 	QList<QRgb> m_colors;
 
 	bool	m_isMoodLampEnabled;
-	QColor m_currentColor;
+	QColor  m_currentColor;
 	bool	m_isLiquidMode;
 	bool	m_isSendDataOnlyIfColorsChanged;
 
-	QRgb m_rgbSaved;
+	QTimer m_timer;
 };

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -167,6 +167,7 @@ namespace MoodLamp
 static const QString IsLiquidMode = "MoodLamp/LiquidMode";
 static const QString Color = "MoodLamp/Color";
 static const QString Speed = "MoodLamp/Speed";
+static const QString Lamp = "MoodLamp/Lamp";
 }
 // [SoundVisualizer]
 namespace SoundVisualizer
@@ -1387,6 +1388,19 @@ void Settings::setMoodLampSpeed(int value)
 	m_this->moodLampSpeedChanged(value);
 }
 
+int Settings::getMoodLampLamp()
+{
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
+	return value(Profile::Key::MoodLamp::Lamp).toInt();
+}
+
+void Settings::setMoodLampLamp(int value)
+{
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
+	setValue(Profile::Key::MoodLamp::Lamp, value);
+	m_this->moodLampLampChanged(value);
+}
+
 #ifdef SOUNDVIZ_SUPPORT
 int Settings::getSoundVisualizerDevice()
 {
@@ -1741,6 +1755,7 @@ void Settings::initCurrentProfile(bool isResetDefault)
 	setNewOption(Profile::Key::MoodLamp::IsLiquidMode,				Profile::MoodLamp::IsLiquidModeDefault, isResetDefault);
 	setNewOption(Profile::Key::MoodLamp::Color,						Profile::MoodLamp::ColorDefault, isResetDefault);
 	setNewOption(Profile::Key::MoodLamp::Speed,						Profile::MoodLamp::SpeedDefault, isResetDefault);
+	setNewOption(Profile::Key::MoodLamp::Lamp,						Profile::MoodLamp::LampDefault, isResetDefault);
 #ifdef SOUNDVIZ_SUPPORT
 	// [SoundVisualizer]
 	setNewOption(Profile::Key::SoundVisualizer::Device,				Profile::SoundVisualizer::DeviceDefault, isResetDefault);

--- a/Software/src/Settings.hpp
+++ b/Software/src/Settings.hpp
@@ -196,6 +196,8 @@ public:
 	static void setMoodLampColor(QColor color);
 	static int getMoodLampSpeed();
 	static void setMoodLampSpeed(int value);
+	static int getMoodLampLamp();
+	static void setMoodLampLamp(int value);
 
 #ifdef SOUNDVIZ_SUPPORT
 	static int getSoundVisualizerDevice();
@@ -321,6 +323,7 @@ signals:
 	void moodLampLiquidModeChanged(bool isLiquidMode);
 	void moodLampColorChanged(const QColor color);
 	void moodLampSpeedChanged(int value);
+	void moodLampLampChanged(int value);
 #ifdef SOUNDVIZ_SUPPORT
 	void soundVisualizerDeviceChanged(int value);
 	void soundVisualizerVisualizerChanged(int value);

--- a/Software/src/SettingsDefaults.hpp
+++ b/Software/src/SettingsDefaults.hpp
@@ -169,6 +169,7 @@ static const double GammaMax = 10.0;
 // [MoodLamp]
 namespace MoodLamp
 {
+static const int LampDefault = 0;
 static const int SpeedMin = 1;
 static const int SpeedDefault = 50;
 static const int SpeedMax = 100;

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -215,6 +215,7 @@ void SettingsWindow::connectSignalsSlots()
 
 	connect(ui->radioButton_LiquidColorMoodLampMode, SIGNAL(toggled(bool)), this, SLOT(onMoodLampLiquidMode_Toggled(bool)));
 	connect(ui->horizontalSlider_MoodLampSpeed, SIGNAL(valueChanged(int)), this, SLOT(onMoodLampSpeed_valueChanged(int)));
+	connect(ui->comboBox_MoodLampLamp, SIGNAL(currentIndexChanged(int)), this, SLOT(onMoodLampLamp_currentIndexChanged(int)));
 
 	// Main options
 	connect(ui->comboBox_LightpackModes, SIGNAL(currentIndexChanged(int)), this, SLOT(onLightpackModes_currentIndexChanged(int)));
@@ -492,6 +493,7 @@ int SettingsWindow::getLigtpackFirmwareVersionMajor()
 void SettingsWindow::onPostInit() {
 	updateUiFromSettings();
 	this->requestFirmwareVersion();
+	this->requestMoodLampLamps();
 #ifdef SOUNDVIZ_SUPPORT
 	this->requestSoundVizDevices();
 	this->requestSoundVizVisualizers();
@@ -978,6 +980,23 @@ void SettingsWindow::updateAvailableSoundVizVisualizers(const QList<SoundManager
 }
 #endif
 
+void SettingsWindow::updateAvailableMoodLampLamps(const QList<MoodLampLampInfo> & lamps, int recommended)
+{
+	ui->comboBox_MoodLampLamp->blockSignals(true);
+	ui->comboBox_MoodLampLamp->clear();
+	int selectedLamp = Settings::getMoodLampLamp();
+	if (selectedLamp == -1) selectedLamp = recommended;
+	int selectIndex = -1;
+	for (int i = 0; i < lamps.size(); i++) {
+		ui->comboBox_MoodLampLamp->addItem(lamps[i].name, lamps[i].id);
+		if (lamps[i].id == selectedLamp) {
+			selectIndex = i;
+		}
+	}
+	ui->comboBox_MoodLampLamp->setCurrentIndex(selectIndex);
+	ui->comboBox_MoodLampLamp->blockSignals(false);
+}
+
 // ----------------------------------------------------------------------------
 // Show / Hide settings and about windows
 // ----------------------------------------------------------------------------
@@ -1361,6 +1380,14 @@ void SettingsWindow::onMoodLampSpeed_valueChanged(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value;
 	Settings::setMoodLampSpeed(value);
+}
+
+void SettingsWindow::onMoodLampLamp_currentIndexChanged(int index)
+{
+	if (!updatingFromSettings) {
+		DEBUG_MID_LEVEL << Q_FUNC_INFO << index << ui->comboBox_MoodLampLamp->currentData().toInt();
+		Settings::setMoodLampLamp(ui->comboBox_MoodLampLamp->currentData().toInt());
+	}
 }
 
 void SettingsWindow::onMoodLampLiquidMode_Toggled(bool checked)
@@ -1799,6 +1826,12 @@ void SettingsWindow::updateUiFromSettings()
 	ui->radioButton_LiquidColorMoodLampMode->setChecked				(Settings::isMoodLampLiquidMode());
 	ui->pushButton_SelectColorMoodLamp->setColor						(Settings::getMoodLampColor());
 	ui->horizontalSlider_MoodLampSpeed->setValue						(Settings::getMoodLampSpeed());
+	for (int i = 0; i < ui->comboBox_MoodLampLamp->count(); i++) {
+		if (ui->comboBox_MoodLampLamp->itemData(i).toInt() == Settings::getMoodLampLamp()) {
+			ui->comboBox_MoodLampLamp->setCurrentIndex(i);
+			break;
+		}
+	}
 
 #ifdef SOUNDVIZ_SUPPORT
 	for (int i = 0; i < ui->comboBox_SoundVizDevice->count(); i++) {

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -78,6 +78,7 @@ signals:
 	void requestSoundVizDevices();
 	void requestSoundVizVisualizers();
 #endif
+	void requestMoodLampLamps();
 	void recreateLedDevice();
 	void resultBacklightStatus(Backlight::Status);
 	void backlightStatusChanged(Backlight::Status);
@@ -111,6 +112,7 @@ public slots:
 	void onPingDeviceEverySecond_Toggled(bool state);
 	void processMessage(const QString &message);
 
+	void updateAvailableMoodLampLamps(const QList<MoodLampLampInfo> & lamps, int recommended);
 #ifdef SOUNDVIZ_SUPPORT
 	void updateAvailableSoundVizDevices(const QList<SoundManagerDeviceInfo> & devices, int recommended);
 	void updateAvailableSoundVizVisualizers(const QList<SoundManagerVisualizerInfo> & visualizers, int recommended);
@@ -134,6 +136,7 @@ private slots:
 	void onLightpackModeChanged(Lightpack::Mode);
 	void onMoodLampColor_changed(QColor color);
 	void onMoodLampSpeed_valueChanged(int value);
+	void onMoodLampLamp_currentIndexChanged(int index);
 	void onMoodLampLiquidMode_Toggled(bool isLiquidMode);
 #ifdef SOUNDVIZ_SUPPORT
 	void onSoundVizDevice_currentIndexChanged(int index);

--- a/Software/src/SettingsWindow.ui
+++ b/Software/src/SettingsWindow.ui
@@ -720,6 +720,9 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
              <number>0</number>
             </property>
             <item>
+             <widget class="QComboBox" name="comboBox_MoodLampLamp"/>
+            </item>
+            <item>
              <layout class="QHBoxLayout" name="horizontalLayout_2">
               <item>
                <widget class="QRadioButton" name="radioButton_ConstantColorMoodLampMode">

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -250,6 +250,7 @@ SOURCES += \
     ApiServer.cpp \
     ApiServerSetColorTask.cpp \
     MoodLampManager.cpp \
+    MoodLamp.cpp \
 	LiquidColorGenerator.cpp \
     LedDeviceManager.cpp \
     SelectWidget.cpp \
@@ -300,6 +301,7 @@ HEADERS += \
     ../../CommonHeaders/COMMANDS.h \
     ../../CommonHeaders/USB_ID.h \
     MoodLampManager.hpp \
+    MoodLamp.hpp \
 	LiquidColorGenerator.hpp \
     LedDeviceManager.hpp \
     SelectWidget.hpp \


### PR DESCRIPTION
In a similar fashion to SoundViz selector, here are some (animated) mood lamps...

Notable change to `MoodLampManager`: the update rate is now managed by lamps and not by `LiquidColorGenerator`, each lamp can have it's own framerate if required so by the desired animation (I used 33ms/30fps as default).

Other (small but) notable change: as per [Qt doc](http://doc.qt.io/qt-5/qtglobal-obsolete.html#qrand), I replaced `(s)qrand` with `QRandomGenerator`, and since it was used only in `LiquidColorGenerator` I removed it from `PrismatikMath` and used directly as a member.

There is one issue that is also present on the `master`: when you quit Prismatik with static color mood lamp on and relaunch, it doesn't turn on unless you switch modes (or, now, lamps).
It looks like some kind of race condition, but I'm having trouble understranding why, maybe you know better this: `emit updateLedsColors(m_colors);` is executed as expected on `start()` etc, but it's as if the `signal` is getting dropped for a certain time. If I put a breakpoint on `emit update...`, it'll stop, and after pressing Continue it works as expected on the first call. I did a test with a call counter, and it needs around 40 calls to start working... I'm not sure what's going on.
This is a non-issue with animated lamps as they `emit ...` all the time.