### PR TITLE
more verbose serial error log

### DIFF
--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -207,6 +207,7 @@ void LedDeviceAdalight::open()
 	// Ubuntu 10.04: on every second attempt to open the device leads to failure
 	if (ok == false)
 	{
+		qWarning() << Q_FUNC_INFO << "Serial device" << m_AdalightDevice->portName() << "open fail, will retry. Error" << (int)m_AdalightDevice->error() << m_AdalightDevice->errorString();
 		// Try one more time
 		m_AdalightDevice->open(QIODevice::WriteOnly);
 		ok = m_AdalightDevice->isOpen();
@@ -215,7 +216,6 @@ void LedDeviceAdalight::open()
 	if (ok)
 	{
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Serial device" << m_AdalightDevice->portName() << "open";
-
 		ok = m_AdalightDevice->setBaudRate(m_baudRate);//Settings::getAdalightSerialPortBaudRate());
 		if (ok)
 		{
@@ -226,16 +226,16 @@ void LedDeviceAdalight::open()
 				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Data bits	:" << m_AdalightDevice->dataBits();
 				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Parity		:" << m_AdalightDevice->parity();
 				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Stop bits	:" << m_AdalightDevice->stopBits();
-				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Flow		:" << m_AdalightDevice->flowControl();
+				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Flow			:" << m_AdalightDevice->flowControl();
 			} else {
-				qWarning() << Q_FUNC_INFO << "Set data bits 8 fail";
+				qWarning() << Q_FUNC_INFO << "Set data bits 8 fail. Error" << (int)m_AdalightDevice->error() << m_AdalightDevice->errorString();
 			}
 		} else {
-			qWarning() << Q_FUNC_INFO << "Set baud rate" << m_baudRate << "fail";
+			qWarning() << Q_FUNC_INFO << "Set baud rate" << m_baudRate << "fail. Error" << (int)m_AdalightDevice->error() << m_AdalightDevice->errorString();
 		}
 
 	} else {
-		qWarning() << Q_FUNC_INFO << "Serial device" << m_AdalightDevice->portName() << "open fail. " << m_AdalightDevice->errorString();
+		qWarning() << Q_FUNC_INFO << "Serial device" << m_AdalightDevice->portName() << "open fail. Error" << (int)m_AdalightDevice->error() << m_AdalightDevice->errorString();
 		DEBUG_OUT << Q_FUNC_INFO << "Available ports:";
 		QList<QSerialPortInfo> availPorts = QSerialPortInfo::availablePorts();
 		for(int i=0; i < availPorts.size(); i++) {

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -201,7 +201,7 @@ void LedDeviceAdalight::open()
 
 	m_AdalightDevice->setPortName(m_portName);// Settings::getAdalightSerialPortName());
 
-	m_AdalightDevice->open(QIODevice::WriteOnly | QIODevice::Unbuffered);
+	m_AdalightDevice->open(QIODevice::WriteOnly);
 	bool ok = m_AdalightDevice->isOpen();
 
 	// Ubuntu 10.04: on every second attempt to open the device leads to failure

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -214,6 +214,7 @@ void LedDeviceArdulight::open()
 	// Ubuntu 10.04: on every second attempt to open the device leads to failure
 	if (ok == false)
 	{
+		qWarning() << Q_FUNC_INFO << "Serial device" << m_ArdulightDevice->portName() << "open fail, will retry. Error" << (int)m_ArdulightDevice->error() << m_ArdulightDevice->errorString();
 		// Try one more time
 		m_ArdulightDevice->open(QIODevice::WriteOnly);
 		ok = m_ArdulightDevice->isOpen();
@@ -233,16 +234,16 @@ void LedDeviceArdulight::open()
 				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Data bits	:" << m_ArdulightDevice->dataBits();
 				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Parity		:" << m_ArdulightDevice->parity();
 				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Stop bits	:" << m_ArdulightDevice->stopBits();
-				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Flow		:" << m_ArdulightDevice->flowControl();
+				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Flow			:" << m_ArdulightDevice->flowControl();
 			} else {
-				qWarning() << Q_FUNC_INFO << "Set data bits 8 fail";
+				qWarning() << Q_FUNC_INFO << "Set data bits 8 fail. Error" << (int)m_ArdulightDevice->error() << m_ArdulightDevice->errorString();
 			}
 		} else {
-			qWarning() << Q_FUNC_INFO << "Set baud rate" << m_baudRate << "fail";
+			qWarning() << Q_FUNC_INFO << "Set baud rate" << m_baudRate << "fail. Error" << (int)m_ArdulightDevice->error() << m_ArdulightDevice->errorString();
 		}
 
 	} else {
-		qWarning() << Q_FUNC_INFO << "Serial device" << m_ArdulightDevice->portName() << "open fail. " << m_ArdulightDevice->errorString();
+		qWarning() << Q_FUNC_INFO << "Serial device" << m_ArdulightDevice->portName() << "open fail. Error" << (int)m_ArdulightDevice->error() << m_ArdulightDevice->errorString();
 		DEBUG_OUT << Q_FUNC_INFO << "Available ports:";
 		QList<QSerialPortInfo> availPorts = QSerialPortInfo::availablePorts();
 		for(int i=0; i < availPorts.size(); i++) {


### PR DESCRIPTION
...and while I was there I removed `QIODevice::Unbuffered` which is [unsupported ](https://doc.qt.io/qt-5/qserialport.html#open)by `open()` and the first call is always failing
https://github.com/psieg/Lightpack/blob/a8b05af871aed0153dcfb5b2f292cacf189230fc/Software/src/LedDeviceAdalight.cpp#L202-L213

So I'm not sure if the subsequent retry is still needed and if it was caused by something similar while 10.04 was around like the comment mentions. But Ardulight does not have `QIODevice::Unbuffered` and still has the retry, so I left the other one too.
