### PR TITLE
led device manager: wrong led device WBA update slot

### DIFF
--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -527,7 +527,7 @@ void LedDeviceManager::disconnectSignalSlotsLedDevice()
 	disconnect(this, SIGNAL(ledDeviceSetLuminosityThreshold(int)),			m_ledDevice, SLOT(setLuminosityThreshold(int)));
 	disconnect(this, SIGNAL(ledDeviceSetMinimumLuminosityEnabled(bool)),	m_ledDevice, SLOT(setMinimumLuminosityThresholdEnabled(bool)));
 	disconnect(this, SIGNAL(ledDeviceRequestFirmwareVersion()),				m_ledDevice, SLOT(requestFirmwareVersion()));
-	disconnect(this, SIGNAL(ledDeviceUpdateWBAdjustments()),				m_ledDevice, SLOT(ledDeviceUpdateWBAdjustments()));
+	disconnect(this, SIGNAL(ledDeviceUpdateWBAdjustments()),				m_ledDevice, SLOT(updateWBAdjustments()));
 	disconnect(this, SIGNAL(ledDeviceUpdateDeviceSettings()),				m_ledDevice, SLOT(updateDeviceSettings()));
 }
 


### PR DESCRIPTION
matching  `connect()`
https://github.com/psieg/Lightpack/blob/a8b05af871aed0153dcfb5b2f292cacf189230fc/Software/src/LedDeviceManager.cpp#L497