### PR TITLE
Reload the gamma ramp every 15 seconds to slow memory leak

### DIFF
--- a/Software/grab/include/WinUtils.hpp
+++ b/Software/grab/include/WinUtils.hpp
@@ -89,6 +89,7 @@ VOID FreeRestrictedSD(PVOID ptr);
 		void apply(QList<QRgb>& colors, const double/*gamma*/);
 		static bool isSupported();
 	private:
+		time_t _gammaAge = 0;
 		WORD _gammaArray[3][256];
 		static bool loadGamma(LPVOID gamma, HDC* dc);
 	};


### PR DESCRIPTION
"fixes" #277, #308