### PR TITLE
Show "low baudrate" warning

### DIFF
--- a/Software/math/PrismatikMath.cpp
+++ b/Software/math/PrismatikMath.cpp
@@ -333,4 +333,9 @@ namespace PrismatikMath
 	quint8 getBrightness(const QRgb rgb) {
 		return static_cast<quint8>(qRed(rgb) * 0.299 + qGreen(rgb) * 0.587 + qBlue(rgb) * 0.114);
 	}
+
+	double theoreticalMaxFrameRate(const double ledCount, const double baudRate) {
+		// math credit https://www.partsnotincluded.com/calculating-adalight-framerate-limits/
+		return pow((10.0 * (3.0 * ledCount + 6.0)) / baudRate + 0.00003 * ledCount, -1.0);
+	}
 }

--- a/Software/math/PrismatikMath.cpp
+++ b/Software/math/PrismatikMath.cpp
@@ -338,4 +338,9 @@ namespace PrismatikMath
 		// math credit https://www.partsnotincluded.com/calculating-adalight-framerate-limits/
 		return pow((10.0 * (3.0 * ledCount + 6.0)) / baudRate + 0.00003 * ledCount, -1.0);
 	}
+
+	double theoreticalMinBaudRate(const double ledCount, const double frameRate) {
+		// derived from theoreticalMaxFrameRate()
+		return (30.0 * ledCount + 60) / (1.0 / frameRate - 0.00003 * ledCount);
+	}
 }

--- a/Software/math/include/PrismatikMath.hpp
+++ b/Software/math/include/PrismatikMath.hpp
@@ -53,6 +53,7 @@ namespace PrismatikMath
 	StructRgb toRgb(const StructLab &);
 	quint8 getBrightness(const QRgb);
 	double theoreticalMaxFrameRate(const double ledCount, const double baudRate);
+	double theoreticalMinBaudRate(const double ledCount, const double frameRate);
 
 	// Convert ASCII char '5' to 5
 	inline char getDigit(const char d)

--- a/Software/math/include/PrismatikMath.hpp
+++ b/Software/math/include/PrismatikMath.hpp
@@ -52,6 +52,7 @@ namespace PrismatikMath
 	StructRgb toRgb(const StructXyz &);
 	StructRgb toRgb(const StructLab &);
 	quint8 getBrightness(const QRgb);
+	double theoreticalMaxFrameRate(const double ledCount, const double baudRate);
 
 	// Convert ASCII char '5' to 5
 	inline char getDigit(const char d)

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -82,11 +82,13 @@ GrabManager::GrabManager(QWidget *parent) : QObject(parent)
 	m_grabber = queryGrabber(Settings::getGrabberType());
 
 	m_timerUpdateFPS = new QTimer(this);
+	m_timerUpdateFPS->setTimerType(Qt::PreciseTimer);
 	connect(m_timerUpdateFPS, SIGNAL(timeout()), this, SLOT(timeoutUpdateFPS()));
 	m_timerUpdateFPS->setSingleShot(false);
 	m_timerUpdateFPS->setInterval(FPS_UPDATE_INTERVAL);
 
 	m_timerFakeGrab = new QTimer(this);
+	m_timerFakeGrab->setTimerType(Qt::PreciseTimer);
 	connect(m_timerFakeGrab, SIGNAL(timeout()), this, SLOT(timeoutFakeGrab()));
 	m_timerFakeGrab->setSingleShot(false);
 	m_timerFakeGrab->setInterval(FAKE_GRAB_INTERVAL);

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -780,6 +780,7 @@ void LightpackApplication::initGrabManager()
 
 	connect(m_grabManager,		SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
 	connect(m_moodlampManager,	SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+	connect(m_moodlampManager,	SIGNAL(moodlampFrametime(const double)),		m_settingsWindow, 	SLOT(refreshAmbilightEvaluated(double)), Qt::QueuedConnection);
 	connect(m_ledDeviceManager,	SIGNAL(openDeviceSuccess(bool)),				m_grabManager,		SLOT(ledDeviceOpenSuccess(bool)), Qt::QueuedConnection);
 	connect(m_ledDeviceManager,	SIGNAL(ioDeviceSuccess(bool)),					m_grabManager,		SLOT(ledDeviceCallSuccess(bool)), Qt::QueuedConnection);
 #ifdef SOUNDVIZ_SUPPORT

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -728,6 +728,7 @@ void LightpackApplication::initGrabManager()
 	connect(settings(), SIGNAL(moodLampSpeedChanged(int)),						m_moodlampManager,	SLOT(setLiquidModeSpeed(int)));
 	connect(settings(), SIGNAL(moodLampLiquidModeChanged(bool)),				m_moodlampManager,	SLOT(setLiquidMode(bool)));
 	connect(settings(), SIGNAL(moodLampLampChanged(int)),						m_moodlampManager,	SLOT(setCurrentLamp(int)));
+	connect(settings(), SIGNAL(sendDataOnlyIfColorsChangesChanged(bool)),		m_moodlampManager,	SLOT(setSendDataOnlyIfColorsChanged(bool)));
 
 #ifdef SOUNDVIZ_SUPPORT
 	if (m_soundManager)
@@ -738,6 +739,7 @@ void LightpackApplication::initGrabManager()
 		connect(settings(), SIGNAL(soundVisualizerMinColorChanged(QColor)),			m_soundManager,		SLOT(setMinColor(QColor)));
 		connect(settings(), SIGNAL(soundVisualizerLiquidSpeedChanged(int)),			m_soundManager,		SLOT(setLiquidModeSpeed(int)));
 		connect(settings(), SIGNAL(soundVisualizerLiquidModeChanged(bool)),			m_soundManager,		SLOT(setLiquidMode(bool)));
+		connect(settings(), SIGNAL(sendDataOnlyIfColorsChangesChanged(bool)),		m_soundManager,		SLOT(setSendDataOnlyIfColorsChanged(bool)));
 
 		connect(m_pluginInterface, SIGNAL(updateSoundVizMinColor(QColor)),			m_soundManager,		SLOT(setMinColor(QColor)),								Qt::QueuedConnection);
 		connect(m_pluginInterface, SIGNAL(updateSoundVizMaxColor(QColor)),			m_soundManager,		SLOT(setMaxColor(QColor)),								Qt::QueuedConnection);

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -784,8 +784,10 @@ void LightpackApplication::initGrabManager()
 	connect(m_ledDeviceManager,	SIGNAL(openDeviceSuccess(bool)),				m_grabManager,		SLOT(ledDeviceOpenSuccess(bool)), Qt::QueuedConnection);
 	connect(m_ledDeviceManager,	SIGNAL(ioDeviceSuccess(bool)),					m_grabManager,		SLOT(ledDeviceCallSuccess(bool)), Qt::QueuedConnection);
 #ifdef SOUNDVIZ_SUPPORT
-	if (m_soundManager)
+	if (m_soundManager) {
 		connect(m_soundManager,		SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+		connect(m_soundManager,		SIGNAL(visualizerFrametime(const double)),	m_settingsWindow, SLOT(refreshAmbilightEvaluated(double)), Qt::QueuedConnection);
+	}
 #endif
 }
 

--- a/Software/src/MoodLampManager.cpp
+++ b/Software/src/MoodLampManager.cpp
@@ -169,7 +169,7 @@ void MoodLampManager::updateColors(const bool forceUpdate)
 	bool changed = (m_lamp ? m_lamp->shine(newColor, m_colors) : false);
 	if (changed || !m_isSendDataOnlyIfColorsChanged || forceUpdate) {
 		emit updateLedsColors(m_colors);
-		emit moodlampFrametime(m_lamp->interval());
+		emit moodlampFrametime(m_elapsedTimer.restart());
 	}
 }
 

--- a/Software/src/MoodLampManager.cpp
+++ b/Software/src/MoodLampManager.cpp
@@ -83,6 +83,7 @@ void MoodLampManager::setLiquidMode(bool state)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << state;
 	m_isLiquidMode = state;
+	emit moodlampFrametime(1000); // reset FPS to 1
 	if (m_isLiquidMode && m_isMoodLampEnabled)
 		m_generator.start();
 	else {
@@ -102,6 +103,7 @@ void MoodLampManager::setSendDataOnlyIfColorsChanged(bool state)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << state;
 	m_isSendDataOnlyIfColorsChanged = state;
+	emit moodlampFrametime(1000); // reset FPS to 1
 }
 
 void MoodLampManager::setNumberOfLeds(int numberOfLeds)
@@ -144,7 +146,7 @@ void MoodLampManager::setCurrentLamp(const int id)
 	}
 
 	m_lamp = MoodLampBase::createWithID(id);
-
+	emit moodlampFrametime(1000); // reset FPS to 1
 	if (m_isMoodLampEnabled && m_lamp)
 		m_timer.start(m_lamp->interval());
 }

--- a/Software/src/MoodLampManager.cpp
+++ b/Software/src/MoodLampManager.cpp
@@ -167,8 +167,10 @@ void MoodLampManager::updateColors(const bool forceUpdate)
 	DEBUG_MID_LEVEL << Q_FUNC_INFO << newColor.rgb();
 
 	bool changed = (m_lamp ? m_lamp->shine(newColor, m_colors) : false);
-	if (changed || !m_isSendDataOnlyIfColorsChanged || forceUpdate)
+	if (changed || !m_isSendDataOnlyIfColorsChanged || forceUpdate) {
 		emit updateLedsColors(m_colors);
+		emit moodlampFrametime(m_lamp->interval());
+	}
 }
 
 void MoodLampManager::initColors(int numberOfLeds)

--- a/Software/src/MoodLampManager.cpp
+++ b/Software/src/MoodLampManager.cpp
@@ -174,6 +174,7 @@ void MoodLampManager::updateColors(const bool forceUpdate)
 		if (forceUpdate) {
 			emit moodlampFrametime(1000);
 			m_elapsedTimer.restart();
+			m_frames = 0;
 		} else if (m_elapsedTimer.hasExpired(1000)) { // 1s
 			emit moodlampFrametime(m_elapsedTimer.restart() / m_frames);
 			m_frames = 0;

--- a/Software/src/MoodLampManager.cpp
+++ b/Software/src/MoodLampManager.cpp
@@ -169,7 +169,14 @@ void MoodLampManager::updateColors(const bool forceUpdate)
 	bool changed = (m_lamp ? m_lamp->shine(newColor, m_colors) : false);
 	if (changed || !m_isSendDataOnlyIfColorsChanged || forceUpdate) {
 		emit updateLedsColors(m_colors);
-		emit moodlampFrametime(m_elapsedTimer.restart());
+		if (forceUpdate) {
+			emit moodlampFrametime(1000);
+			m_elapsedTimer.restart();
+		} else if (m_elapsedTimer.hasExpired(1000)) { // 1s
+			emit moodlampFrametime(m_elapsedTimer.restart() / m_frames);
+			m_frames = 0;
+		}
+		m_frames++;
 	}
 }
 

--- a/Software/src/MoodLampManager.hpp
+++ b/Software/src/MoodLampManager.hpp
@@ -80,4 +80,5 @@ private:
 
 	QTimer m_timer;
 	QElapsedTimer m_elapsedTimer;
+	size_t m_frames{ 1 };
 };

--- a/Software/src/MoodLampManager.hpp
+++ b/Software/src/MoodLampManager.hpp
@@ -28,6 +28,7 @@
 #include <QObject>
 #include <QColor>
 #include <QTimer>
+#include <QElapsedTimer>
 #include "LiquidColorGenerator.hpp"
 #include "MoodLamp.hpp"
 
@@ -78,4 +79,5 @@ private:
 	bool	m_isSendDataOnlyIfColorsChanged;
 
 	QTimer m_timer;
+	QElapsedTimer m_elapsedTimer;
 };

--- a/Software/src/MoodLampManager.hpp
+++ b/Software/src/MoodLampManager.hpp
@@ -41,6 +41,7 @@ public:
 signals:
 	void updateLedsColors(const QList<QRgb> & colors);
 	void lampList(const QList<MoodLampLampInfo> &, int);
+	void moodlampFrametime(const double frameMs);
 
 public:
 	void start(bool isMoodLampEnabled);

--- a/Software/src/MoodLampManager.hpp
+++ b/Software/src/MoodLampManager.hpp
@@ -48,7 +48,6 @@ public:
 	void start(bool isMoodLampEnabled);
 
 	// Common options
-	void setSendDataOnlyIfColorsChanged(bool state);
 	void reset();
 
 public slots:
@@ -60,6 +59,7 @@ public slots:
 	void setCurrentColor(QColor color);
 	void setCurrentLamp(const int id);
 	void requestLampList();
+	void setSendDataOnlyIfColorsChanged(bool state);
 
 private slots:
 	void updateColors(const bool forceUpdate = false);

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -1151,7 +1151,7 @@ void SettingsWindow::refreshAmbilightEvaluated(double updateResultMs)
 		QPalette palette = ui->label_GrabFrequency_value->palette();
 
 		if (theoreticalMaxHz <= hz) {
-			palette.setColor(QPalette::WindowText, QColorConstants::Red);
+			palette.setColor(QPalette::WindowText, Qt::red);
 			baudRateWarning = tr(" LOW BAUDRATE!");
 		} else
 			palette.setColor(QPalette::WindowText, defaultPalette.color(QPalette::WindowText));

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -1136,8 +1136,6 @@ void SettingsWindow::refreshAmbilightEvaluated(double updateResultMs)
 	if (updateResultMs != 0)
 		hz = 1000.0 / updateResultMs; /* ms to hz */
 	
-	const double maxHz = 1000.0 / ui->spinBox_GrabSlowdown->value(); // cap with display refresh rate?
-	
 	const SupportedDevices::DeviceType device = Settings::getConnectedDevice();
 	QString baudRateWarning;
 	if (device == SupportedDevices::DeviceTypeArdulight || device == SupportedDevices::DeviceTypeAdalight) {
@@ -1162,7 +1160,11 @@ void SettingsWindow::refreshAmbilightEvaluated(double updateResultMs)
 		this->labelFPS->setPalette(palette);
 	}
 	
-	QString fpsText = QString::number(hz, 'f', 0) + " / " + QString::number(maxHz, 'f', 0);
+	QString fpsText = QString::number(hz, 'f', 0);
+	if (ui->comboBox_LightpackModes->currentIndex() == GrabModeIndex) {
+		const double maxHz = 1000.0 / ui->spinBox_GrabSlowdown->value(); // cap with display refresh rate?
+		fpsText += " / " + QString::number(maxHz, 'f', 0);
+	}
 
 	ui->label_GrabFrequency_value->setText(fpsText);
 

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -1178,6 +1178,11 @@ void SettingsWindow::refreshAmbilightEvaluated(double updateResultMs)
 
 		ui->label_GrabFrequency_value->setPalette(palette);
 		this->labelFPS->setPalette(palette);
+		
+		// this acts as a "read" status for the tooltip
+		// the detected max can be reset, which should remove the warning when the grab interval was adjusted
+		if (this->labelFPS->underMouse())
+			m_maxFPS = hz;
 	}
 
 	this->labelFPS->setText(tr("FPS: ") + fpsText);

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -318,7 +318,7 @@ void SettingsWindow::connectSignalsSlots()
 	connect(&m_smoothScrollTimer, SIGNAL(timeout()), this, SLOT(scrollThanks()));
 	connect(ui->checkBox_checkForUpdates, SIGNAL(toggled(bool)), this, SLOT(onCheckBox_checkForUpdates_Toggled(bool)));
 	connect(ui->checkBox_installUpdates, SIGNAL(toggled(bool)), this, SLOT(onCheckBox_installUpdates_Toggled(bool)));
-	connect(&m_baudrateTriggerTimer, SIGNAL(timeout()), this, SLOT(clearBaudrateWarning()));
+	connect(&m_baudrateWarningClearTimer, SIGNAL(timeout()), this, SLOT(clearBaudrateWarning()));
 }
 
 // ----------------------------------------------------------------------------
@@ -1177,7 +1177,7 @@ void SettingsWindow::refreshAmbilightEvaluated(double updateResultMs)
 			.arg(PrismatikMath::theoreticalMaxFrameRate(ledCount, baudRate), 0, 'f', 0)
 			.arg(std::round(PrismatikMath::theoreticalMinBaudRate(ledCount, m_maxFPS) / 100.0) * 100.0, 0, 'f', 0);
 			this->labelFPS->setToolTip(toolTipMsg);
-			m_baudrateTriggerTimer.start(15000);
+			m_baudrateWarningClearTimer.start(15000);
 		} else
 			palette.setColor(QPalette::WindowText, defaultPalette.color(QPalette::WindowText));
 

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -295,6 +295,7 @@ private:
 	QLabel *labelProfile;
 	QLabel *labelDevice;
 	QLabel *labelFPS;
+	double m_maxFPS{ 0 };
 
 	QCache<QString, QPixmap> m_pixmapCache;
 

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -298,7 +298,7 @@ private:
 	QLabel *labelDevice;
 	QLabel *labelFPS;
 	double m_maxFPS{ 0 };
-	QTimer m_baudrateTriggerTimer;
+	QTimer m_baudrateWarningClearTimer;
 
 	QCache<QString, QPixmap> m_pixmapCache;
 

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -240,6 +240,8 @@ private slots:
 	void onCheckBox_checkForUpdates_Toggled(bool isEnabled);
 	void onCheckBox_installUpdates_Toggled(bool isEnabled);
 
+	void clearBaudrateWarning();
+
 private:
 	void updateExpertModeWidgetsVisibility();
 	void updateDeviceTabWidgetsVisibility();
@@ -296,6 +298,7 @@ private:
 	QLabel *labelDevice;
 	QLabel *labelFPS;
 	double m_maxFPS{ 0 };
+	QTimer m_baudrateTriggerTimer;
 
 	QCache<QString, QPixmap> m_pixmapCache;
 

--- a/Software/src/SoundManagerBase.cpp
+++ b/Software/src/SoundManagerBase.cpp
@@ -181,8 +181,10 @@ void SoundManagerBase::updateColors()
 
 	updateFft();
 	bool colorsChanged = (m_visualizer ? m_visualizer->visualize(m_fft, fftSize(), m_colors) : false);
-	if (colorsChanged || !m_isSendDataOnlyIfColorsChanged)
+	if (colorsChanged || !m_isSendDataOnlyIfColorsChanged) {
 		emit updateLedsColors(m_colors);
+		emit visualizerFrametime(m_elapsedTimer.restart());
+	}
 }
 
 void SoundManagerBase::initColors(int numberOfLeds)

--- a/Software/src/SoundManagerBase.cpp
+++ b/Software/src/SoundManagerBase.cpp
@@ -183,7 +183,11 @@ void SoundManagerBase::updateColors()
 	bool colorsChanged = (m_visualizer ? m_visualizer->visualize(m_fft, fftSize(), m_colors) : false);
 	if (colorsChanged || !m_isSendDataOnlyIfColorsChanged) {
 		emit updateLedsColors(m_colors);
-		emit visualizerFrametime(m_elapsedTimer.restart());
+		if (m_elapsedTimer.hasExpired(1000)) { // 1s
+			emit visualizerFrametime(m_elapsedTimer.restart() / m_frames);
+			m_frames = 0;
+		}
+		m_frames++;
 	}
 }
 

--- a/Software/src/SoundManagerBase.hpp
+++ b/Software/src/SoundManagerBase.hpp
@@ -95,4 +95,5 @@ protected:
 	float*	m_fft{nullptr};
 	
 	QElapsedTimer m_elapsedTimer;
+	size_t m_frames{ 1 };
 };

--- a/Software/src/SoundManagerBase.hpp
+++ b/Software/src/SoundManagerBase.hpp
@@ -57,7 +57,6 @@ public:
 	virtual void start(bool isEnabled) { Q_UNUSED(isEnabled); Q_ASSERT(("Not implemented", false)); };
 
 	// Common options
-	void setSendDataOnlyIfColorsChanged(bool state);
 	void reset();
 	virtual size_t fftSize() const;
 	float* fft() const;
@@ -75,6 +74,7 @@ public slots:
 	void requestDeviceList();
 	void requestVisualizerList();
 	void updateColors();
+	void setSendDataOnlyIfColorsChanged(bool state);
 
 protected:
 	virtual bool init() = 0;

--- a/Software/src/SoundManagerBase.hpp
+++ b/Software/src/SoundManagerBase.hpp
@@ -27,6 +27,7 @@
 
 #include <QObject>
 #include <QColor>
+#include <QElapsedTimer>
 #include "SoundVisualizer.hpp"
 
 struct SoundManagerDeviceInfo {
@@ -50,6 +51,7 @@ signals:
 	void updateLedsColors(const QList<QRgb> & colors);
 	void deviceList(const QList<SoundManagerDeviceInfo> & devices, int recommended);
 	void visualizerList(const QList<SoundManagerVisualizerInfo>& visualizers, int recommended);
+	void visualizerFrametime(const double);
 
 public:
 	virtual void start(bool isEnabled) { Q_UNUSED(isEnabled); Q_ASSERT(("Not implemented", false)); };
@@ -91,4 +93,6 @@ protected:
 	bool	m_isSendDataOnlyIfColorsChanged{false};
 	
 	float*	m_fft{nullptr};
+	
+	QElapsedTimer m_elapsedTimer;
 };


### PR DESCRIPTION
People using low baud rates with long strips seems to be a recurring issue, hopefully this will help them troubleshoot.
I used [this formula](https://www.partsnotincluded.com/calculating-adalight-framerate-limits/) to get an estimate for current configuration max and when FPS goes over it FPS counter becomes red and shows "LOW BAUDRATE". This is for Adalight/Ardulight only.

![Screenshot 2020-02-07 at 23 29 44](https://user-images.githubusercontent.com/239811/74082522-1c918680-4a5b-11ea-85eb-4d56de9d878a.png)

Also, since mood lamps and soundviz are animated, I made them report their FPS so they can trigger the same warning. I removed " / MAX" part for these modes since the MAX is based on grab interval.

And lastly, I set grab fps timer to a `PreciseTimer` to get more accurate readings.

Edit: if travis can be bumped to `osx_image: xcode11.3`, that'd be great :)