### PR TITLE
x11 grabber tweak

### DIFF
--- a/Software/grab/X11Grabber.cpp
+++ b/Software/grab/X11Grabber.cpp
@@ -134,6 +134,7 @@ bool X11Grabber::reallocate(const QList<ScreenInfo> &screens)
         d->shminfo.readOnly = False;
 
         XShmAttach(_display, &d->shminfo);
+        XSync(_display, False);
 
         GrabbedScreen grabScreen;
         grabScreen.imgData = (unsigned char *)mem;

--- a/Software/grab/X11Grabber.cpp
+++ b/Software/grab/X11Grabber.cpp
@@ -157,7 +157,7 @@ GrabResult X11Grabber::grabScreens()
                      reinterpret_cast<X11GrabberData *>(_screensWithWidgets[i].associatedData)->image,
                      0,
                      0,
-                     0x00FFFFFF
+                     AllPlanes
                      );
     }
 #if 0


### PR DESCRIPTION
this one, I don't know...
while looking around for x11/sync related issues I saw several screen capture samples and they all had these:
- `AllPlanes` instead of a custom `0x00ffffff` mask
- call to `XSync` right after `XShmAttach`

for example in Chromium
https://chromium.googlesource.com/chromium/src/media/+/41a1dc24d5c38474a287a05ab0a8296c71a1cce3/video/capture/screen/x11/x_server_pixel_buffer.cc#138
and
https://chromium.googlesource.com/chromium/src/media/+/41a1dc24d5c38474a287a05ab0a8296c71a1cce3/video/capture/screen/x11/x_server_pixel_buffer.cc#209

So I assume this is _da wae_ to do it. (the documentation leaves a lot to be desired)
Now, this does not fix the weird capture thing from #320 and #325 , but on my VM this hugely reduces Xorg CPU usage (Prismatik unchanged): 10ms grab, 25% -> 15%.
Unfortunately #320 reported unchanged usage on his bare metal setup, but also no ill effects.