### PR TITLE
Respect host linker variables

### DIFF
--- a/Software/grab/grab.pro
+++ b/Software/grab/grab.pro
@@ -23,6 +23,10 @@ INCLUDEPATH += ./include \
                ../math/include \
                ..
 
+QMAKE_CFLAGS = $$(CFLAGS)
+QMAKE_CXXFLAGS = $$(CXXFLAGS)
+QMAKE_LFLAGS = $$(LDFLAGS)
+
 QMAKE_CXXFLAGS += -std=c++17
 CONFIG(clang) {
     QMAKE_CXXFLAGS += -stdlib=libc++

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -58,6 +58,10 @@ DEFINES += $${SUPPORTED_GRABBERS}
 
 LIBS    += -L../lib -lgrab -lprismatik-math
 
+QMAKE_CFLAGS = $$(CFLAGS)
+QMAKE_CXXFLAGS = $$(CXXFLAGS)
+QMAKE_LFLAGS = $$(LDFLAGS)
+
 CONFIG(gcc):QMAKE_CXXFLAGS += -std=c++11
 CONFIG(clang) {
     QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++


### PR DESCRIPTION
Not doing so can result in problems during build, see https://bugs.archlinux.org/task/26435

Just for the record, without this patch it resulted in the following [namcap](https://wiki.archlinux.org/index.php/Namcap) warnings on Arch Linux:
* ELF file ('usr/bin/prismatik') lacks FULL RELRO, check LDFLAGS
* Unused shared library '/usr/lib/libGL.so.1'