### PR TITLE
brightness/power limit

### DIFF
--- a/Software/src/AbstractLedDevice.cpp
+++ b/Software/src/AbstractLedDevice.cpp
@@ -47,6 +47,18 @@ void AbstractLedDevice::setBrightnessCap(int value, bool updateColors) {
 		setColors(m_colorsSaved);
 }
 
+void AbstractLedDevice::setLedMilliAmps(const int value, const bool updateColors) {
+	m_ledMilliAmps = value;
+	if (updateColors)
+		setColors(m_colorsSaved);
+}
+
+void AbstractLedDevice::setPowerSupplyAmps(const double value, const bool updateColors) {
+	m_powerSupplyAmps = value;
+	if (updateColors)
+		setColors(m_colorsSaved);
+}
+
 void AbstractLedDevice::setLuminosityThreshold(int value, bool updateColors) {
 	m_luminosityThreshold = value;
 	if (updateColors)
@@ -90,12 +102,12 @@ void AbstractLedDevice::updateDeviceSettings()
 */
 void AbstractLedDevice::applyColorModifications(const QList<QRgb> &inColors, QList<StructRgb> &outColors) {
 
-	bool isApplyWBAdjustments = m_wbAdjustments.count() == inColors.count();
+	const bool isApplyWBAdjustments = m_wbAdjustments.count() == inColors.count();
 
 	for(int i = 0; i < inColors.count(); i++) {
 
 		//renormalize to 12bit
-		double k = 4095/255.0;
+		const constexpr double k = 4095/255.0;
 		outColors[i].r = qRed(inColors[i]) * k;
 		outColors[i].g = qGreen(inColors[i]) * k;
 		outColors[i].b = qBlue(inColors[i]) * k;
@@ -103,22 +115,25 @@ void AbstractLedDevice::applyColorModifications(const QList<QRgb> &inColors, QLi
 		PrismatikMath::gammaCorrection(m_gamma, outColors[i]);
 	}
 
-	StructLab avgColor = PrismatikMath::toLab(PrismatikMath::avgColor(outColors));
+	const StructLab avgColor = PrismatikMath::toLab(PrismatikMath::avgColor(outColors));
+
+	const double ampCoef = m_ledMilliAmps / (4095.0 * 3.0) / 1000.0;
+	double estimatedTotalAmps = 0.0;
 
 	for (int i = 0; i < outColors.count(); ++i) {
 		StructLab lab = PrismatikMath::toLab(outColors[i]);
-		int dl = m_luminosityThreshold - lab.l;
+		const int dl = m_luminosityThreshold - lab.l;
 		if (dl > 0) {
 			if (m_isMinimumLuminosityEnabled) { // apply minimum luminosity or dead-zone
 				// Cross-fade a and b channels to avarage value within kFadingRange, fadingFactor = (dL - fadingRange)^2 / (fadingRange^2)
-				const int kFadingRange = 5;
-				double fadingCoeff = dl < kFadingRange ? (dl - kFadingRange)*(dl - kFadingRange)/(kFadingRange*kFadingRange): 1;
-				char da = avgColor.a - lab.a;
-				char db = avgColor.b - lab.b;
+				constexpr int kFadingRange = 5;
+				const double fadingCoeff = dl < kFadingRange ? (dl - kFadingRange)*(dl - kFadingRange)/(kFadingRange*kFadingRange): 1;
+				const char da = avgColor.a - lab.a;
+				const char db = avgColor.b - lab.b;
 				lab.l = m_luminosityThreshold;
 				lab.a += PrismatikMath::round(da * fadingCoeff);
 				lab.b += PrismatikMath::round(db * fadingCoeff);
-				StructRgb rgb = PrismatikMath::toRgb(lab);
+				const StructRgb rgb = PrismatikMath::toRgb(lab);
 				outColors[i] = rgb;
 			} else {
 				outColors[i].r = 0;
@@ -135,12 +150,23 @@ void AbstractLedDevice::applyColorModifications(const QList<QRgb> &inColors, QLi
 			outColors[i].b *= m_wbAdjustments[i].blue;
 		}
 		if (m_brightnessCap < SettingsScope::Profile::Device::BrightnessCapMax) {
-			const double bcapFactor = (40.95 * 3 * m_brightnessCap) / (outColors[i].r + outColors[i].g + outColors[i].b);
+			const double bcapFactor = (m_brightnessCap / 100.0 * 4095 * 3) / (outColors[i].r + outColors[i].g + outColors[i].b);
 			if (bcapFactor < 1.0) {
 				outColors[i].r *= bcapFactor;
 				outColors[i].g *= bcapFactor;
 				outColors[i].b *= bcapFactor;
 			}
+		}
+
+		estimatedTotalAmps += ((double)outColors[i].r + (double)outColors[i].g + (double)outColors[i].b) * ampCoef;
+	}
+
+	if (m_powerSupplyAmps > 0.0 && m_powerSupplyAmps < estimatedTotalAmps) {
+		const double powerRatio = m_powerSupplyAmps / estimatedTotalAmps;
+		for (StructRgb& color : outColors) {
+			color.r *= powerRatio;
+			color.g *= powerRatio;
+			color.b *= powerRatio;
 		}
 	}
 }

--- a/Software/src/AbstractLedDevice.hpp
+++ b/Software/src/AbstractLedDevice.hpp
@@ -71,6 +71,7 @@ public slots:
 	virtual void setSmoothSlowdown(int value) = 0;
 	virtual void setGamma(double value, bool updateColors = true);
 	virtual void setBrightness(int value, bool updateColors = true);
+	virtual void setBrightnessCap(int value, bool updateColors = true);
 	virtual void setColorSequence(QString value) = 0;
 	virtual void setLuminosityThreshold(int value, bool updateColors = true);
 	virtual void setMinimumLuminosityThresholdEnabled(bool value, bool updateColors = true);
@@ -98,6 +99,7 @@ protected:
 	QString m_colorSequence;
 	double m_gamma;
 	int m_brightness;
+	int m_brightnessCap;
 	int m_luminosityThreshold;
 	bool m_isMinimumLuminosityEnabled;
 

--- a/Software/src/AbstractLedDevice.hpp
+++ b/Software/src/AbstractLedDevice.hpp
@@ -72,6 +72,8 @@ public slots:
 	virtual void setGamma(double value, bool updateColors = true);
 	virtual void setBrightness(int value, bool updateColors = true);
 	virtual void setBrightnessCap(int value, bool updateColors = true);
+	virtual void setLedMilliAmps(const int value, const bool updateColors = true);
+	virtual void setPowerSupplyAmps(const double value, const bool updateColors = true);
 	virtual void setColorSequence(QString value) = 0;
 	virtual void setLuminosityThreshold(int value, bool updateColors = true);
 	virtual void setMinimumLuminosityThresholdEnabled(bool value, bool updateColors = true);
@@ -100,6 +102,8 @@ protected:
 	double m_gamma;
 	int m_brightness;
 	int m_brightnessCap;
+	int m_ledMilliAmps{0};
+	double m_powerSupplyAmps{0.0};
 	int m_luminosityThreshold;
 	bool m_isMinimumLuminosityEnabled;
 

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -634,7 +634,7 @@ void LedDeviceManager::cmdQueueProcessNext()
 
 		case LedDeviceCommands::SetBrightnessCap:
 			m_cmdTimeoutTimer->start();
-			emit ledDeviceSetBrightness(m_savedBrightness);
+			emit ledDeviceSetBrightnessCap(m_savedBrightnessCap);
 			break;
 
 		case LedDeviceCommands::SetColorSequence:

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -450,54 +450,62 @@ AbstractLedDevice * LedDeviceManager::createLedDevice(SupportedDevices::DeviceTy
 #		endif /* Q_OS_WIN */
 	}
 
+	AbstractLedDevice* device = nullptr;
+
 	switch (deviceType){
 
 	case SupportedDevices::DeviceTypeLightpack:
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "SupportedDevices::LightpackDevice";
-		return (AbstractLedDevice *)new LedDeviceLightpack();
+		device = (AbstractLedDevice *)new LedDeviceLightpack();
 
 	case SupportedDevices::DeviceTypeAlienFx:
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "SupportedDevices::AlienFxDevice";
 
 #		ifdef Q_OS_WIN
-		return (AbstractLedDevice *)new LedDeviceAlienFx();
+		device = (AbstractLedDevice *)new LedDeviceAlienFx();
 #		else
 		break;
 #		endif /* Q_OS_WIN */
 
 	case SupportedDevices::DeviceTypeAdalight:
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "SupportedDevices::AdalightDevice";
-		return (AbstractLedDevice *)new LedDeviceAdalight(Settings::getAdalightSerialPortName(), Settings::getAdalightSerialPortBaudRate());
+		device = (AbstractLedDevice *)new LedDeviceAdalight(Settings::getAdalightSerialPortName(), Settings::getAdalightSerialPortBaudRate());
 
 	case SupportedDevices::DeviceTypeArdulight:
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "SupportedDevices::ArdulightDevice";
-		return (AbstractLedDevice *)new LedDeviceArdulight(Settings::getArdulightSerialPortName(), Settings::getArdulightSerialPortBaudRate());
+		device = (AbstractLedDevice *)new LedDeviceArdulight(Settings::getArdulightSerialPortName(), Settings::getArdulightSerialPortBaudRate());
 
 	case SupportedDevices::DeviceTypeDrgb:
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "SupportedDevices::DrgbDevice";
-		return (AbstractLedDevice*)new LedDeviceDrgb(Settings::getDrgbAddress(), Settings::getDrgbPort(), Settings::getDrgbTimeout());
+		device = (AbstractLedDevice*)new LedDeviceDrgb(Settings::getDrgbAddress(), Settings::getDrgbPort(), Settings::getDrgbTimeout());
 
 	case SupportedDevices::DeviceTypeDnrgb:
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "SupportedDevices::DnrgbDevice";
-		return (AbstractLedDevice*)new LedDeviceDnrgb(Settings::getDnrgbAddress(), Settings::getDnrgbPort(), Settings::getDnrgbTimeout());
+		device = (AbstractLedDevice*)new LedDeviceDnrgb(Settings::getDnrgbAddress(), Settings::getDnrgbPort(), Settings::getDnrgbTimeout());
 
 	case SupportedDevices::DeviceTypeWarls:
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "SupportedDevices::WarlsDevice";
-		return (AbstractLedDevice*)new LedDeviceWarls(Settings::getWarlsAddress(), Settings::getWarlsPort(), Settings::getWarlsTimeout());
+		device = (AbstractLedDevice*)new LedDeviceWarls(Settings::getWarlsAddress(), Settings::getWarlsPort(), Settings::getWarlsTimeout());
 
 	case SupportedDevices::DeviceTypeVirtual:
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "SupportedDevices::VirtualDevice";
-		return (AbstractLedDevice *)new LedDeviceVirtual();
+		device = (AbstractLedDevice *)new LedDeviceVirtual();
 
 	default:
 		break;
+	}
+
+	if (device) {
+		device->setLedMilliAmps(Settings::getDeviceLedMilliAmps(deviceType));
+		device->setPowerSupplyAmps(Settings::getDevicePowerSupplyAmps(deviceType));
+		return device;
 	}
 
 	qFatal("%s %s%d%s", Q_FUNC_INFO,
 			"Create LedDevice fail. deviceType = '", deviceType,
 			"'. Application exit.");
 
-	return NULL; // Avoid compiler warning
+	return nullptr; // Avoid compiler warning
 }
 
 void LedDeviceManager::connectSignalSlotsLedDevice()

--- a/Software/src/LedDeviceManager.hpp
+++ b/Software/src/LedDeviceManager.hpp
@@ -60,6 +60,7 @@ signals:
 	void ledDeviceSetSmoothSlowdown(int value);
 	void ledDeviceSetGamma(double value);
 	void ledDeviceSetBrightness(int value);
+	void ledDeviceSetBrightnessCap(int value);
 	void ledDeviceSetLuminosityThreshold(int value);
 	void ledDeviceSetMinimumLuminosityEnabled(bool);
 	void ledDeviceSetColorSequence(QString value);
@@ -82,6 +83,7 @@ public slots:
 	void setSmoothSlowdown(int value);
 	void setGamma(double value);
 	void setBrightness(int value);
+	void setBrightnessCap(int value);
 	void setLuminosityThreshold(int value);
 	void setMinimumLuminosityEnabled(bool value);
 	void setColorSequence(QString value);
@@ -119,6 +121,7 @@ private:
 	int m_savedSmoothSlowdown;
 	double m_savedGamma;
 	int m_savedBrightness;
+	int m_savedBrightnessCap;
 	int m_savedLuminosityThreshold;
 	bool m_savedIsMinimumLuminosityEnabled;
 	QString m_savedColorSequence;

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -647,6 +647,7 @@ void LightpackApplication::startLedDeviceManager()
 	connect(settings(), SIGNAL(deviceUsbPowerLedDisabledChanged(bool)), m_ledDeviceManager, SLOT(setUsbPowerLedDisabled(bool)),			Qt::QueuedConnection);
 	connect(settings(), SIGNAL(deviceGammaChanged(double)),				m_ledDeviceManager, SLOT(setGamma(double)),						Qt::QueuedConnection);
 	connect(settings(), SIGNAL(deviceBrightnessChanged(int)),			m_ledDeviceManager, SLOT(setBrightness(int)),					Qt::QueuedConnection);
+	connect(settings(), SIGNAL(deviceBrightnessCapChanged(int)),		m_ledDeviceManager, SLOT(setBrightnessCap(int)),				Qt::QueuedConnection);
 	connect(settings(), SIGNAL(luminosityThresholdChanged(int)),		m_ledDeviceManager, SLOT(setLuminosityThreshold(int)),			Qt::QueuedConnection);
 	connect(settings(), SIGNAL(minimumLuminosityEnabledChanged(bool)),	m_ledDeviceManager, SLOT(setMinimumLuminosityEnabled(bool)),	Qt::QueuedConnection);
 	connect(settings(), SIGNAL(ledCoefBlueChanged(int,double)),			m_ledDeviceManager, SLOT(updateWBAdjustments()),				Qt::QueuedConnection);
@@ -709,7 +710,7 @@ void LightpackApplication::initGrabManager()
 	else
 		qWarning() << Q_FUNC_INFO << "No compatible Sound Manager";
 #endif
-	
+
 	connect(settings(), SIGNAL(grabberTypeChanged(const Grab::GrabberType &)),	m_grabManager,		SLOT(onGrabberTypeChanged(const Grab::GrabberType &)),	Qt::QueuedConnection);
 	connect(settings(), SIGNAL(grabSlowdownChanged(int)),						m_grabManager,		SLOT(onGrabSlowdownChanged(int)),						Qt::QueuedConnection);
 	connect(settings(), SIGNAL(grabAvgColorsEnabledChanged(bool)),				m_grabManager,		SLOT(onGrabAvgColorsEnabledChanged(bool)),				Qt::QueuedConnection);

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -1253,7 +1253,7 @@ double Settings::getDevicePowerSupplyAmps(const SupportedDevices::DeviceType dev
 	}
 
 	// TODO: validator on maximum number of leds for current 'device'
-	return valueMain(key).toInt();
+	return valueMain(key).toDouble();
 }
 
 void Settings::setColorSequence(SupportedDevices::DeviceType device, QString colorSequence)

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -211,6 +211,7 @@ static const QString RefreshDelay = "Device/RefreshDelay";
 static const QString IsUsbPowerLedDisabled = "Device/IsUsbPowerLedDisabled";
 static const QString Smooth = "Device/Smooth";
 static const QString Brightness = "Device/Brightness";
+static const QString BrightnessCap = "Device/BrightnessCap";
 static const QString ColorDepth = "Device/ColorDepth";
 static const QString Gamma = "Device/Gamma";
 }
@@ -664,7 +665,7 @@ void Settings::setApiKey(const QString & apiKey)
 }
 
 bool Settings::isExpertModeEnabled()
-{	
+{
 	return valueMain(Main::Key::IsExpertModeEnabled).toBool();
 }
 
@@ -1282,6 +1283,18 @@ void Settings::setDeviceBrightness(int value)
 	m_this->deviceBrightnessChanged(value);
 }
 
+int Settings::getDeviceBrightnessCap()
+{
+	return getValidDeviceBrightnessCap(value(Profile::Key::Device::BrightnessCap).toInt());
+}
+
+void Settings::setDeviceBrightnessCap(int value)
+{
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
+	setValue(Profile::Key::Device::BrightnessCap, getValidDeviceBrightnessCap(value));
+	m_this->deviceBrightnessCapChanged(value);
+}
+
 int Settings::getDeviceSmooth()
 {
 	return getValidDeviceSmooth(value(Profile::Key::Device::Smooth).toInt());
@@ -1743,6 +1756,15 @@ int Settings::getValidDeviceBrightness(int value)
 	return value;
 }
 
+int Settings::getValidDeviceBrightnessCap(int value)
+{
+	if (value < Profile::Device::BrightnessCapMin)
+		value = Profile::Device::BrightnessCapMin;
+	else if (value > Profile::Device::BrightnessCapMax)
+		value = Profile::Device::BrightnessCapMax;
+	return value;
+}
+
 int Settings::getValidDeviceSmooth(int value)
 {
 	if (value < Profile::Device::SmoothMin)
@@ -1826,7 +1848,7 @@ void Settings::setValidLedCoef(int ledIndex, const QString & keyCoef, double coe
 					<< keyCoef
 					<< error
 					<< "Convert to double error. Set it to default value" << keyCoef << "=" << Profile::Led::CoefDefault;
-		coef = Profile::Led::CoefDefault;		
+		coef = Profile::Led::CoefDefault;
 	}
 	Settings::setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "/" + keyCoef, coef);
 }
@@ -1928,6 +1950,7 @@ void Settings::initCurrentProfile(bool isResetDefault)
 	setNewOption(Profile::Key::Device::RefreshDelay,				Profile::Device::RefreshDelayDefault, isResetDefault);
 	setNewOption(Profile::Key::Device::IsUsbPowerLedDisabled,		Profile::Device::IsUsbPowerLedDisabled, isResetDefault);
 	setNewOption(Profile::Key::Device::Brightness,					Profile::Device::BrightnessDefault, isResetDefault);
+	setNewOption(Profile::Key::Device::BrightnessCap,				Profile::Device::BrightnessCapDefault, isResetDefault);
 	setNewOption(Profile::Key::Device::Smooth,						Profile::Device::SmoothDefault, isResetDefault);
 	setNewOption(Profile::Key::Device::Gamma,						Profile::Device::GammaDefault, isResetDefault);
 	setNewOption(Profile::Key::Device::ColorDepth,					Profile::Device::ColorDepthDefault, isResetDefault);

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -100,6 +100,8 @@ static const QString NumberOfLeds = "Adalight/NumberOfLeds";
 static const QString ColorSequence = "Adalight/ColorSequence";
 static const QString Port = "Adalight/SerialPort";
 static const QString BaudRate = "Adalight/BaudRate";
+static const QString LedMilliAmps = "Adalight/LedMilliAmps";
+static const QString PowerSupplyAmps = "Adalight/PowerSupplyAmps";
 }
 namespace Ardulight
 {
@@ -107,18 +109,26 @@ static const QString NumberOfLeds = "Ardulight/NumberOfLeds";
 static const QString ColorSequence = "Ardulight/ColorSequence";
 static const QString Port = "Ardulight/SerialPort";
 static const QString BaudRate = "Ardulight/BaudRate";
+static const QString LedMilliAmps = "Ardulight/LedMilliAmps";
+static const QString PowerSupplyAmps = "Ardulight/PowerSupplyAmps";
 }
 namespace AlienFx
 {
 static const QString NumberOfLeds = "AlienFx/NumberOfLeds";
+static const QString LedMilliAmps = "AlienFx/LedMilliAmps";
+static const QString PowerSupplyAmps = "AlienFx/PowerSupplyAmps";
 }
 namespace Lightpack
 {
 static const QString NumberOfLeds = "Lightpack/NumberOfLeds";
+static const QString LedMilliAmps = "Lightpack/LedMilliAmps";
+static const QString PowerSupplyAmps = "Lightpack/PowerSupplyAmps";
 }
 namespace Virtual
 {
 static const QString NumberOfLeds = "Virtual/NumberOfLeds";
+static const QString LedMilliAmps = "Virtual/LedMilliAmps";
+static const QString PowerSupplyAmps = "Virtual/PowerSupplyAmps";
 }
 namespace Drgb
 {
@@ -126,6 +136,8 @@ static const QString NumberOfLeds = "Drgb/NumberOfLeds";
 static const QString Address = "Drgb/Address";
 static const QString Port = "Drgb/Port";
 static const QString Timeout = "Drgb/Timeout";
+static const QString LedMilliAmps = "Drgb/LedMilliAmps";
+static const QString PowerSupplyAmps = "Drgb/PowerSupplyAmps";
 }
 namespace Dnrgb
 {
@@ -133,6 +145,8 @@ static const QString NumberOfLeds = "Dnrgb/NumberOfLeds";
 static const QString Address = "Dnrgb/Address";
 static const QString Port = "Dnrgb/Port";
 static const QString Timeout = "Dnrgb/Timeout";
+static const QString LedMilliAmps = "Dnrgb/LedMilliAmps";
+static const QString PowerSupplyAmps = "Dnrgb/PowerSupplyAmps";
 }
 namespace Warls
 {
@@ -140,6 +154,8 @@ static const QString NumberOfLeds = "Warls/NumberOfLeds";
 static const QString Address = "Warls/Address";
 static const QString Port = "Warls/Port";
 static const QString Timeout = "Warls/Timeout";
+static const QString LedMilliAmps = "Warls/LedMilliAmps";
+static const QString PowerSupplyAmps = "Warls/PowerSupplyAmps";
 }
 } /*Key*/
 
@@ -266,6 +282,8 @@ QString Settings::m_applicationDirPath = "";
 
 QMap<SupportedDevices::DeviceType, QString> Settings::m_devicesTypeToNameMap;
 QMap<SupportedDevices::DeviceType, QString> Settings::m_devicesTypeToKeyNumberOfLedsMap;
+QMap<SupportedDevices::DeviceType, QString> Settings::m_devicesTypeToKeyLedMilliAmpsMap;
+QMap<SupportedDevices::DeviceType, QString> Settings::m_devicesTypeToKeyPowerSupplyAmpsMap;
 
 Settings::Settings() : QObject(NULL) {
 	qRegisterMetaType<Grab::GrabberType>("Grab::GrabberType");
@@ -328,9 +346,27 @@ bool Settings::Initialize( const QString & applicationDirPath, bool isDebugLevel
 	setNewOptionMain(Main::Key::AlienFx::NumberOfLeds,		Main::AlienFx::NumberOfLedsDefault);
 	setNewOptionMain(Main::Key::Lightpack::NumberOfLeds,	Main::Lightpack::NumberOfLedsDefault);
 	setNewOptionMain(Main::Key::Virtual::NumberOfLeds,		Main::Virtual::NumberOfLedsDefault);
-	setNewOptionMain(Main::Key::Drgb::NumberOfLeds,         Main::Drgb::NumberOfLedsDefault);
-	setNewOptionMain(Main::Key::Dnrgb::NumberOfLeds,        Main::Dnrgb::NumberOfLedsDefault);
-	setNewOptionMain(Main::Key::Warls::NumberOfLeds,        Main::Warls::NumberOfLedsDefault);
+	setNewOptionMain(Main::Key::Drgb::NumberOfLeds,			Main::Drgb::NumberOfLedsDefault);
+	setNewOptionMain(Main::Key::Dnrgb::NumberOfLeds,		Main::Dnrgb::NumberOfLedsDefault);
+	setNewOptionMain(Main::Key::Warls::NumberOfLeds,		Main::Warls::NumberOfLedsDefault);
+
+	setNewOptionMain(Main::Key::Adalight::LedMilliAmps,		Main::Device::LedMilliAmpsDefault);
+	setNewOptionMain(Main::Key::Ardulight::LedMilliAmps,	Main::Device::LedMilliAmpsDefault);
+	setNewOptionMain(Main::Key::AlienFx::LedMilliAmps,		Main::Device::LedMilliAmpsDefault);
+	setNewOptionMain(Main::Key::Lightpack::LedMilliAmps,	Main::Device::LedMilliAmpsDefault);
+	setNewOptionMain(Main::Key::Virtual::LedMilliAmps,		Main::Device::LedMilliAmpsDefault);
+	setNewOptionMain(Main::Key::Drgb::LedMilliAmps,			Main::Device::LedMilliAmpsDefault);
+	setNewOptionMain(Main::Key::Dnrgb::LedMilliAmps,		Main::Device::LedMilliAmpsDefault);
+	setNewOptionMain(Main::Key::Warls::LedMilliAmps,		Main::Device::LedMilliAmpsDefault);
+
+	setNewOptionMain(Main::Key::Adalight::PowerSupplyAmps,	Main::Device::PowerSupplyAmpsDefault);
+	setNewOptionMain(Main::Key::Ardulight::PowerSupplyAmps,	Main::Device::PowerSupplyAmpsDefault);
+	setNewOptionMain(Main::Key::AlienFx::PowerSupplyAmps,	Main::Device::PowerSupplyAmpsDefault);
+	setNewOptionMain(Main::Key::Lightpack::PowerSupplyAmps,	Main::Device::PowerSupplyAmpsDefault);
+	setNewOptionMain(Main::Key::Virtual::PowerSupplyAmps,	Main::Device::PowerSupplyAmpsDefault);
+	setNewOptionMain(Main::Key::Drgb::PowerSupplyAmps,		Main::Device::PowerSupplyAmpsDefault);
+	setNewOptionMain(Main::Key::Dnrgb::PowerSupplyAmps,		Main::Device::PowerSupplyAmpsDefault);
+	setNewOptionMain(Main::Key::Warls::PowerSupplyAmps,		Main::Device::PowerSupplyAmpsDefault);
 
 	setNewOptionMain(Main::Key::Drgb::Address,              Main::Drgb::AddressDefault);
 	setNewOptionMain(Main::Key::Drgb::Port,                 Main::Drgb::PortDefault);
@@ -1079,6 +1115,141 @@ int Settings::getNumberOfLeds(SupportedDevices::DeviceType device)
 	{
 		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device;
 		return MaximumNumberOfLeds::Default;
+	}
+
+	// TODO: validator on maximum number of leds for current 'device'
+	return valueMain(key).toInt();
+}
+
+void Settings::setDeviceLedMilliAmps(const SupportedDevices::DeviceType device, const int mAmps)
+{
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
+
+	if(getDeviceLedMilliAmps(device) == mAmps)
+		//nothing to do
+		return;
+
+	const QString& key = m_devicesTypeToKeyLedMilliAmpsMap.value(device);
+
+	if (key == "")
+	{
+		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device << "LedMilliAmps ==" << mAmps;
+		return;
+	}
+
+	setValueMain(key, mAmps);
+	{
+		using namespace SupportedDevices;
+		switch(device) {
+			case DeviceTypeLightpack:
+			m_this->lightpackLedMilliAmpsChanged(mAmps);
+			break;
+
+			case DeviceTypeAdalight:
+			m_this->adalightLedMilliAmpsChanged(mAmps);
+			break;
+
+			case DeviceTypeArdulight:
+			m_this->ardulightLedMilliAmpsChanged(mAmps);
+			break;
+
+			case DeviceTypeVirtual:
+			m_this->virtualLedMilliAmpsChanged(mAmps);
+			break;
+
+			case DeviceTypeDrgb:
+			m_this->drgbLedMilliAmpsChanged(mAmps);
+			break;
+
+			case DeviceTypeDnrgb:
+			m_this->dnrgbLedMilliAmpsChanged(mAmps);
+			break;
+
+			case DeviceTypeWarls:
+			m_this->warlsLedMilliAmpsChanged(mAmps);
+			break;
+		default:
+			qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device << "LedMilliAmps ==" << mAmps;
+		}
+	}
+}
+
+int Settings::getDeviceLedMilliAmps(const SupportedDevices::DeviceType device)
+{
+	const QString& key = m_devicesTypeToKeyLedMilliAmpsMap.value(device);
+
+	if (key == "")
+	{
+		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device;
+		return Main::Device::LedMilliAmpsDefault;
+	}
+
+	// TODO: validator on maximum number of leds for current 'device'
+	return valueMain(key).toInt();
+}
+
+
+void Settings::setDevicePowerSupplyAmps(const SupportedDevices::DeviceType device, const double amps)
+{
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
+
+	if(getDevicePowerSupplyAmps(device) == amps)
+		//nothing to do
+		return;
+
+	const QString& key = m_devicesTypeToKeyPowerSupplyAmpsMap.value(device);
+
+	if (key == "")
+	{
+		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device << "PowerSupplyAmps ==" << amps;
+		return;
+	}
+
+	setValueMain(key, amps);
+	{
+		using namespace SupportedDevices;
+		switch(device) {
+			case DeviceTypeLightpack:
+			m_this->lightpackPowerSupplyAmpsChanged(amps);
+			break;
+
+			case DeviceTypeAdalight:
+			m_this->adalightPowerSupplyAmpsChanged(amps);
+			break;
+
+			case DeviceTypeArdulight:
+			m_this->ardulightPowerSupplyAmpsChanged(amps);
+			break;
+
+			case DeviceTypeVirtual:
+			m_this->virtualPowerSupplyAmpsChanged(amps);
+			break;
+
+			case DeviceTypeDrgb:
+			m_this->drgbPowerSupplyAmpsChanged(amps);
+			break;
+
+			case DeviceTypeDnrgb:
+			m_this->dnrgbPowerSupplyAmpsChanged(amps);
+			break;
+
+			case DeviceTypeWarls:
+			m_this->warlsPowerSupplyAmpsChanged(amps);
+			break;
+		default:
+			qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device << "PowerSupplyAmps ==" << amps;
+		}
+	}
+}
+
+double Settings::getDevicePowerSupplyAmps(const SupportedDevices::DeviceType device)
+{
+	const QString& key = m_devicesTypeToKeyPowerSupplyAmpsMap.value(device);
+
+	if (key == "")
+	{
+		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device;
+		return Main::Device::PowerSupplyAmpsDefault;
 	}
 
 	// TODO: validator on maximum number of leds for current 'device'
@@ -2077,25 +2248,42 @@ void Settings::initDevicesMap()
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 
-	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeAdalight]	= Main::Value::ConnectedDevice::AdalightDevice;
+	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeAdalight] = Main::Value::ConnectedDevice::AdalightDevice;
 	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeArdulight] = Main::Value::ConnectedDevice::ArdulightDevice;
 	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeLightpack] = Main::Value::ConnectedDevice::LightpackDevice;
-	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeVirtual]	= Main::Value::ConnectedDevice::VirtualDevice;
+	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeVirtual] = Main::Value::ConnectedDevice::VirtualDevice;
 	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeDrgb] = Main::Value::ConnectedDevice::DrgbDevice;
 	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeDnrgb] = Main::Value::ConnectedDevice::DnrgbDevice;
 	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeWarls] = Main::Value::ConnectedDevice::WarlsDevice;
 
-	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeAdalight]	= Main::Key::Adalight::NumberOfLeds;
+	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeAdalight] = Main::Key::Adalight::NumberOfLeds;
 	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeArdulight] = Main::Key::Ardulight::NumberOfLeds;
 	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeLightpack] = Main::Key::Lightpack::NumberOfLeds;
-	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeVirtual]	= Main::Key::Virtual::NumberOfLeds;
+	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeVirtual] = Main::Key::Virtual::NumberOfLeds;
 	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeDrgb] = Main::Key::Drgb::NumberOfLeds;
 	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeDnrgb] = Main::Key::Dnrgb::NumberOfLeds;
 	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeWarls] = Main::Key::Warls::NumberOfLeds;
 
+	m_devicesTypeToKeyLedMilliAmpsMap[SupportedDevices::DeviceTypeAdalight] = Main::Key::Adalight::LedMilliAmps;
+	m_devicesTypeToKeyLedMilliAmpsMap[SupportedDevices::DeviceTypeArdulight] = Main::Key::Ardulight::LedMilliAmps;
+	m_devicesTypeToKeyLedMilliAmpsMap[SupportedDevices::DeviceTypeLightpack] = Main::Key::Lightpack::LedMilliAmps;
+	m_devicesTypeToKeyLedMilliAmpsMap[SupportedDevices::DeviceTypeVirtual] = Main::Key::Virtual::LedMilliAmps;
+	m_devicesTypeToKeyLedMilliAmpsMap[SupportedDevices::DeviceTypeDrgb] = Main::Key::Drgb::LedMilliAmps;
+	m_devicesTypeToKeyLedMilliAmpsMap[SupportedDevices::DeviceTypeDnrgb] = Main::Key::Dnrgb::LedMilliAmps;
+	m_devicesTypeToKeyLedMilliAmpsMap[SupportedDevices::DeviceTypeWarls] = Main::Key::Warls::LedMilliAmps;
+
+	m_devicesTypeToKeyPowerSupplyAmpsMap[SupportedDevices::DeviceTypeAdalight] = Main::Key::Adalight::PowerSupplyAmps;
+	m_devicesTypeToKeyPowerSupplyAmpsMap[SupportedDevices::DeviceTypeArdulight] = Main::Key::Ardulight::PowerSupplyAmps;
+	m_devicesTypeToKeyPowerSupplyAmpsMap[SupportedDevices::DeviceTypeLightpack] = Main::Key::Lightpack::PowerSupplyAmps;
+	m_devicesTypeToKeyPowerSupplyAmpsMap[SupportedDevices::DeviceTypeVirtual] = Main::Key::Virtual::PowerSupplyAmps;
+	m_devicesTypeToKeyPowerSupplyAmpsMap[SupportedDevices::DeviceTypeDrgb] = Main::Key::Drgb::PowerSupplyAmps;
+	m_devicesTypeToKeyPowerSupplyAmpsMap[SupportedDevices::DeviceTypeDnrgb] = Main::Key::Dnrgb::PowerSupplyAmps;
+	m_devicesTypeToKeyPowerSupplyAmpsMap[SupportedDevices::DeviceTypeWarls] = Main::Key::Warls::PowerSupplyAmps;
 #ifdef ALIEN_FX_SUPPORTED
-	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeAlienFx]	= Main::Value::ConnectedDevice::AlienFxDevice;
-	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeAlienFx]	= Main::Key::AlienFx::NumberOfLeds;
+	m_devicesTypeToNameMap[SupportedDevices::DeviceTypeAlienFx] = Main::Value::ConnectedDevice::AlienFxDevice;
+	m_devicesTypeToKeyNumberOfLedsMap[SupportedDevices::DeviceTypeAlienFx] = Main::Key::AlienFx::NumberOfLeds;
+	m_devicesTypeToKeyLedMilliAmpsMap[SupportedDevices::DeviceTypeAlienFx] = Main::Key::AlienFx::LedMilliAmps;
+	m_devicesTypeToKeyPowerSupplyAmpsMap[SupportedDevices::DeviceTypeAlienFx] = Main::Key::AlienFx::PowerSupplyAmps;
 #endif
 }
 

--- a/Software/src/Settings.hpp
+++ b/Software/src/Settings.hpp
@@ -189,6 +189,8 @@ public:
 	static void setDeviceUsbPowerLedDisabled(bool isDisabled);
 	static int getDeviceBrightness();
 	static void setDeviceBrightness(int value);
+	static int getDeviceBrightnessCap();
+	static void setDeviceBrightnessCap(int value);
 	static int getDeviceSmooth();
 	static void setDeviceSmooth(int value);
 	static int getDeviceColorDepth();
@@ -256,9 +258,10 @@ public:
 	static QString getAutoUpdatingVersion();
 	static void setAutoUpdatingVersion(const QString & version);
 
-private:		
+private:
 	static int getValidDeviceRefreshDelay(int value);
 	static int getValidDeviceBrightness(int value);
+	static int getValidDeviceBrightnessCap(int value);
 	static int getValidDeviceSmooth(int value);
 	static int getValidDeviceColorDepth(int value);
 	static double getValidDeviceGamma(double value);
@@ -340,6 +343,7 @@ signals:
 	void deviceRefreshDelayChanged(int value);
 	void deviceUsbPowerLedDisabledChanged(bool isDisabled);
 	void deviceBrightnessChanged(int value);
+	void deviceBrightnessCapChanged(int value);
 	void deviceSmoothChanged(int value);
 	void deviceColorDepthChanged(int value);
 	void deviceGammaChanged(double gamma);

--- a/Software/src/Settings.hpp
+++ b/Software/src/Settings.hpp
@@ -150,6 +150,10 @@ public:
 	static void setWarlsPort(const QString& port);
 	static int getWarlsTimeout();
 	static void setWarlsTimeout(const int timeout);
+	static int getDeviceLedMilliAmps(const SupportedDevices::DeviceType device);
+	static void setDeviceLedMilliAmps(const SupportedDevices::DeviceType device, const int mamps);
+	static double getDevicePowerSupplyAmps(const SupportedDevices::DeviceType device);
+	static void setDevicePowerSupplyAmps(const SupportedDevices::DeviceType device, const double amps);
 	static QStringList getSupportedSerialPortBaudRates();
 	static bool isConnectedDeviceUsesSerialPort();
 	// [Adalight | Ardulight | Lightpack | ... | Virtual]
@@ -311,24 +315,38 @@ signals:
 	void hotkeyChanged(const QString &actionName, const QKeySequence & newKeySequence, const QKeySequence &oldKeySequence);
 	void adalightSerialPortNameChanged(const QString & port);
 	void adalightSerialPortBaudRateChanged(const QString & baud);
+	void adalightLedMilliAmpsChanged(const int mAmps);
+	void adalightPowerSupplyAmpsChanged(const double amps);
 	void ardulightSerialPortNameChanged(const QString & port);
 	void ardulightSerialPortBaudRateChanged(const QString & baud);
+	void ardulightLedMilliAmpsChanged(const int mAmps);
+	void ardulightPowerSupplyAmpsChanged(const double amps);
 	void drgbAddressChanged(const QString& address);
 	void drgbPortChanged(const QString& port);
 	void drgbTimeoutChanged(const int timeout);
+	void drgbLedMilliAmpsChanged(const int mAmps);
+	void drgbPowerSupplyAmpsChanged(const double amps);
 	void dnrgbAddressChanged(const QString& address);
 	void dnrgbPortChanged(const QString& port);
 	void dnrgbTimeoutChanged(const int timeout);
+	void dnrgbLedMilliAmpsChanged(const int mAmps);
+	void dnrgbPowerSupplyAmpsChanged(const double amps);
 	void warlsAddressChanged(const QString& address);
 	void warlsPortChanged(const QString& port);
 	void warlsTimeoutChanged(const int timeout);
+	void warlsLedMilliAmpsChanged(const int mAmps);
+	void warlsPowerSupplyAmpsChanged(const double amps);
 	void lightpackNumberOfLedsChanged(int numberOfLeds);
+	void lightpackLedMilliAmpsChanged(const int mAmps);
+	void lightpackPowerSupplyAmpsChanged(const double amps);
 	void adalightNumberOfLedsChanged(int numberOfLeds);
 	void ardulightNumberOfLedsChanged(int numberOfLeds);
-	void virtualNumberOfLedsChanged(int numberOfLeds);
 	void drgbNumberOfLedsChanged(int numberOfLeds);
 	void dnrgbNumberOfLedsChanged(int numberOfLeds);
 	void warlsNumberOfLedsChanged(int numberOfLeds);
+	void virtualNumberOfLedsChanged(int numberOfLeds);
+	void virtualLedMilliAmpsChanged(const int mAmps);
+	void virtualPowerSupplyAmpsChanged(const double amps);
 	void grabSlowdownChanged(int value);
 	void backlightEnabledChanged(bool isEnabled);
 	void grabAvgColorsEnabledChanged(bool isEnabled);
@@ -381,5 +399,7 @@ private:
 	static Settings *m_this;
 	static QMap<SupportedDevices::DeviceType, QString> m_devicesTypeToNameMap;
 	static QMap<SupportedDevices::DeviceType, QString> m_devicesTypeToKeyNumberOfLedsMap;
+	static QMap<SupportedDevices::DeviceType, QString> m_devicesTypeToKeyLedMilliAmpsMap;
+	static QMap<SupportedDevices::DeviceType, QString> m_devicesTypeToKeyPowerSupplyAmpsMap;
 };
 } /*SettingsScope*/

--- a/Software/src/SettingsDefaults.hpp
+++ b/Software/src/SettingsDefaults.hpp
@@ -103,6 +103,11 @@ static const int PortDefault = 3636;
 static const QString AuthKey = "";
 // See ApiKey generation in Settings initialization
 }
+namespace Device
+{
+static const int LedMilliAmpsDefault = 50;
+static const double PowerSupplyAmpsDefault = 0.0;
+}
 namespace Adalight
 {
 static const int NumberOfLedsDefault = 25;

--- a/Software/src/SettingsDefaults.hpp
+++ b/Software/src/SettingsDefaults.hpp
@@ -222,6 +222,10 @@ static const int BrightnessMin = 0;
 static const int BrightnessDefault = 100;
 static const int BrightnessMax = 100;
 
+static const int BrightnessCapMin = 1;
+static const int BrightnessCapDefault = 100;
+static const int BrightnessCapMax = 100;
+
 static const int SmoothMin = 0;
 static const int SmoothDefault = 100;
 static const int SmoothMax = 255;

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -2106,6 +2106,11 @@ void SettingsWindow::on_pushButton_GammaCorrectionHelp_clicked()
 	showHelpOf(ui->horizontalSlider_GammaCorrection);
 }
 
+void SettingsWindow::on_pushButton_BrightnessCapHelp_clicked()
+{
+	showHelpOf(ui->horizontalSlider_DeviceBrightnessCap);
+}
+
 void SettingsWindow::on_pushButton_lumosityThresholdHelp_clicked()
 {
 	showHelpOf(ui->horizontalSlider_LuminosityThreshold);

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -233,6 +233,7 @@ void SettingsWindow::connectSignalsSlots()
 	connect(ui->checkBox_DisableUsbPowerLed, SIGNAL(toggled(bool)), this, SLOT(onDisableUsbPowerLed_toggled(bool)));
 	connect(ui->spinBox_DeviceSmooth, SIGNAL(valueChanged(int)), this, SLOT(onDeviceSmooth_valueChanged(int)));
 	connect(ui->spinBox_DeviceBrightness, SIGNAL(valueChanged(int)), this, SLOT(onDeviceBrightness_valueChanged(int)));
+	connect(ui->spinBox_DeviceBrightnessCap, SIGNAL(valueChanged(int)), this, SLOT(onDeviceBrightnessCap_valueChanged(int)));
 	connect(ui->spinBox_DeviceColorDepth, SIGNAL(valueChanged(int)), this, SLOT(onDeviceColorDepth_valueChanged(int)));
 	connect(ui->doubleSpinBox_DeviceGamma, SIGNAL(valueChanged(double)), this, SLOT(onDeviceGammaCorrection_valueChanged(double)));
 	connect(ui->horizontalSlider_GammaCorrection, SIGNAL(valueChanged(int)), this, SLOT(onSliderDeviceGammaCorrection_valueChanged(int)));
@@ -267,7 +268,7 @@ void SettingsWindow::connectSignalsSlots()
 #else
 	ui->pushButton_SoundVizDeviceHelp->hide();
 #endif // Q_OS_MACOS
-	
+
 #endif// SOUNDVIZ_SUPPORT
 	connect(ui->checkBox_ExpertModeEnabled, SIGNAL(toggled(bool)), this, SLOT(onExpertModeEnabled_Toggled(bool)));
 	connect(ui->checkBox_KeepLightsOnAfterExit, SIGNAL(toggled(bool)), this, SLOT(onKeepLightsAfterExit_Toggled(bool)));
@@ -464,6 +465,7 @@ void SettingsWindow::setDeviceTabWidgetsVisibility(DeviceTab::Options options)
 void SettingsWindow::syncLedDeviceWithSettingsWindow()
 {
 	emit updateBrightness(Settings::getDeviceBrightness());
+	emit updateBrightnessCap(Settings::getDeviceBrightnessCap());
 	emit updateGamma(Settings::getDeviceGamma());
 }
 
@@ -1076,7 +1078,7 @@ void SettingsWindow::ledDeviceOpenSuccess(bool isSuccess)
 }
 
 void SettingsWindow::ledDeviceCallSuccess(bool isSuccess)
-{	
+{
 	DEBUG_HIGH_LEVEL << Q_FUNC_INFO << isSuccess << m_backlightStatus << sender();
 
 	// If Backlight::StatusOff then nothings changed
@@ -1135,7 +1137,7 @@ void SettingsWindow::ledDeviceFirmwareVersionUnofficialResult(const int version)
 }
 
 void SettingsWindow::refreshAmbilightEvaluated(double updateResultMs)
-{	
+{
 	DEBUG_HIGH_LEVEL << Q_FUNC_INFO << updateResultMs;
 
 	double hz = 0;
@@ -1161,7 +1163,7 @@ void SettingsWindow::refreshAmbilightEvaluated(double updateResultMs)
 		DEBUG_HIGH_LEVEL << Q_FUNC_INFO << "Therotical Max Hz for led count and baud rate:" << theoreticalMaxHz << ledCount << baudRate;
 		if (theoreticalMaxHz <= hz)
 			qWarning() << Q_FUNC_INFO << hz << "FPS went over theoretical max of" << theoreticalMaxHz;
-		
+
 		const QPalette& defaultPalette = ui->label_GrabFrequency_txt_fps->palette();
 
 		QPalette palette = ui->label_GrabFrequency_value->palette();
@@ -1343,6 +1345,13 @@ void SettingsWindow::onDeviceBrightness_valueChanged(int percent)
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << percent;
 
 	Settings::setDeviceBrightness(percent);
+}
+
+void SettingsWindow::onDeviceBrightnessCap_valueChanged(int percent)
+{
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO << percent;
+
+	Settings::setDeviceBrightnessCap(percent);
 }
 
 void SettingsWindow::onDeviceColorDepth_valueChanged(int value)
@@ -1850,7 +1859,7 @@ void SettingsWindow::updateUiFromSettings()
 	onLightpackModeChanged(mode);
 
 	ui->checkBox_ExpertModeEnabled->setChecked						(Settings::isExpertModeEnabled());
-	
+
 	ui->checkBox_checkForUpdates->setChecked							(Settings::isCheckForUpdatesEnabled());
 	ui->checkBox_installUpdates->setChecked							(Settings::isInstallUpdatesEnabled());
 
@@ -1913,6 +1922,7 @@ void SettingsWindow::updateUiFromSettings()
 	ui->checkBox_DisableUsbPowerLed->setChecked						(Settings::isDeviceUsbPowerLedDisabled());
 	ui->horizontalSlider_DeviceRefreshDelay->setValue				(Settings::getDeviceRefreshDelay());
 	ui->horizontalSlider_DeviceBrightness->setValue					(Settings::getDeviceBrightness());
+	ui->horizontalSlider_DeviceBrightnessCap->setValue					(Settings::getDeviceBrightnessCap());
 	ui->horizontalSlider_DeviceSmooth->setValue						(Settings::getDeviceSmooth());
 	ui->horizontalSlider_DeviceColorDepth->setValue					(Settings::getDeviceColorDepth());
 	ui->doubleSpinBox_DeviceGamma->setValue							(Settings::getDeviceGamma());

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -73,6 +73,7 @@ signals:
 	void updateSlowdown(int value);
 	void updateGamma(double value);
 	void updateBrightness(int percent);
+	void updateBrightnessCap(int percent);
 	void requestFirmwareVersion();
 #ifdef SOUNDVIZ_SUPPORT
 	void requestSoundVizDevices();
@@ -179,6 +180,7 @@ private slots:
 	void onDisableUsbPowerLed_toggled(bool state);
 	void onDeviceSmooth_valueChanged(int value);
 	void onDeviceBrightness_valueChanged(int value);
+	void onDeviceBrightnessCap_valueChanged(int value);
 	void onDeviceColorDepth_valueChanged(int value);
 	void onDeviceGammaCorrection_valueChanged(double value);
 	void onSliderDeviceGammaCorrection_valueChanged(int value);

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -216,6 +216,7 @@ private slots:
 	void on_pushButton_LightpackRefreshDelayHelp_clicked();
 
 	void on_pushButton_GammaCorrectionHelp_clicked();
+	void on_pushButton_BrightnessCapHelp_clicked();
 
 	void on_pushButton_lumosityThresholdHelp_clicked();
 

--- a/Software/src/SettingsWindow.ui
+++ b/Software/src/SettingsWindow.ui
@@ -1300,29 +1300,168 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
         <property name="rightMargin">
          <number>20</number>
         </property>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_GammaCorrection">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
+        <item row="7" column="0" colspan="4">
+         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterLockComputer">
           <property name="text">
-           <string>Gamma correction:</string>
+           <string>Keep lights ON after lock computer</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="2">
-         <widget class="QPushButton" name="pushButton_GammaCorrectionHelp">
+        <item row="4" column="3">
+         <widget class="QLabel" name="label_12">
+          <property name="maximumSize">
+           <size>
+            <width>16</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>%</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QSlider" name="horizontalSlider_GammaCorrection">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="whatsThis">
+           <string>&lt;h4&gt;Gamma correction&lt;/h4&gt; It controls the level of saturation. The effect is clearly detectable in a video in screen grabbing mode&lt;br/&gt;Recommended value: 2.00</string>
+          </property>
+          <property name="minimum">
+           <number>5</number>
+          </property>
+          <property name="maximum">
+           <number>1000</number>
+          </property>
+          <property name="singleStep">
+           <number>5</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="tickPosition">
+           <enum>QSlider::NoTicks</enum>
+          </property>
+          <property name="tickInterval">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+        <item row="14" column="0" colspan="4">
+         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterExit">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Keep lights ON after exit</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="0" colspan="4">
+         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterSuspend">
+          <property name="text">
+           <string>Keep lights ON after system suspend</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QSlider" name="horizontalSlider_DeviceBrightness">
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="pageStep">
+           <number>1</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="17" column="0">
+         <spacer name="verticalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="15" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <property name="bottomMargin">
+           <number>13</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="pbRunConfigurationWizard">
+            <property name="text">
+             <string>Run configuration wizard</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item row="2" column="3">
+         <widget class="QLabel" name="label_15">
+          <property name="maximumSize">
+           <size>
+            <width>16</width>
+            <height>16777215</height>
+           </size>
+          </property>
           <property name="styleSheet">
            <string notr="true">margin:0px;</string>
+          </property>
+          <property name="text">
+           <string>%</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="5">
+         <widget class="QPushButton" name="pushButton_BrightnessCapHelp">
+          <property name="maximumSize">
+           <size>
+            <width>16</width>
+            <height>16777215</height>
+           </size>
           </property>
           <property name="text">
            <string/>
@@ -1343,7 +1482,20 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
          </widget>
         </item>
-        <item row="16" column="0" colspan="3">
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_GammaCorrection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Gamma correction:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="16" column="0" colspan="4">
          <widget class="QTabWidget" name="tabDevices">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1715,7 +1867,143 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </widget>
          </widget>
         </item>
-        <item row="6" column="1">
+        <item row="4" column="0">
+         <widget class="QSlider" name="horizontalSlider_DeviceBrightnessCap">
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="whatsThis">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Brightness Cap&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Lowers the brightness limit of LEDs (as opposed to overall brightness). Can be used to limit the power draw and the heat output. Defaults to 100% (no limit).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Overall brightness:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Brightness cap:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="QSpinBox" name="spinBox_DeviceBrightnessCap">
+          <property name="maximumSize">
+           <size>
+            <width>45</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>29</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QSpinBox" name="spinBox_DeviceBrightness">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>45</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>45</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>9</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="5">
+         <widget class="QPushButton" name="pushButton_GammaCorrectionHelp">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">margin:0px;</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../res/LightpackResources.qrc">
+            <normaloff>:/icons/help.png</normaloff>:/icons/help.png</iconset>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
          <widget class="QDoubleSpinBox" name="doubleSpinBox_DeviceGamma">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -1746,223 +2034,6 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
           <property name="value">
            <double>0.050000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="label_15">
-          <property name="styleSheet">
-           <string notr="true">margin:0px;</string>
-          </property>
-          <property name="text">
-           <string>%</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="17" column="0">
-         <spacer name="verticalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="2" column="0">
-         <widget class="QSlider" name="horizontalSlider_DeviceBrightness">
-          <property name="minimum">
-           <number>0</number>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="pageStep">
-           <number>1</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="15" column="0">
-         <layout class="QHBoxLayout" name="horizontalLayout_8">
-          <property name="bottomMargin">
-           <number>13</number>
-          </property>
-          <item>
-           <widget class="QPushButton" name="pbRunConfigurationWizard">
-            <property name="text">
-             <string>Run configuration wizard</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Overall brightness:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0" colspan="3">
-         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterLockComputer">
-          <property name="text">
-           <string>Keep lights ON after lock computer</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QSpinBox" name="spinBox_DeviceBrightness">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>60</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="minimum">
-           <number>0</number>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-         </widget>
-        </item>
-        <item row="14" column="0" colspan="3">
-         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterExit">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Keep lights ON after exit</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0" colspan="3">
-         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterSuspend">
-          <property name="text">
-           <string>Keep lights ON after system suspend</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QSlider" name="horizontalSlider_GammaCorrection">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="whatsThis">
-           <string>&lt;h4&gt;Gamma correction&lt;/h4&gt; It controls the level of saturation. The effect is clearly detectable in a video in screen grabbing mode&lt;br/&gt;Recommended value: 2.00</string>
-          </property>
-          <property name="minimum">
-           <number>5</number>
-          </property>
-          <property name="maximum">
-           <number>1000</number>
-          </property>
-          <property name="singleStep">
-           <number>5</number>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="tickPosition">
-           <enum>QSlider::NoTicks</enum>
-          </property>
-          <property name="tickInterval">
-           <number>100</number>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="label_12">
-          <property name="text">
-           <string>%</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Brightness cap:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QSpinBox" name="spinBox_DeviceBrightnessCap">
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QSlider" name="horizontalSlider_DeviceBrightnessCap">
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -3146,10 +3217,7 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
   <tabstop>radioButton_LuminosityDeadZone</tabstop>
   <tabstop>pushButton_EnableDisableDevice</tabstop>
   <tabstop>horizontalSlider_DeviceBrightness</tabstop>
-  <tabstop>spinBox_DeviceBrightness</tabstop>
   <tabstop>horizontalSlider_GammaCorrection</tabstop>
-  <tabstop>doubleSpinBox_DeviceGamma</tabstop>
-  <tabstop>pushButton_GammaCorrectionHelp</tabstop>
   <tabstop>checkBox_KeepLightsOnAfterLockComputer</tabstop>
   <tabstop>checkBox_KeepLightsOnAfterScreenOff</tabstop>
   <tabstop>checkBox_KeepLightsOnAfterSuspend</tabstop>

--- a/Software/src/SettingsWindow.ui
+++ b/Software/src/SettingsWindow.ui
@@ -1307,19 +1307,6 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
          </widget>
         </item>
-        <item row="4" column="3">
-         <widget class="QLabel" name="label_12">
-          <property name="maximumSize">
-           <size>
-            <width>16</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>%</string>
-          </property>
-         </widget>
-        </item>
         <item row="6" column="0">
          <widget class="QSlider" name="horizontalSlider_GammaCorrection">
           <property name="sizePolicy">
@@ -1435,25 +1422,6 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
            </spacer>
           </item>
          </layout>
-        </item>
-        <item row="2" column="3">
-         <widget class="QLabel" name="label_15">
-          <property name="maximumSize">
-           <size>
-            <width>16</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">margin:0px;</string>
-          </property>
-          <property name="text">
-           <string>%</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
         </item>
         <item row="4" column="5">
          <widget class="QPushButton" name="pushButton_BrightnessCapHelp">
@@ -1916,7 +1884,7 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
          <widget class="QSpinBox" name="spinBox_DeviceBrightnessCap">
           <property name="maximumSize">
            <size>
-            <width>50</width>
+            <width>60</width>
             <height>16777215</height>
            </size>
           </property>
@@ -1935,7 +1903,10 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           <property name="value">
            <number>100</number>
           </property>
-         </widget>
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          </widget>
         </item>
         <item row="2" column="2">
          <widget class="QSpinBox" name="spinBox_DeviceBrightness">
@@ -1953,7 +1924,7 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
           <property name="maximumSize">
            <size>
-            <width>50</width>
+            <width>60</width>
             <height>16777215</height>
            </size>
           </property>
@@ -1972,7 +1943,10 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           <property name="value">
            <number>100</number>
           </property>
-         </widget>
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          </widget>
         </item>
         <item row="6" column="5">
          <widget class="QPushButton" name="pushButton_GammaCorrectionHelp">

--- a/Software/src/SettingsWindow.ui
+++ b/Software/src/SettingsWindow.ui
@@ -1300,66 +1300,20 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
         <property name="rightMargin">
          <number>20</number>
         </property>
-        <item row="13" column="0">
-         <layout class="QHBoxLayout" name="horizontalLayout_8">
-          <property name="bottomMargin">
-           <number>13</number>
-          </property>
-          <item>
-           <widget class="QPushButton" name="pbRunConfigurationWizard">
-            <property name="text">
-             <string>Run configuration wizard</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="label_15">
-          <property name="styleSheet">
-           <string notr="true">margin:0px;</string>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_GammaCorrection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="text">
-           <string>%</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <string>Gamma correction:</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QSlider" name="horizontalSlider_DeviceBrightness">
-          <property name="minimum">
-           <number>0</number>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="pageStep">
-           <number>1</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
+        <item row="6" column="2">
          <widget class="QPushButton" name="pushButton_GammaCorrectionHelp">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -1382,41 +1336,14 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
-         <widget class="QDoubleSpinBox" name="doubleSpinBox_DeviceGamma">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>60</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="minimum">
-           <double>0.050000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.050000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.050000000000000</double>
+        <item row="8" column="0">
+         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterScreenOff">
+          <property name="text">
+           <string>Keep lights ON after display sleep</string>
           </property>
          </widget>
         </item>
-        <item row="14" column="0" colspan="3">
+        <item row="16" column="0" colspan="3">
          <widget class="QTabWidget" name="tabDevices">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1459,6 +1386,122 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
             <property name="rightMargin">
              <number>0</number>
             </property>
+            <item row="8" column="0">
+             <widget class="QSlider" name="horizontalSlider_DeviceRefreshDelay">
+              <property name="whatsThis">
+               <string>&lt;h4&gt;Refresh delay&lt;/h4&gt; This setting’s values are inversely proportional to the PWM’s frequency. It's affects to performance.</string>
+              </property>
+              <property name="minimum">
+               <number>64</number>
+              </property>
+              <property name="maximum">
+               <number>1023</number>
+              </property>
+              <property name="pageStep">
+               <number>1</number>
+              </property>
+              <property name="value">
+               <number>64</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="0">
+             <widget class="QLabel" name="label_DeviceRefreshDelay">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Refresh delay (Lightpack 5 and below):</string>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="0">
+             <spacer name="verticalSpacer_8">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="4" column="2">
+             <widget class="QPushButton" name="pushButton_LightpackColorDepthHelp">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">margin:0px;</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="icon">
+               <iconset resource="../res/LightpackResources.qrc">
+                <normaloff>:/icons/help.png</normaloff>:/icons/help.png</iconset>
+              </property>
+              <property name="flat">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="2">
+             <widget class="QPushButton" name="pushButton_LightpackRefreshDelayHelp">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">margin:0px;</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="icon">
+               <iconset resource="../res/LightpackResources.qrc">
+                <normaloff>:/icons/help.png</normaloff>:/icons/help.png</iconset>
+              </property>
+              <property name="flat">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QSlider" name="horizontalSlider_DeviceColorDepth">
+              <property name="whatsThis">
+               <string>&lt;h4&gt;Color depth&lt;/h4&gt; Number of colors per channel, one RGB LED uses 3 channels (value in power of 3).</string>
+              </property>
+              <property name="minimum">
+               <number>32</number>
+              </property>
+              <property name="maximum">
+               <number>255</number>
+              </property>
+              <property name="pageStep">
+               <number>1</number>
+              </property>
+              <property name="value">
+               <number>100</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
             <item row="8" column="1">
              <widget class="QSpinBox" name="spinBox_DeviceRefreshDelay">
               <property name="sizePolicy">
@@ -1490,54 +1533,6 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
               </property>
              </widget>
             </item>
-            <item row="9" column="0">
-             <spacer name="verticalSpacer_8">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="8" column="0">
-             <widget class="QSlider" name="horizontalSlider_DeviceRefreshDelay">
-              <property name="whatsThis">
-               <string>&lt;h4&gt;Refresh delay&lt;/h4&gt; This setting’s values are inversely proportional to the PWM’s frequency. It's affects to performance.</string>
-              </property>
-              <property name="minimum">
-               <number>64</number>
-              </property>
-              <property name="maximum">
-               <number>1023</number>
-              </property>
-              <property name="pageStep">
-               <number>1</number>
-              </property>
-              <property name="value">
-               <number>64</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
-             <widget class="QLabel" name="label_9">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Smoothness:</string>
-              </property>
-             </widget>
-            </item>
             <item row="6" column="2">
              <widget class="QPushButton" name="pushButton_LightpackSmoothnessHelp">
               <property name="sizePolicy">
@@ -1558,94 +1553,6 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
               </property>
               <property name="flat">
                <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="7" column="0">
-             <widget class="QLabel" name="label_DeviceRefreshDelay">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Refresh delay (Lightpack 5 and below):</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QSpinBox" name="spinBox_DeviceColorDepth">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>50</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>60</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="minimum">
-               <number>32</number>
-              </property>
-              <property name="maximum">
-               <number>255</number>
-              </property>
-              <property name="value">
-               <number>100</number>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <widget class="QSlider" name="horizontalSlider_DeviceColorDepth">
-              <property name="whatsThis">
-               <string>&lt;h4&gt;Color depth&lt;/h4&gt; Number of colors per channel, one RGB LED uses 3 channels (value in power of 3).</string>
-              </property>
-              <property name="minimum">
-               <number>32</number>
-              </property>
-              <property name="maximum">
-               <number>255</number>
-              </property>
-              <property name="pageStep">
-               <number>1</number>
-              </property>
-              <property name="value">
-               <number>100</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="0">
-             <widget class="QSlider" name="horizontalSlider_DeviceSmooth">
-              <property name="whatsThis">
-               <string>&lt;h4&gt;Smoothness&lt;/h4&gt; It defines how many steps will be color changed in</string>
-              </property>
-              <property name="minimum">
-               <number>0</number>
-              </property>
-              <property name="maximum">
-               <number>255</number>
-              </property>
-              <property name="pageStep">
-               <number>1</number>
-              </property>
-              <property name="value">
-               <number>100</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
               </property>
              </widget>
             </item>
@@ -1680,52 +1587,6 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
               </property>
              </widget>
             </item>
-            <item row="8" column="2">
-             <widget class="QPushButton" name="pushButton_LightpackRefreshDelayHelp">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">margin:0px;</string>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="icon">
-               <iconset resource="../res/LightpackResources.qrc">
-                <normaloff>:/icons/help.png</normaloff>:/icons/help.png</iconset>
-              </property>
-              <property name="flat">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="2">
-             <widget class="QPushButton" name="pushButton_LightpackColorDepthHelp">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">margin:0px;</string>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="icon">
-               <iconset resource="../res/LightpackResources.qrc">
-                <normaloff>:/icons/help.png</normaloff>:/icons/help.png</iconset>
-              </property>
-              <property name="flat">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
             <item row="3" column="0">
              <widget class="QLabel" name="label_DeviceColorDepth">
               <property name="sizePolicy">
@@ -1739,10 +1600,76 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
               </property>
              </widget>
             </item>
+            <item row="4" column="1">
+             <widget class="QSpinBox" name="spinBox_DeviceColorDepth">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>50</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>60</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="minimum">
+               <number>32</number>
+              </property>
+              <property name="maximum">
+               <number>255</number>
+              </property>
+              <property name="value">
+               <number>100</number>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="0">
+             <widget class="QSlider" name="horizontalSlider_DeviceSmooth">
+              <property name="whatsThis">
+               <string>&lt;h4&gt;Smoothness&lt;/h4&gt; It defines how many steps will be color changed in</string>
+              </property>
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>255</number>
+              </property>
+              <property name="pageStep">
+               <number>1</number>
+              </property>
+              <property name="value">
+               <number>100</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
             <item row="2" column="0">
              <widget class="QCheckBox" name="checkBox_DisableUsbPowerLed">
               <property name="text">
                <string>Disable USB Power LED</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_9">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Smoothness:</string>
               </property>
              </widget>
             </item>
@@ -1788,45 +1715,54 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </widget>
          </widget>
         </item>
-        <item row="5" column="0" colspan="3">
-         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterLockComputer">
-          <property name="text">
-           <string>Keep lights ON after lock computer</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QSlider" name="horizontalSlider_GammaCorrection">
+        <item row="6" column="1">
+         <widget class="QDoubleSpinBox" name="doubleSpinBox_DeviceGamma">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="whatsThis">
-           <string>&lt;h4&gt;Gamma correction&lt;/h4&gt; It controls the level of saturation. The effect is clearly detectable in a video in screen grabbing mode&lt;br/&gt;Recommended value: 2.00</string>
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
           </property>
           <property name="minimum">
-           <number>5</number>
+           <double>0.050000000000000</double>
           </property>
           <property name="maximum">
-           <number>1000</number>
+           <double>10.000000000000000</double>
           </property>
           <property name="singleStep">
-           <number>5</number>
+           <double>0.050000000000000</double>
           </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="tickPosition">
-           <enum>QSlider::NoTicks</enum>
-          </property>
-          <property name="tickInterval">
-           <number>100</number>
+          <property name="value">
+           <double>0.050000000000000</double>
           </property>
          </widget>
         </item>
-        <item row="15" column="0">
+        <item row="2" column="2">
+         <widget class="QLabel" name="label_15">
+          <property name="styleSheet">
+           <string notr="true">margin:0px;</string>
+          </property>
+          <property name="text">
+           <string>%</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="17" column="0">
          <spacer name="verticalSpacer_2">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -1839,8 +1775,54 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
          </spacer>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_GammaCorrection">
+        <item row="2" column="0">
+         <widget class="QSlider" name="horizontalSlider_DeviceBrightness">
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="pageStep">
+           <number>1</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="15" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <property name="bottomMargin">
+           <number>13</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="pbRunConfigurationWizard">
+            <property name="text">
+             <string>Run configuration wizard</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_5">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -1848,7 +1830,14 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Gamma correction:</string>
+           <string>Overall brightness:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0" colspan="3">
+         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterLockComputer">
+          <property name="text">
+           <string>Keep lights ON after lock computer</string>
           </property>
          </widget>
         </item>
@@ -1883,27 +1872,7 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Overall brightness:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0" colspan="3">
-         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterSuspend">
-          <property name="text">
-           <string>Keep lights ON after system suspend</string>
-          </property>
-         </widget>
-        </item>
-        <item row="12" column="0" colspan="3">
+        <item row="14" column="0" colspan="3">
          <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterExit">
           <property name="minimumSize">
            <size>
@@ -1916,10 +1885,84 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
-         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterScreenOff">
+        <item row="9" column="0" colspan="3">
+         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterSuspend">
           <property name="text">
-           <string>Keep lights ON after display sleep</string>
+           <string>Keep lights ON after system suspend</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QSlider" name="horizontalSlider_GammaCorrection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="whatsThis">
+           <string>&lt;h4&gt;Gamma correction&lt;/h4&gt; It controls the level of saturation. The effect is clearly detectable in a video in screen grabbing mode&lt;br/&gt;Recommended value: 2.00</string>
+          </property>
+          <property name="minimum">
+           <number>5</number>
+          </property>
+          <property name="maximum">
+           <number>1000</number>
+          </property>
+          <property name="singleStep">
+           <number>5</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="tickPosition">
+           <enum>QSlider::NoTicks</enum>
+          </property>
+          <property name="tickInterval">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="QLabel" name="label_12">
+          <property name="text">
+           <string>%</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Brightness cap:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QSpinBox" name="spinBox_DeviceBrightnessCap">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QSlider" name="horizontalSlider_DeviceBrightnessCap">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -3444,6 +3487,38 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
     <hint type="destinationlabel">
      <x>422</x>
      <y>210</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>horizontalSlider_DeviceBrightnessCap</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>spinBox_DeviceBrightnessCap</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>253</x>
+     <y>116</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>390</x>
+     <y>116</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spinBox_DeviceBrightnessCap</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>horizontalSlider_DeviceBrightnessCap</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>390</x>
+     <y>116</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>253</x>
+     <y>116</y>
     </hint>
    </hints>
   </connection>

--- a/Software/src/SettingsWindow.ui
+++ b/Software/src/SettingsWindow.ui
@@ -1916,7 +1916,7 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
          <widget class="QSpinBox" name="spinBox_DeviceBrightnessCap">
           <property name="maximumSize">
            <size>
-            <width>45</width>
+            <width>50</width>
             <height>16777215</height>
            </size>
           </property>
@@ -1953,7 +1953,7 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
           <property name="maximumSize">
            <size>
-            <width>45</width>
+            <width>50</width>
             <height>16777215</height>
            </size>
           </property>

--- a/Software/src/enums.hpp
+++ b/Software/src/enums.hpp
@@ -171,6 +171,7 @@ enum Cmd {
 	SetSmoothSlowdown,
 	SetGamma,
 	SetBrightness,
+	SetBrightnessCap,
 	SetLuminosityThreshold,
 	SetMinimumLuminosityEnabled,
 	SetColorSequence,

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -299,6 +299,7 @@ SOURCES += \
     wizard/LightpackDiscoveryPage.cpp \
     wizard/ConfigureDevicePage.cpp \
     wizard/ConfigureUdpDevicePage.cpp \
+    wizard/ConfigureDevicePowerPage.cpp \
     wizard/SelectDevicePage.cpp \
     wizard/GlobalColorCoefPage.cpp \
     wizard/CustomDistributor.cpp \
@@ -355,6 +356,7 @@ HEADERS += \
     wizard/LightpackDiscoveryPage.hpp \
     wizard/ConfigureDevicePage.hpp \
     wizard/ConfigureUdpDevicePage.hpp \
+    wizard/ConfigureDevicePowerPage.hpp \
     wizard/SelectDevicePage.hpp \
     wizard/GlobalColorCoefPage.hpp \
     types.h \
@@ -400,6 +402,7 @@ FORMS += SettingsWindow.ui \
     wizard/LightpackDiscoveryPage.ui \
     wizard/ConfigureDevicePage.ui \
     wizard/ConfigureUdpDevicePage.ui \
+    wizard/ConfigureDevicePowerPage.ui \
     wizard/SelectDevicePage.ui \
     wizard/GlobalColorCoefPage.ui
 

--- a/Software/src/wizard/ConfigureDevicePowerPage.cpp
+++ b/Software/src/wizard/ConfigureDevicePowerPage.cpp
@@ -1,0 +1,108 @@
+/*
+ * ConfigureDevicePowerPage.cpp
+ *
+ *	Created on: 15/02/2020
+ *		Project: Prismatik
+ *
+ *	Copyright (c) 2013 Tim
+ *
+ *	Lightpack is an open-source, USB content-driving ambient lighting
+ *	hardware.
+ *
+ *	Prismatik is a free, open-source software: you can redistribute it and/or
+ *	modify it under the terms of the GNU General Public License as published
+ *	by the Free Software Foundation, either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Prismatik and Lightpack files is distributed in the hope that it will be
+ *	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the GNU
+ *	General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program.	If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <QDesktopWidget>
+#include <QMessageBox>
+
+#include "ConfigureDevicePowerPage.hpp"
+#include "ui_ConfigureDevicePowerPage.h"
+#include "Settings.hpp"
+#include "LedDeviceDrgb.hpp"
+#include "LedDeviceDnrgb.hpp"
+#include "LedDeviceWarls.hpp"
+#include "Wizard.hpp"
+
+using namespace SettingsScope;
+
+ConfigureDevicePowerPage::ConfigureDevicePowerPage(bool isInitFromSettings, TransientSettings *ts, QWidget *parent):
+	QWizardPage(parent),
+	SettingsAwareTrait(isInitFromSettings, ts),
+	ui(new Ui::ConfigureDevicePowerPage)
+{
+	ui->setupUi(this);
+}
+
+void ConfigureDevicePowerPage::initializePage()
+{
+	SupportedDevices::DeviceType device = SupportedDevices::DefaultDeviceType;
+	if (field("isDrgb").toBool())
+		device = SupportedDevices::DeviceTypeDrgb;
+	else if (field("isDnrgb").toBool())
+		device = SupportedDevices::DeviceTypeDnrgb;
+	else if (field("isWarls").toBool())
+		device = SupportedDevices::DeviceTypeWarls;
+	else if (field("isLightpack").toBool())
+		device = SupportedDevices::DeviceTypeLightpack;
+	else if (field("isAdalight").toBool())
+		device = SupportedDevices::DeviceTypeAdalight;
+	else if (field("isArdulight").toBool())
+		device = SupportedDevices::DeviceTypeArdulight;
+	else if (field("isVirtual").toBool())
+		device = SupportedDevices::DeviceTypeVirtual;
+	else if (field("isAlienFx").toBool())
+		device = SupportedDevices::DeviceTypeAlienFx;
+
+	ui->sbLedMilliAmps->setValue(Settings::getDeviceLedMilliAmps(device));
+	ui->sbPowerSupplyAmps->setValue(Settings::getDevicePowerSupplyAmps(device));
+}
+
+
+bool ConfigureDevicePowerPage::validatePage()
+{
+	SupportedDevices::DeviceType device = SupportedDevices::DefaultDeviceType;
+	if (field("isDrgb").toBool())
+		device = SupportedDevices::DeviceTypeDrgb;
+	else if (field("isDnrgb").toBool())
+		device = SupportedDevices::DeviceTypeDnrgb;
+	else if (field("isWarls").toBool())
+		device = SupportedDevices::DeviceTypeWarls;
+	else if (field("isLightpack").toBool())
+		device = SupportedDevices::DeviceTypeLightpack;
+	else if (field("isAdalight").toBool())
+		device = SupportedDevices::DeviceTypeAdalight;
+	else if (field("isArdulight").toBool())
+		device = SupportedDevices::DeviceTypeArdulight;
+	else if (field("isVirtual").toBool())
+		device = SupportedDevices::DeviceTypeVirtual;
+	else if (field("isAlienFx").toBool())
+		device = SupportedDevices::DeviceTypeAlienFx;
+
+	const int ledMilliAmps = ui->sbLedMilliAmps->value();
+	const double powerSupplyAmps = ui->sbPowerSupplyAmps->value();
+
+	Settings::setDeviceLedMilliAmps(device, ledMilliAmps);
+	Settings::setDevicePowerSupplyAmps(device, powerSupplyAmps);
+
+	_transSettings->ledDevice->setLedMilliAmps(ledMilliAmps);
+	_transSettings->ledDevice->setPowerSupplyAmps(powerSupplyAmps);
+
+	return true;
+}
+
+ConfigureDevicePowerPage::~ConfigureDevicePowerPage()
+{
+	delete ui;
+}

--- a/Software/src/wizard/ConfigureDevicePowerPage.hpp
+++ b/Software/src/wizard/ConfigureDevicePowerPage.hpp
@@ -1,10 +1,10 @@
 /*
- * Wizard.hpp
+ * ConfigureDevicePowerPage.hpp
  *
- *	Created on: 10/22/2013
- *		Project: %PROJECT% (Use "Lightpack" for hardware/firmware, or "Prismatik" for software)
+ *	Created on: 15/02/2020
+ *		Project: Prismatik
  *
- *	Copyright (c) 2013 %NICKNAME%
+ *	Copyright (c) 2013 Tim
  *
  *	Lightpack is an open-source, USB content-driving ambient lighting
  *	hardware.
@@ -24,46 +24,30 @@
  *
  */
 
-#ifndef WIZARD_HPP
-#define WIZARD_HPP
+#ifndef CONFIGUREDEVICEPOWERPAGE_HPP
+#define CONFIGUREDEVICEPOWERPAGE_HPP
 
-#include <QApplication>
-#include <QWizard>
+#include <QWizardPage>
 #include "SettingsAwareTrait.hpp"
 
 namespace Ui {
-class Wizard;
+class ConfigureDevicePowerPage;
 }
 
-enum {
-	Page_LightpackDiscovery,
-	Page_ChooseDevice,
-	Page_ConfigureDevice,
-    Page_ConfigureUdpDevice,
-	Page_MonitorConfiguration,
-	Page_ChooseProfile,
-	Page_ZonePlacement,
-    Page_ConfigureDevicePower,
-	Page_GlobalColorCoef
-};
-
-class Wizard : public QWizard, SettingsAwareTrait
+class ConfigureDevicePowerPage : public QWizardPage, SettingsAwareTrait
 {
 	Q_OBJECT
 
 public:
-	explicit Wizard(bool isInitFromSettings, QWidget *parent = 0);
-	~Wizard();
+	explicit ConfigureDevicePowerPage(bool isInitFromSettings, TransientSettings *ts, QWidget *parent = 0);
+	~ConfigureDevicePowerPage();
 
-	int skipMonitorConfigurationPage() {
-		this->setField("screenId", -1);
-		return Page_ChooseProfile;
-	}
-
-public slots:
+protected:
+	void initializePage();
+	bool validatePage();
 
 private:
-	Ui::Wizard *_ui;
+	Ui::ConfigureDevicePowerPage*ui;
 };
 
-#endif // WIZARD_HPP
+#endif // CONFIGUREDEVICEPOWERPAGE_HPP

--- a/Software/src/wizard/ConfigureDevicePowerPage.ui
+++ b/Software/src/wizard/ConfigureDevicePowerPage.ui
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureDevicePowerPage</class>
+ <widget class="QWizardPage" name="ConfigureDevicePowerPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>WizardPage</string>
+  </property>
+  <property name="title">
+   <string>Device configuration</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QStackedWidget" name="stackedWidget">
+     <widget class="QWidget" name="page">
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="4" column="0">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="3" column="3">
+        <widget class="QLabel" name="lmAmps">
+         <property name="text">
+          <string>mAmps</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="3">
+        <widget class="QLabel" name="lAmps">
+         <property name="text">
+          <string>Amps</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="5">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="4" column="2">
+        <widget class="QDoubleSpinBox" name="sbPowerSupplyAmps">
+         <property name="singleStep">
+          <double>0.100000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="lpowerSupplyAmps">
+         <property name="text">
+          <string>Power Supply current limit</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="lledMilliAmps">
+         <property name="text">
+          <string>Single LED current</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="QSpinBox" name="sbLedMilliAmps">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>50</number>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="3">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="2" colspan="2">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0" rowspan="2" colspan="6">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;If your LED power supply cannot provide enough current AND you know your LED's current requirements (check datasheet if needed) you can limit the current here. This will reduce the overall brightness on current hungry scenes. &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;Leave Power Supply current limit at &amp;quot;0&amp;quot; to disable limiting.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Warning&lt;/span&gt;: Power Supply current limit value might not match exactly your power supply so adjust as necessary.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignBottom|Qt::AlignJustify</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_2"/>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Software/src/wizard/Wizard.cpp
+++ b/Software/src/wizard/Wizard.cpp
@@ -33,6 +33,7 @@
 #include "SelectDevicePage.hpp"
 #include "ConfigureDevicePage.hpp"
 #include "ConfigureUdpDevicePage.hpp"
+#include "ConfigureDevicePowerPage.hpp"
 #include "GlobalColorCoefPage.hpp"
 #include "AbstractLedDevice.hpp"
 
@@ -51,6 +52,7 @@ Wizard::Wizard(bool isInitFromSettings, QWidget *parent) :
 	this->setPage(Page_MonitorConfiguration, new MonitorConfigurationPage(_isInitFromSettings, _transSettings) );
 	this->setPage(Page_ChooseProfile, new SelectProfilePage(_isInitFromSettings, _transSettings));
 	this->setPage(Page_ZonePlacement, new ZonePlacementPage(_isInitFromSettings, _transSettings));
+    this->setPage(Page_ConfigureDevicePower, new ConfigureDevicePowerPage(_isInitFromSettings, _transSettings));
 	this->setPage(Page_GlobalColorCoef, new GlobalColorCoefPage(_isInitFromSettings, _transSettings));
 }
 

--- a/Software/src/wizard/Wizard.cpp
+++ b/Software/src/wizard/Wizard.cpp
@@ -48,11 +48,11 @@ Wizard::Wizard(bool isInitFromSettings, QWidget *parent) :
 	this->setPage(Page_LightpackDiscovery, new LightpackDiscoveryPage(_isInitFromSettings, _transSettings) );
 	this->setPage(Page_ChooseDevice, new SelectDevicePage(_isInitFromSettings, _transSettings) );
 	this->setPage(Page_ConfigureDevice, new ConfigureDevicePage(_isInitFromSettings, _transSettings) );
-    this->setPage(Page_ConfigureUdpDevice, new ConfigureUdpDevicePage(_isInitFromSettings, _transSettings));
+	this->setPage(Page_ConfigureUdpDevice, new ConfigureUdpDevicePage(_isInitFromSettings, _transSettings));
 	this->setPage(Page_MonitorConfiguration, new MonitorConfigurationPage(_isInitFromSettings, _transSettings) );
 	this->setPage(Page_ChooseProfile, new SelectProfilePage(_isInitFromSettings, _transSettings));
 	this->setPage(Page_ZonePlacement, new ZonePlacementPage(_isInitFromSettings, _transSettings));
-    this->setPage(Page_ConfigureDevicePower, new ConfigureDevicePowerPage(_isInitFromSettings, _transSettings));
+	this->setPage(Page_ConfigureDevicePower, new ConfigureDevicePowerPage(_isInitFromSettings, _transSettings));
 	this->setPage(Page_GlobalColorCoef, new GlobalColorCoefPage(_isInitFromSettings, _transSettings));
 }
 

--- a/Software/src/wizard/Wizard.hpp
+++ b/Software/src/wizard/Wizard.hpp
@@ -39,11 +39,11 @@ enum {
 	Page_LightpackDiscovery,
 	Page_ChooseDevice,
 	Page_ConfigureDevice,
-    Page_ConfigureUdpDevice,
+	Page_ConfigureUdpDevice,
 	Page_MonitorConfiguration,
 	Page_ChooseProfile,
 	Page_ZonePlacement,
-    Page_ConfigureDevicePower,
+	Page_ConfigureDevicePower,
 	Page_GlobalColorCoef
 };
 


### PR DESCRIPTION
This is for #342, which reminded me of a similar thing implemented on WLED, both are good ideas, so I added them:
- brightness cap (in device tab): to limit brightest LEDs as per request
![image](https://user-images.githubusercontent.com/239811/83912872-dfba6f80-a76e-11ea-8168-48dc1622ded4.png)

- power supply limit (in device wizard): inspired by WLED, the idea is to put current requirements per LED and whatever current the power supply can provide and if the estimated current requirement for a given frame goes over the limit readjust the colors to fit within the limit
![image](https://user-images.githubusercontent.com/239811/83912937-fc56a780-a76e-11ea-8fc6-87a4ac8636b4.png)
The caveat is that IRL it's not linear and depends on different things, but it's a start.
