### PR TITLE
grabberbase: don't trim preparedRect width to multiple of 4

### DIFF
--- a/Software/grab/GrabberBase.cpp
+++ b/Software/grab/GrabberBase.cpp
@@ -206,10 +206,6 @@ void GrabberBase::grab()
 					std::floor(grabbedScreen->scale * preparedRect.bottom())
 				);
 
-			// Align width by 4 for accelerated calculations
-			preparedRect.setWidth(preparedRect.width() - (preparedRect.width() % 4));
-
-
 			if( !preparedRect.isValid() ){
 				qWarning() << Q_FUNC_INFO << " preparedRect is not valid:" << Debug::toString(preparedRect);
 				// width and height can't be negative

--- a/Software/grab/calculations.cpp
+++ b/Software/grab/calculations.cpp
@@ -348,7 +348,6 @@ namespace Grab {
 	namespace Calculations {
 		QRgb calculateAvgColor(const unsigned char * const buffer, BufferFormat bufferFormat, const size_t pitch, const QRect &rect) {
 
-			Q_ASSERT_X(rect.width() % pixelsPerStep == 0, "average color calculation", "rect width should be aligned by 4 bytes");
 			ColorValue color;
 			switch(bufferFormat) {
 			case BufferFormatArgb:


### PR DESCRIPTION
fixes #319, the SIMD PR allows this with low cost

"summer teeth" before
![brol_3_col](https://user-images.githubusercontent.com/239811/82695134-d4425100-9c64-11ea-8132-fc891a59ad98.png)
![brol_3_og](https://user-images.githubusercontent.com/239811/82695139-d5737e00-9c64-11ea-8b51-d5963ab5c14d.png)
![brol_5_col](https://user-images.githubusercontent.com/239811/82695141-d60c1480-9c64-11ea-9dd3-32bee52de993.png)
![brol_5_og](https://user-images.githubusercontent.com/239811/82695143-d60c1480-9c64-11ea-9519-811a8cf44f54.png)

after
![brol_3_col](https://user-images.githubusercontent.com/239811/82695412-5468b680-9c65-11ea-832f-e9ce97fb88c7.png)
![brol_3_og](https://user-images.githubusercontent.com/239811/82695413-55014d00-9c65-11ea-8c82-15c41c70b702.png)
![brol_7_col](https://user-images.githubusercontent.com/239811/82695414-55014d00-9c65-11ea-8bfb-ab74dba5411b.png)
![brol_7_og](https://user-images.githubusercontent.com/239811/82695416-55014d00-9c65-11ea-9182-de4dfe8409a5.png)

actually in this particular configuration there are no skipped LEDs, but that's what happens with denser setups