### PR TITLE
adalight/ardulight led devices: skip writing frames to serial when buffer is full

### DIFF
--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -55,6 +55,7 @@ LedDeviceAdalight::LedDeviceAdalight(const QString &portName, const int baudRate
 LedDeviceAdalight::~LedDeviceAdalight()
 {
 	close();
+	delete m_lastWillTimer;
 }
 
 void LedDeviceAdalight::close()

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -60,12 +60,17 @@ LedDeviceAdalight::~LedDeviceAdalight()
 
 void LedDeviceAdalight::close()
 {
-	if (m_AdalightDevice != NULL) {
-		m_AdalightDevice->close();
+	if (m_AdalightDevice == NULL)
+		return;
 
-		delete m_AdalightDevice;
-		m_AdalightDevice = NULL;
+	if (m_lastWillTimer->isActive()) {
+		m_lastWillTimer->stop();
+		writeLastWill(true);
 	}
+	m_AdalightDevice->close();
+
+	delete m_AdalightDevice;
+	m_AdalightDevice = NULL;
 }
 
 void LedDeviceAdalight::setColors(const QList<QRgb> & colors)

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -249,9 +249,9 @@ void LedDeviceAdalight::open()
 	emit openDeviceSuccess(ok);
 }
 
-void LedDeviceAdalight::writeLastWill()
+void LedDeviceAdalight::writeLastWill(const bool force)
 {
-	if (m_AdalightDevice->bytesToWrite() == 0) {
+	if (force || m_AdalightDevice->bytesToWrite() == 0) {
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << "Writing last will frame";
 		setColors(m_colorsSaved);
 	}

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -253,6 +253,11 @@ bool LedDeviceAdalight::writeBuffer(const QByteArray & buff)
 	if (m_AdalightDevice == NULL || m_AdalightDevice->isOpen() == false)
 		return false;
 
+	if (m_AdalightDevice->bytesToWrite() > buff.count()) {
+		DEBUG_MID_LEVEL << Q_FUNC_INFO << "Serial bytesToWrite:" << m_AdalightDevice->bytesToWrite() << ", skipping current frame";
+		return true;
+	}
+
 	int bytesWritten = m_AdalightDevice->write(buff);
 
 	if (bytesWritten != buff.count())

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -252,7 +252,6 @@ void LedDeviceAdalight::writeLastWill()
 {
 	if (m_AdalightDevice->bytesToWrite() == 0) {
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << "Writing last will frame";
-		m_lastWillTimer->stop();
 		setColors(m_colorsSaved);
 	}
 }
@@ -271,6 +270,7 @@ bool LedDeviceAdalight::writeBuffer(const QByteArray & buff)
 		m_lastWillTimer->start(100);
 		return true;
 	}
+	m_lastWillTimer->stop();
 
 	int bytesWritten = m_AdalightDevice->write(buff);
 

--- a/Software/src/LedDeviceAdalight.hpp
+++ b/Software/src/LedDeviceAdalight.hpp
@@ -51,6 +51,7 @@ public slots:
 	void updateDeviceSettings();
 	int maxLedsCount() { return 511; }
 	virtual int defaultLedsCount() { return 25; }
+	void writeLastWill();
 
 private:
 	bool writeBuffer(const QByteArray & buff);
@@ -64,4 +65,5 @@ private:
 	QByteArray m_writeBuffer;
 	QString m_portName;
 	int m_baudRate;
+	QTimer* m_lastWillTimer{nullptr};
 };

--- a/Software/src/LedDeviceAdalight.hpp
+++ b/Software/src/LedDeviceAdalight.hpp
@@ -51,7 +51,7 @@ public slots:
 	void updateDeviceSettings();
 	int maxLedsCount() { return 511; }
 	virtual int defaultLedsCount() { return 25; }
-	void writeLastWill();
+	void writeLastWill(const bool force = false);
 
 private:
 	bool writeBuffer(const QByteArray & buff);

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -259,9 +259,9 @@ void LedDeviceArdulight::open()
 	emit openDeviceSuccess(ok);
 }
 
-void LedDeviceArdulight::writeLastWill()
+void LedDeviceArdulight::writeLastWill(const bool force)
 {
-	if (m_ArdulightDevice->bytesToWrite() == 0) {
+	if (force || m_ArdulightDevice->bytesToWrite() == 0) {
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << "Writing last will frame";
 		setColors(m_colorsSaved);
 	}

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -58,6 +58,7 @@ LedDeviceArdulight::LedDeviceArdulight(const QString &portName, const int baudRa
 LedDeviceArdulight::~LedDeviceArdulight()
 {
 	close();
+	delete m_lastWillTimer;
 }
 
 void LedDeviceArdulight::close()

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -63,12 +63,17 @@ LedDeviceArdulight::~LedDeviceArdulight()
 
 void LedDeviceArdulight::close()
 {
-	if (m_ArdulightDevice != NULL) {
-		m_ArdulightDevice->close();
+	if (m_ArdulightDevice == NULL)
+		return;
 
-		delete m_ArdulightDevice;
-		m_ArdulightDevice = NULL;
+	if (m_lastWillTimer->isActive()) {
+		m_lastWillTimer->stop();
+		writeLastWill(true);
 	}
+	m_ArdulightDevice->close();
+
+	delete m_ArdulightDevice;
+	m_ArdulightDevice = NULL;
 }
 
 void LedDeviceArdulight::setColors(const QList<QRgb> & colors)

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -261,6 +261,11 @@ bool LedDeviceArdulight::writeBuffer(const QByteArray & buff)
 	if (m_ArdulightDevice == NULL || m_ArdulightDevice->isOpen() == false)
 		return false;
 
+	if (m_ArdulightDevice->bytesToWrite() > buff.count()) {
+		DEBUG_MID_LEVEL << Q_FUNC_INFO << "Serial bytesToWrite:" << m_ArdulightDevice->bytesToWrite() << ", skipping current frame";
+		return true;
+	}
+
 	int bytesWritten = m_ArdulightDevice->write(buff);
 
 	if (bytesWritten != buff.count())

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -262,7 +262,6 @@ void LedDeviceArdulight::writeLastWill()
 {
 	if (m_ArdulightDevice->bytesToWrite() == 0) {
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << "Writing last will frame";
-		m_lastWillTimer->stop();
 		setColors(m_colorsSaved);
 	}
 }
@@ -281,6 +280,7 @@ bool LedDeviceArdulight::writeBuffer(const QByteArray & buff)
 		m_lastWillTimer->start(100);
 		return true;
 	}
+	m_lastWillTimer->stop();
 
 	int bytesWritten = m_ArdulightDevice->write(buff);
 

--- a/Software/src/LedDeviceArdulight.hpp
+++ b/Software/src/LedDeviceArdulight.hpp
@@ -51,7 +51,7 @@ public slots:
 	void updateDeviceSettings();
 	int maxLedsCount(){ return 255; }
 	virtual int defaultLedsCount() { return 25; }
-	void writeLastWill();
+	void writeLastWill(const bool force = false);
 
 private:
 	bool writeBuffer(const QByteArray & buff);

--- a/Software/src/LedDeviceArdulight.hpp
+++ b/Software/src/LedDeviceArdulight.hpp
@@ -51,7 +51,7 @@ public slots:
 	void updateDeviceSettings();
 	int maxLedsCount(){ return 255; }
 	virtual int defaultLedsCount() { return 25; }
-    void writeLastWill();
+	void writeLastWill();
 
 private:
 	bool writeBuffer(const QByteArray & buff);
@@ -65,5 +65,5 @@ private:
 
 	QString m_portName;
 	int m_baudRate;
-    QTimer* m_lastWillTimer{ nullptr };
+	QTimer* m_lastWillTimer{ nullptr };
 };

--- a/Software/src/LedDeviceArdulight.hpp
+++ b/Software/src/LedDeviceArdulight.hpp
@@ -51,6 +51,7 @@ public slots:
 	void updateDeviceSettings();
 	int maxLedsCount(){ return 255; }
 	virtual int defaultLedsCount() { return 25; }
+    void writeLastWill();
 
 private:
 	bool writeBuffer(const QByteArray & buff);
@@ -64,4 +65,5 @@ private:
 
 	QString m_portName;
 	int m_baudRate;
+    QTimer* m_lastWillTimer{ nullptr };
 };


### PR DESCRIPTION
While searching for that mystery leak (#308) I took a look at the edge case where the baud rate is so low that the serial buffer doesn't have enough time to be emptied: the frames pile up and cause massive lag (and the ever growing buffer).

So here I gave a go to [bytesToWrite()](https://doc.qt.io/qt-5/qserialport.html#bytesToWrite) and it works pretty well. I tried 9600bauds @ 30 fps with 60 leds, the lag was minimal (compared to no skipping), at the cost of visual frame rate, which remained constant so it's not jarring.

This should also help people who have baudrate/framerate ratio slightly over the optimal value, where they would start seeing the lag 1h later, it should keep them in-sync with few dropped frames.

I implemented a _last will_ with a timer so the very last frame is not skipped (the turn-off frame for instance)

In optimal conditions it stays off and only kicks in when needed.