### PR TITLE
SIMD color averaging

### DIFF
--- a/Software/build-vars.prf.default
+++ b/Software/build-vars.prf.default
@@ -25,6 +25,12 @@ win32: {
 
 unix:!macx {
 	# CONFIG += debug
+	# QMAKE_CC = clang
+	# QMAKE_CXX = clang++
+	# QMAKE_CFLAGS_DEBUG += -ggdb
+	# QMAKE_CFLAGS_RELEASE += -march=native
+	# QMAKE_CXXFLAGS_DEBUG += -ggdb
+	# QMAKE_CXXFLAGS_RELEASE += -march=native
 	DEFINES += PULSEAUDIO_SUPPORT
 	# PULSEAUDIO_INC_DIR = "../../../pulseaudio/src"
 	# PULSEAUDIO_LIB_DIR = "../../../pulseaudio/src/.libs"
@@ -39,4 +45,12 @@ macx {
 	# QMAKE_MAC_SDK_OVERRIDE = macosx10.8
 	DEFINES += SOUNDVIZ_SUPPORT
 	# DEFINES += SAVE_FRAME_TO_FILE
+
+	# CONFIG += debug
+	# QMAKE_CC += clang
+	# QMAKE_CXX += clang++
+	# QMAKE_CFLAGS_DEBUG += -ggdb
+	# QMAKE_CFLAGS_RELEASE += -march=native
+	# QMAKE_CXXFLAGS_DEBUG += -ggdb
+	# QMAKE_CXXFLAGS_RELEASE += -march=native
 }

--- a/Software/grab/GrabberBase.cpp
+++ b/Software/grab/GrabberBase.cpp
@@ -168,28 +168,30 @@ void GrabberBase::grab()
 			QRect preparedRect = clippedRect.translated(-monitorRect.x(), -monitorRect.y());
 
 			// grabbed screen is rotated => rotate the widget
-			if (grabbedScreen->rotation != 0)
-				if (grabbedScreen->rotation % 4 == 1) // rotated 90
+			if (grabbedScreen->rotation != 0) {
+				if (grabbedScreen->rotation % 4 == 1) { // rotated 90
 					preparedRect.setCoords(
 						monitorRect.height() - preparedRect.bottom(),
 						preparedRect.left(),
 						monitorRect.height() - preparedRect.top(),
 						preparedRect.right()
 					);
-				else if (grabbedScreen->rotation % 4 == 2) // rotated 180
+				} else if (grabbedScreen->rotation % 4 == 2) { // rotated 180
 					preparedRect.setCoords(
 						monitorRect.width() - preparedRect.right(),
 						monitorRect.height() - preparedRect.bottom(),
 						monitorRect.width() - preparedRect.left(),
 						monitorRect.height() - preparedRect.top()
 					);
-				else if (grabbedScreen->rotation % 4 == 3) // rotated 270
+				} else if (grabbedScreen->rotation % 4 == 3) { // rotated 270
 					preparedRect.setCoords(
 						preparedRect.top(),
 						monitorRect.width() - preparedRect.right(),
 						preparedRect.bottom(),
 						monitorRect.width() - preparedRect.left()
 					);
+				}
+			}
 
 			// grabbed screen was scaled => scale the widget
 			if (grabbedScreen->scale != 1.0)

--- a/Software/grab/GrabberBase.cpp
+++ b/Software/grab/GrabberBase.cpp
@@ -141,6 +141,10 @@ void GrabberBase::grab()
 		_context->grabResult->clear();
 
 		for (int i = 0; i < _context->grabWidgets->size(); ++i) {
+			if (!_context->grabWidgets->at(i)->isAreaEnabled()) {
+				_context->grabResult->append(qRgb(0,0,0));
+				continue;
+			}
 			QRect widgetRect = _context->grabWidgets->at(i)->frameGeometry();
 			getValidRect(widgetRect);
 
@@ -214,19 +218,13 @@ void GrabberBase::grab()
 				continue;
 			}
 
-			using namespace Grab;
 			const int bytesPerPixel = 4;
-			QRgb avgColor;
-			if (_context->grabWidgets->at(i)->isAreaEnabled()) {
-				Q_ASSERT(grabbedScreen->imgData);
-				Calculations::calculateAvgColor(
-					&avgColor, grabbedScreen->imgData, grabbedScreen->imgFormat,
-					grabbedScreen->bytesPerRow > 0 ? grabbedScreen->bytesPerRow : grabbedScreen->screenInfo.rect.width() * bytesPerPixel,
-					preparedRect);
-				_context->grabResult->append(avgColor);
-			} else {
-				_context->grabResult->append(qRgb(0,0,0));
-			}
+			Q_ASSERT(grabbedScreen->imgData);
+			QRgb avgColor = Grab::Calculations::calculateAvgColor(
+				grabbedScreen->imgData, grabbedScreen->imgFormat,
+				grabbedScreen->bytesPerRow > 0 ? grabbedScreen->bytesPerRow : grabbedScreen->screenInfo.rect.width() * bytesPerPixel,
+				preparedRect);
+			_context->grabResult->append(avgColor);
 		}
 
 	}

--- a/Software/grab/calculations.cpp
+++ b/Software/grab/calculations.cpp
@@ -149,7 +149,7 @@ static bool avx2_available() {
 	uint32_t eax = 0x07;
 	uint32_t ecx = 0x00;
 #if defined(_MSC_VER)
-	__cpuidex(abcd, eax, ecx);
+	__cpuidex((int*)abcd, eax, ecx);
 #else
 	uint32_t ebx = 0;
 	uint32_t edx = 0;

--- a/Software/grab/calculations.cpp
+++ b/Software/grab/calculations.cpp
@@ -25,17 +25,12 @@
 
 #include "calculations.hpp"
 #include <stdint.h>
+#include <immintrin.h>
 
 #define PIXEL_FORMAT_ARGB 2,1,0 // channel positions in a 4 byte color
 #define PIXEL_FORMAT_ABGR 0,1,2
 #define PIXEL_FORMAT_RGBA 3,2,1
 #define PIXEL_FORMAT_BGRA 1,2,3
-
-#define PIXEL_INDEX(_channelOffset_,_position_) (index + _channelOffset_ + (bytesPerPixel * _position_))
-#define PIXEL_CHANNEL(_channel_,_position_) (buffer[PIXEL_INDEX(offset##_channel_,_position_)])
-#define PIXEL_R(_position_) (PIXEL_CHANNEL(R,_position_))
-#define PIXEL_G(_position_) (PIXEL_CHANNEL(G,_position_))
-#define PIXEL_B(_position_) (PIXEL_CHANNEL(B,_position_))
 
 namespace {
 	const uint8_t bytesPerPixel = 4;
@@ -46,84 +41,190 @@ namespace {
 	};
 
 	template<uint8_t offsetR, uint8_t offsetG, uint8_t offsetB>
-	static unsigned int accumulateBuffer(
-		const unsigned char *buffer,
+	static ColorValue accumulateBuffer128(
+		const int * const buffer,
 		const size_t pitch,
-		const QRect &rect,
-		ColorValue *resultColor) {
-		unsigned int r = 0, g = 0, b = 0;
-		unsigned int count = 0; // count the amount of pixels taken into account
-		for (int currentY = 0; currentY < rect.height(); currentY++) {
-			size_t index = pitch * (rect.y() + currentY) + rect.x() * bytesPerPixel;
-			for (int currentX = 0; currentX < rect.width(); currentX += pixelsPerStep) {
-				r += PIXEL_R(0) + PIXEL_R(1) + PIXEL_R(2) + PIXEL_R(3);
-				g += PIXEL_G(0) + PIXEL_G(1) + PIXEL_G(2) + PIXEL_G(3);
-				b += PIXEL_B(0) + PIXEL_B(1) + PIXEL_B(2) + PIXEL_B(3);
-				count += pixelsPerStep;
-				index += bytesPerPixel * pixelsPerStep;
-			}
-		}
+		const QRect& rect) {
 
-		resultColor->r = r;
-		resultColor->g = g;
-		resultColor->b = b;
-		return count;
+		const __m128i* const buffer128 = (const __m128i* const)buffer;
+
+		const size_t pitch4px = pitch / pixelsPerStep;
+
+		// (000000FF 000000FF 000000FF 000000FF)
+		const __m128i colorByteMask = _mm_set1_epi32(0x000000FFU);
+
+		__m128i sum[bytesPerPixel] = {0,0,0,0};
+		size_t index = pitch4px * rect.y() + rect.x() / pixelsPerStep;
+
+		for (size_t currentY = 0; currentY < (size_t)rect.height(); ++currentY) {
+			for (size_t currentX = 0; currentX < (size_t)rect.width() / pixelsPerStep; ++currentX) {
+				// (AARRGGBB AARRGGBB AARRGGBB AARRGGBB)
+				const __m128i vec4 = _mm_loadu_si128(&buffer128[index + currentX]);
+
+				//   (AARRGGBB AARRGGBB AARRGGBB AARRGGBB) >> offsetR
+				// = (0000AARR GGBBAARR GGBBAARR GGBBAARR)
+				// & (000000FF 000000FF 000000FF 000000FF)
+				// = (000000RR 000000RR 000000RR 000000RR)
+				sum[offsetR] = _mm_add_epi32(sum[offsetR], _mm_and_si128(_mm_srli_si128(vec4, offsetR), colorByteMask));
+				sum[offsetG] = _mm_add_epi32(sum[offsetG], _mm_and_si128(_mm_srli_si128(vec4, offsetG), colorByteMask));
+				sum[offsetB] = _mm_add_epi32(sum[offsetB], _mm_and_si128(_mm_srli_si128(vec4, offsetB), colorByteMask));
+			}
+			index += pitch4px;
+		}
+		//   ((BBBBBBBB BBBBBBBB BBBBBBBB BBBBBBBB) + (GGGGGGGG GGGGGGGG GGGGGGGG GGGGGGGG))
+		// + ((RRRRRRRR RRRRRRRR RRRRRRRR RRRRRRRR) + (AAAAAAAA AAAAAAAA AAAAAAAA AAAAAAAA))
+		// = ((GGGGGGGG GGGGGGGG BBBBBBBB BBBBBBBB) + (AAAAAAAA AAAAAAAA RRRRRRRR RRRRRRRR))
+		// =  (AAAAAAAA RRRRRRRR GGGGGGGG BBBBBBBB)
+		const __m128i horizontalSum128 = _mm_hadd_epi32(_mm_hadd_epi32(sum[0], sum[1]), _mm_hadd_epi32(sum[2], sum[3]));
+		const size_t count = rect.height() * rect.width();
+		ColorValue color;
+		color.r = (_mm_extract_epi32(horizontalSum128, offsetR) / count) & 0xff;
+		color.g = (_mm_extract_epi32(horizontalSum128, offsetG) / count) & 0xff;
+		color.b = (_mm_extract_epi32(horizontalSum128, offsetB) / count) & 0xff;
+		return color;
+	};
+
+	template<uint8_t offsetR, uint8_t offsetG, uint8_t offsetB>
+	static ColorValue accumulateBuffer256(
+		const int * const buffer,
+		const size_t pitch,
+		const QRect& rect) {
+
+		const __m256i colorByteMask = _mm256_set1_epi32(0x000000FFU);
+
+		/*
+			rect min width is 4px, here we do 8px steps
+			in order to get the remaining 4px we make 2 load masks:
+				- one full width (8px)
+				- one half width (4px)
+			we calculate 2 horizontal (x) limits:
+				- softlimit = number of 8px steps excluding the remainder
+				- hardlimit = number of 8px steps including the remainder (equal to softlimit or softlimit+1)
+			while we are under the softlimit we can du full loads
+			and a half load when we reach the hardlimit
+
+			note: this is much faster without half loads
+		*/
+		constexpr uint64_t full = 0xFFFFFFFFFFFFFFFFLLU;
+		constexpr uint64_t zero = 0x0000000000000000LLU;
+		const __m256i loadmasks[2] = {
+			_mm256_set_epi64x(full,full,zero,zero),
+			_mm256_set1_epi64x(full)
+		};
+		const size_t softlimit = rect.width() / pixelsPerStep / 2;
+		const size_t hardlimit = (rect.width() + pixelsPerStep) / pixelsPerStep / 2;
+		__m256i sum[bytesPerPixel] = {0,0,0,0}; // A,R,G,B sums
+		size_t index = pitch * rect.y() + rect.x(); // starting offset for lines
+		for (size_t currentY = 0; currentY < (size_t)rect.height(); ++currentY) {
+			for (size_t currentX = 0; currentX < hardlimit; ++currentX) {
+				const size_t maskIdx = (currentX < softlimit); // use bool as load mask index to avoid branches
+				const __m256i vec8 = _mm256_maskload_epi32(&buffer[index + currentX * pixelsPerStep * 2], loadmasks[maskIdx]);
+				sum[offsetR] = _mm256_add_epi32(sum[offsetR], _mm256_and_si256(_mm256_srli_si256(vec8, offsetR), colorByteMask));
+				sum[offsetG] = _mm256_add_epi32(sum[offsetG], _mm256_and_si256(_mm256_srli_si256(vec8, offsetG), colorByteMask));
+				sum[offsetB] = _mm256_add_epi32(sum[offsetB], _mm256_and_si256(_mm256_srli_si256(vec8, offsetB), colorByteMask));
+			}
+			index += pitch;
+		}
+		const __m256i horizontalSum256 = _mm256_hadd_epi32(_mm256_hadd_epi32(sum[0], sum[1]) , _mm256_hadd_epi32(sum[2], sum[3]));
+		const __m128i horizontalSum128 = _mm_add_epi32(_mm256_extracti128_si256(horizontalSum256, 0), _mm256_extracti128_si256(horizontalSum256, 1));
+		const size_t count = rect.height() * rect.width();
+		ColorValue color;
+		color.r = (_mm_extract_epi32(horizontalSum128, offsetR) / count) & 0xff;
+		color.g = (_mm_extract_epi32(horizontalSum128, offsetG) / count) & 0xff;
+		color.b = (_mm_extract_epi32(horizontalSum128, offsetB) / count) & 0xff;
+		return color;
+	};
+
+// https://software.intel.com/en-us/articles/how-to-detect-new-instruction-support-in-the-4th-generation-intel-core-processor-family
+#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 1300)
+static bool avx2_available() {
+	return _may_i_use_cpu_feature(_FEATURE_AVX2) != 0;
+}
+#else /* non-Intel compiler */
+#if defined(_MSC_VER)
+# include <intrin.h>
+#endif
+static bool avx2_available() {
+	uint32_t abcd[4] = {0,0,0,0};
+	uint32_t eax = 0x07;
+	uint32_t ecx = 0x00;
+#if defined(_MSC_VER)
+	__cpuidex(abcd, eax, ecx);
+#else
+	uint32_t ebx = 0;
+	uint32_t edx = 0;
+# if defined( __i386__ ) && defined ( __PIC__ )
+	 /* in case of PIC under 32-bit EBX cannot be clobbered */
+	__asm__ ( "movl %%ebx, %%edi \n\t cpuid \n\t xchgl %%ebx, %%edi" : "=D" (ebx),
+# else
+	__asm__ ( "cpuid" : "+b" (ebx),
+# endif
+			  "+a" (eax), "+c" (ecx), "=d" (edx) );
+	abcd[0] = eax; abcd[1] = ebx; abcd[2] = ecx; abcd[3] = edx;
+#endif
+	// CPUID.(EAX=07H, ECX=0H):EBX.AVX2[bit 5]==1
+	return (abcd[1] & (1 << 5)) != 0;
+}
+#endif
+
+/*
+	accumulateBuffer128 requires SSE4.1
+	accumulateBuffer256 requires AVX2
+
+	instruction availability:
+	Steam Hardware & Software Survey (March 2020)
+	SSE4.1   97.88% / +0.69%
+	AVX2     74.19% / +2.73%
+
+	by default set functions to SSE and upgrade to AVX2 when available
+*/
+auto accumulateARGB = accumulateBuffer128<PIXEL_FORMAT_ARGB>;
+auto accumulateABGR = accumulateBuffer128<PIXEL_FORMAT_ABGR>;
+auto accumulateRGBA = accumulateBuffer128<PIXEL_FORMAT_RGBA>;
+auto accumulateBGRA = accumulateBuffer128<PIXEL_FORMAT_BGRA>;
+
+struct avxupgrade {
+	avxupgrade() {
+		if (avx2_available()) {
+			accumulateARGB = accumulateBuffer256<PIXEL_FORMAT_ARGB>;
+			accumulateABGR = accumulateBuffer256<PIXEL_FORMAT_ABGR>;
+			accumulateRGBA = accumulateBuffer256<PIXEL_FORMAT_RGBA>;
+			accumulateBGRA = accumulateBuffer256<PIXEL_FORMAT_BGRA>;
+		}
 	}
+};
+avxupgrade avxup;
 } // namespace
 
 namespace Grab {
 	namespace Calculations {
-		QRgb calculateAvgColor(QRgb *result, const unsigned char *buffer, BufferFormat bufferFormat, const size_t pitch, const QRect &rect) {
+		QRgb calculateAvgColor(const unsigned char * const buffer, BufferFormat bufferFormat, const size_t pitch, const QRect &rect) {
 
 			Q_ASSERT_X(rect.width() % pixelsPerStep == 0, "average color calculation", "rect width should be aligned by 4 bytes");
 
-			unsigned int count = 0; // count the amount of pixels taken into account
-			ColorValue color = {0, 0, 0};
-
+			ColorValue color;
 			switch(bufferFormat) {
 			case BufferFormatArgb:
-				count = accumulateBuffer<PIXEL_FORMAT_ARGB>(buffer, pitch, rect, &color);
+				color = accumulateARGB((int*)buffer, pitch / bytesPerPixel, rect);
 				break;
 
 			case BufferFormatAbgr:
-				count = accumulateBuffer<PIXEL_FORMAT_ABGR>(buffer, pitch, rect, &color);
+				color = accumulateABGR((int*)buffer, pitch / bytesPerPixel, rect);
 				break;
 
 			case BufferFormatRgba:
-				count = accumulateBuffer<PIXEL_FORMAT_RGBA>(buffer, pitch, rect, &color);
+				color = accumulateRGBA((int*)buffer, pitch / bytesPerPixel, rect);
 				break;
 
 			case BufferFormatBgra:
-				count = accumulateBuffer<PIXEL_FORMAT_BGRA>(buffer, pitch, rect, &color);
+				color = accumulateBGRA((int*)buffer, pitch / bytesPerPixel, rect);
 				break;
 			default:
 				return -1;
 				break;
 			}
 
-			if ( count > 1 ) {
-				color.r = (color.r / count) & 0xff;
-				color.g = (color.g / count) & 0xff;
-				color.b = (color.b / count) & 0xff;
-			}
-
-			*result = qRgb(color.r, color.g, color.b);
-			return *result;
-		}
-
-		QRgb calculateAvgColor(QList<QRgb> *colors) {
-			int r=0, g=0, b=0;
-			const int size = colors->size();
-			for(int i=0; i < size; i++) {
-				const QRgb rgb = colors->at(i);
-				r += qRed(rgb);
-				g += qGreen(rgb);
-				b += qBlue(rgb);
-			}
-			r = r / size;
-			g = g / size;
-			b = b / size;
-			return qRgb(r, g, b);
+			return qRgb(color.r, color.g, color.b);
 		}
 	}
 }

--- a/Software/grab/calculations.cpp
+++ b/Software/grab/calculations.cpp
@@ -189,7 +189,7 @@ static uint32_t available_simd() {
 void run_cpuid(uint32_t eax, uint32_t ecx, uint32_t* abcd)
 {
 #if defined(_MSC_VER)
-    __cpuidex(abcd, eax, ecx);
+    __cpuidex((int*)abcd, eax, ecx);
 #else
     uint32_t ebx = 0;
     uint32_t edx = 0;

--- a/Software/grab/grab.pro
+++ b/Software/grab/grab.pro
@@ -129,6 +129,22 @@ macx {
     #        -framework CoreGraphics
     #        -framework CoreFoundation
     #QMAKE_MAC_SDK = macosx10.8
+
+    QMAKE_CFLAGS += -mavx2
+    QMAKE_CFLAGS_RELEASE -= -O2
+    QMAKE_CFLAGS_RELEASE += -O3
+    QMAKE_CXXFLAGS += -mavx2
+    QMAKE_CXXFLAGS_RELEASE -= -O2
+    QMAKE_CXXFLAGS_RELEASE += -O3
+}
+
+unix:!macx {
+    QMAKE_CFLAGS += -mavx2
+    QMAKE_CFLAGS_RELEASE -= -O2
+    QMAKE_CFLAGS_RELEASE += -O3
+    QMAKE_CXXFLAGS += -mavx2
+    QMAKE_CXXFLAGS_RELEASE -= -O2
+    QMAKE_CXXFLAGS_RELEASE += -O3
 }
 
 OTHER_FILES += \

--- a/Software/grab/grab.pro
+++ b/Software/grab/grab.pro
@@ -23,9 +23,9 @@ INCLUDEPATH += ./include \
                ../math/include \
                ..
 
-CONFIG(gcc):QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 CONFIG(clang) {
-    QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++
+    QMAKE_CXXFLAGS += -stdlib=libc++
     LIBS += -stdlib=libc++
 }
 

--- a/Software/grab/include/calculations.hpp
+++ b/Software/grab/include/calculations.hpp
@@ -32,8 +32,6 @@
 
 namespace Grab {
 	namespace Calculations {
-
-		QRgb calculateAvgColor(QRgb *result, const unsigned char *buffer, BufferFormat bufferFormat, const size_t pitch, const QRect &rect );
-		QRgb calculateAvgColor(QList<QRgb> *colors);
+		QRgb calculateAvgColor(const unsigned char * const buffer, BufferFormat bufferFormat, const size_t pitch, const QRect &rect);
 	}
 }

--- a/Software/tests/GrabCalculationTest.cpp
+++ b/Software/tests/GrabCalculationTest.cpp
@@ -2,8 +2,8 @@
 
 void GrabCalculationTest::testCase1()
 {
-	QRgb result;
 	unsigned char buf[16];
 	memset(buf, 0xfa, 16);
-	QVERIFY2(Grab::Calculations::calculateAvgColor(&result, buf, BufferFormatArgb, 16, QRect(0,0,4,1)) == QColor(0xfa, 0xfa, 0xfa).rgb(), qPrintable(QString("Failure. calculateAvgColor returned wrong errorcode %1").arg(result, 1, 16)));
+	QRgb result = Grab::Calculations::calculateAvgColor(buf, BufferFormatArgb, 16, QRect(0,0,4,1));
+	QVERIFY2(result == QColor(0xfa, 0xfa, 0xfa).rgb(), qPrintable(QString("Failure. calculateAvgColor returned wrong errorcode %1").arg(result, 1, 16)));
 }


### PR DESCRIPTION
a more efficient way for doing color averaging with better vectorisation

by default this uses SSE4.1 (4 pixel steps), and when available upgrades to AVX2 (8 pixel steps)
this is relatively old tech, and if [Steam Hardware survey](https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam) is to believe their availability is decent (98 and 74% respectively) and growing

since the linux version captures at full scale I used it as the main test platform:
 - in isolated microbenching AVX2 was almost twice as fast as the old method, SSE a close second
 - in Prismatik, depending on profile/build the decrease in CPU usage was around 10-35% (and at the same time with higher reported FPS when grab interval was set to 1ms)
 - in my case clang gave the best results, closely followed by gcc9, gcc7 was slightly worse

I bumped grab build to `-O3` and added `-march=native` to general defaults (commented out)
`-mavx2` flag also covers SSE so I didn't bother with `-msse4.1` (compilers were ok with it)

tested with
 - gcc7, gcc9, clang10, clang11, vs2019
 - Haswell i5, Ryzen 1700
 - win10, macos, ubuntu

seems to be portable


...and some cleaning / warning fixes in the area

on a related note: you think we can bump C++ to 14 or 17? or you have reasons to keep it at 11?