### PR TITLE
widget wizard improvement

### DIFF
--- a/Software/src/wizard/CustomDistributor.hpp
+++ b/Software/src/wizard/CustomDistributor.hpp
@@ -33,8 +33,10 @@ class CustomDistributor : public AreaDistributor
 public:
 	CustomDistributor(QRect screen, int top, int side, int bottom, double thickness = 0.15, double standWidth = 0.0) :
 		AreaDistributor(screen, top + 2 * side + bottom),
-		_topLeds(top), _sideLeds(side), _bottomLeds(bottom), _thickness(thickness), _standWidth(bottom % 2 == 0 ? standWidth : 0.0),
-		_dx(0), _dy(0)
+		_dx(0), _dy(0), _sizeBudget(0),
+		_topLeds(top), _sideLeds(side), _bottomLeds(bottom),
+		_thickness(thickness), _standWidth(standWidth)
+
 	{}
 	virtual ~CustomDistributor();
 
@@ -42,6 +44,7 @@ public:
 
 protected:
 	char _dx, _dy;
+	uint8_t _sizeBudget;
 	int _width, _height;
 	int _x, _y;
 	int _topLeds, _sideLeds, _bottomLeds;

--- a/Software/src/wizard/ZonePlacementPage.cpp
+++ b/Software/src/wizard/ZonePlacementPage.cpp
@@ -65,7 +65,7 @@ void ZonePlacementPage::initializePage()
 
 	device()->setSmoothSlowdown(70);
 
-	_ui->sbNumberOfLeds->setMaximum(device()->maxLedsCount()); 
+	_ui->sbNumberOfLeds->setMaximum(device()->maxLedsCount());
 
 	if (_isInitFromSettings) {
 		int ledCount = Settings::getNumberOfLeds(Settings::getConnectedDevice());
@@ -165,59 +165,72 @@ void ZonePlacementPage::removeLastGrabArea()
 void ZonePlacementPage::on_pbAndromeda_clicked()
 {
 	QRect screen = QGuiApplication::screens().value(_screenId, QGuiApplication::primaryScreen())->geometry();
-	double a = (double)screen.width() / screen.height();
-	int sideLeds = PrismatikMath::round(_ui->sbNumberOfLeds->value() / (2 + 2 * a));
+	const int bottomWidth = screen.width() * (1.0 - STAND_WIDTH);
+	const int perimiter = screen.width() + screen.height() * 2 + bottomWidth;
+	const int ledSize = perimiter / _ui->sbNumberOfLeds->value();
 
-	int baseCount = (PrismatikMath::round(_ui->sbNumberOfLeds->value() - 2 * sideLeds)) / 2;
-	int rawCount = PrismatikMath::round(baseCount * (1 - STAND_WIDTH));
-	// we need symmetric bottom
-	int bottomLeds = rawCount + rawCount % 2;
-
+	const int topLeds = screen.width() / ledSize;
+	const int sideLeds = screen.height() / ledSize;
+	const int bottomLeds = _ui->sbNumberOfLeds->value() - topLeds - sideLeds * 2;
 	CustomDistributor *custom = new CustomDistributor(
 		screen,
-		_ui->sbNumberOfLeds->value() - 2 * sideLeds - bottomLeds,
+		topLeds,
 		sideLeds,
 		bottomLeds,
 		THICKNESS,
-		0.5);
+		STAND_WIDTH);
 
 	distributeAreas(custom);
-
+	_ui->sbTopLeds->setValue(topLeds);
+	_ui->sbSideLeds->setValue(sideLeds);
+	_ui->sbBottomLeds->setValue(bottomLeds);
+	_ui->sbThickness->setValue(THICKNESS * 100);
+	_ui->sbStandWidth->setValue(STAND_WIDTH * 100);
 	delete custom;
 }
 
 void ZonePlacementPage::on_pbCassiopeia_clicked()
 {
 	QRect screen = QGuiApplication::screens().value(_screenId, QGuiApplication::primaryScreen())->geometry();
-	double a = (double)screen.width() / screen.height();
-	int sideLeds = PrismatikMath::round(_ui->sbNumberOfLeds->value() / (2 + a));
-
+	const int perimiter = screen.width() + screen.height() * 2;
+	const int ledSize = perimiter / _ui->sbNumberOfLeds->value();
+	const int sideLeds = screen.height() / ledSize;
+	const int topLeds = _ui->sbNumberOfLeds->value() - sideLeds * 2;
 	CustomDistributor *custom = new CustomDistributor(
 		screen,
-		_ui->sbNumberOfLeds->value() - 2 * sideLeds,
+		topLeds,
 		sideLeds,
 		0,
 		THICKNESS,
 		STAND_WIDTH);
 
 	distributeAreas(custom);
-
+	_ui->sbTopLeds->setValue(topLeds);
+	_ui->sbSideLeds->setValue(sideLeds);
+	_ui->sbBottomLeds->setValue(0);
+	_ui->sbThickness->setValue(THICKNESS * 100);
+	_ui->sbStandWidth->setValue(STAND_WIDTH * 100);
 	delete custom;
 }
 
 void ZonePlacementPage::on_pbPegasus_clicked()
 {
 	QRect screen = QGuiApplication::screens().value(_screenId, QGuiApplication::primaryScreen())->geometry();
+	const int sideLeds = _ui->sbNumberOfLeds->value() / 2;
 	CustomDistributor *custom = new CustomDistributor(
 		screen,
 		0,
-		_ui->sbNumberOfLeds->value() / 2,
+		sideLeds,
 		0,
 		THICKNESS,
 		STAND_WIDTH);
 
 	distributeAreas(custom);
-
+	_ui->sbTopLeds->setValue(0);
+	_ui->sbSideLeds->setValue(sideLeds);
+	_ui->sbBottomLeds->setValue(0);
+	_ui->sbThickness->setValue(THICKNESS * 100);
+	_ui->sbStandWidth->setValue(STAND_WIDTH * 100);
 	delete custom;
 }
 
@@ -227,10 +240,10 @@ void ZonePlacementPage::on_pbCustom_clicked()
 	QRect screen = QGuiApplication::screens().value(_screenId, QGuiApplication::primaryScreen())->geometry();
 	CustomDistributor *custom = new CustomDistributor(
 		screen,
-		_ui->sbTopLeds->value(), 
+		_ui->sbTopLeds->value(),
 		_ui->sbSideLeds->value(),
 		_ui->sbBottomLeds->value(),
-		_ui->sbThickness->value() / 100.0, 
+		_ui->sbThickness->value() / 100.0,
 		_ui->sbStandWidth->value() / 100.0);
 
 	distributeAreas(custom, _ui->cbInvertOrder->isChecked(), _ui->sbNumberingOffset->value());
@@ -264,4 +277,3 @@ void ZonePlacementPage::on_numberOfLeds_valueChanged(int numOfLed)
 
 	_transSettings->ledCount = numOfLed;
 }
-

--- a/Software/src/wizard/ZonePlacementPage.cpp
+++ b/Software/src/wizard/ZonePlacementPage.cpp
@@ -169,9 +169,9 @@ void ZonePlacementPage::on_pbAndromeda_clicked()
 	const int perimiter = screen.width() + screen.height() * 2 + bottomWidth;
 	const int ledSize = perimiter / _ui->sbNumberOfLeds->value();
 
-	const int topLeds = screen.width() / ledSize;
+	const int bottomLeds = ((bottomWidth / ledSize) + 1) & ~1;//round up / down to next even number
 	const int sideLeds = screen.height() / ledSize;
-	const int bottomLeds = _ui->sbNumberOfLeds->value() - topLeds - sideLeds * 2;
+	const int topLeds = _ui->sbNumberOfLeds->value() - bottomLeds - sideLeds * 2;
 	CustomDistributor *custom = new CustomDistributor(
 		screen,
 		topLeds,

--- a/Software/src/wizard/ZonePlacementPage.cpp
+++ b/Software/src/wizard/ZonePlacementPage.cpp
@@ -166,8 +166,8 @@ void ZonePlacementPage::on_pbAndromeda_clicked()
 {
 	QRect screen = QGuiApplication::screens().value(_screenId, QGuiApplication::primaryScreen())->geometry();
 	const int bottomWidth = screen.width() * (1.0 - STAND_WIDTH);
-	const int perimiter = screen.width() + screen.height() * 2 + bottomWidth;
-	const int ledSize = perimiter / _ui->sbNumberOfLeds->value();
+	const int perimeter = screen.width() + screen.height() * 2 + bottomWidth;
+	const int ledSize = perimeter / _ui->sbNumberOfLeds->value();
 
 	const int bottomLeds = ((bottomWidth / ledSize) + 1) & ~1;//round up / down to next even number
 	const int sideLeds = screen.height() / ledSize;
@@ -192,8 +192,8 @@ void ZonePlacementPage::on_pbAndromeda_clicked()
 void ZonePlacementPage::on_pbCassiopeia_clicked()
 {
 	QRect screen = QGuiApplication::screens().value(_screenId, QGuiApplication::primaryScreen())->geometry();
-	const int perimiter = screen.width() + screen.height() * 2;
-	const int ledSize = perimiter / _ui->sbNumberOfLeds->value();
+	const int perimeter = screen.width() + screen.height() * 2;
+	const int ledSize = perimeter / _ui->sbNumberOfLeds->value();
 	const int sideLeds = screen.height() / ledSize;
 	const int topLeds = _ui->sbNumberOfLeds->value() - sideLeds * 2;
 	CustomDistributor *custom = new CustomDistributor(


### PR DESCRIPTION
The objective here is to make widgets more even:
- when a side isn't a multiple of LEDs, the leftover space was put into the middle LED, making it (sometimes considerably) larger than the others, so I took that space and redistributed it between middle widgets (1px per)
- the presets (Andromeda etc) can have big differences in sizes between horizontal and vertical LEDs, I made them closer
- Andromeda is using `STAND_WIDTH` (`0.33`) for math and then passes `0.5` to the distributor, changed that
- presets are now updating "custom" fields
- custom config is not using the "stand width" value with odd bottom number

_Andromeda before / after_
![andromeda](https://user-images.githubusercontent.com/239811/81508449-79c00100-9304-11ea-94bd-c82364afd0c7.PNG)
![andromeda_new](https://user-images.githubusercontent.com/239811/81510246-ad088d00-9310-11ea-98d3-fab79d0e5a46.PNG)

_Cassiopeia before / after_
![cassiopeia](https://user-images.githubusercontent.com/239811/81508475-a116ce00-9304-11ea-941a-4d5aae0b8460.PNG)
![cassiopeia_new](https://user-images.githubusercontent.com/239811/81508477-a247fb00-9304-11ea-9a05-418c244cb91e.PNG)

_Pegasus before / after_
![pegasus](https://user-images.githubusercontent.com/239811/81508503-b855bb80-9304-11ea-9c16-ad7b279e0575.PNG)
![pegasus_new](https://user-images.githubusercontent.com/239811/81508505-b8ee5200-9304-11ea-8be8-bd1a376e5c48.PNG)

_Custom even bottom before / after_
![custom_even](https://user-images.githubusercontent.com/239811/81508547-fce15700-9304-11ea-8035-180f0d71844e.PNG)
![custom_even_new](https://user-images.githubusercontent.com/239811/81508548-fd79ed80-9304-11ea-9cc0-2066f092a77d.PNG)

_Custom odd bottom before / after_
![custom_odd](https://user-images.githubusercontent.com/239811/81508592-3ade7b00-9305-11ea-8941-9543401a71ed.PNG)
![custom_odd_new](https://user-images.githubusercontent.com/239811/81508594-3b771180-9305-11ea-8e9e-06fc2e9b123f.PNG)
