### PR TITLE
Bugfix/linux release build with debug flags

### DIFF
--- a/Software/build-vars.prf.default
+++ b/Software/build-vars.prf.default
@@ -4,12 +4,12 @@
 #------------------------------------------------------------------------------
 # General
 #------------------------------------------------------------------------------
-win32: {	
+win32: {
 	# Set this to -Win32 for 32-bit
 	OPENSSL_DIR = "C:\\OpenSSL-Win64\\bin"
 	# Set this to run without openssl. The updatecheck won't work.
 	# DEFINES += NO_OPENSSL
-	
+
 	# optional: BASS library directory, for sound visualization (http://www.un4seen.com/)
 	DEFINES += BASS_SOUND_SUPPORT
 	BASS_DIR = "C:\\bass"
@@ -19,23 +19,24 @@ win32: {
 	DEFINES += NIGHTLIGHT_SUPPORT
 	NIGHTLIGHT_DIR = C:\\NightLightLibrary
 
-    # Set this to x86 to compile 32-bit
-    TARGET_ARCH = x86_64
+	# Set this to x86 to compile 32-bit
+	TARGET_ARCH = x86_64
 }
 
 unix:!macx {
-    DEFINES += PULSEAUDIO_SUPPORT
-#    PULSEAUDIO_INC_DIR = "../../../pulseaudio/src"
-#    PULSEAUDIO_LIB_DIR = "../../../pulseaudio/src/.libs"
-#    FFTW3_INC_DIR = "../../../fftw-3.3.8/api"
-#    FFTW3_LIB_DIR = "../../../fftw-3.3.8/.libs"
+	# CONFIG += debug
+	DEFINES += PULSEAUDIO_SUPPORT
+	# PULSEAUDIO_INC_DIR = "../../../pulseaudio/src"
+	# PULSEAUDIO_LIB_DIR = "../../../pulseaudio/src/.libs"
+	# FFTW3_INC_DIR = "../../../fftw-3.3.8/api"
+	# FFTW3_LIB_DIR = "../../../fftw-3.3.8/.libs"
 }
 
 # For Qt lrelease reasons, to change the MAC SDK, you have to edit src.pro directly
 # When using variables, lrelease complains about QMAKE_MAC_SDK not being set
 # You can override QMAKE_MAC_SDK value by setting this variable.
 macx {
-#     QMAKE_MAC_SDK_OVERRIDE = macosx10.8
-    DEFINES += SOUNDVIZ_SUPPORT
-#    DEFINES += SAVE_FRAME_TO_FILE
+	# QMAKE_MAC_SDK_OVERRIDE = macosx10.8
+	DEFINES += SOUNDVIZ_SUPPORT
+	# DEFINES += SAVE_FRAME_TO_FILE
 }

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -65,7 +65,7 @@ CONFIG(clang) {
 }
 
 unix:!macx{
-    CONFIG    += link_pkgconfig debug
+    CONFIG    += link_pkgconfig
     PKGCONFIG += libusb-1.0
 
     DESKTOP = $$(XDG_CURRENT_DESKTOP)


### PR DESCRIPTION
I'm not sure if there's an obscure reason for it... so I moved it to build vars.

There's also this weird combo
https://github.com/psieg/Lightpack/blob/3f7c82839843d8da36a7c878f8ec8d6614015e89/Software/src/src.pro#L107