### PR TITLE
DesktopDuplication call releaseFrame before acquireNextFrame

### DIFF
--- a/Software/grab/include/DDuplGrabber.hpp
+++ b/Software/grab/include/DDuplGrabber.hpp
@@ -63,7 +63,7 @@ class DDuplGrabber : public GrabberBase
 {
 	Q_OBJECT
 public:
-	DDuplGrabber(QObject * parent, GrabberContext *context);
+	DDuplGrabber(QObject* parent, GrabberContext* context);
 	virtual ~DDuplGrabber();
 
 	DECLARE_GRABBER_NAME("DDuplGrabber")
@@ -73,13 +73,13 @@ public slots:
 
 protected slots:
 	virtual GrabResult grabScreens();
-	virtual bool reallocate(const QList< ScreenInfo > &grabScreens);
-	bool _reallocate(const QList< ScreenInfo > &grabScreens, bool noRecursion = false);
+	virtual bool reallocate(const QList< ScreenInfo >& grabScreens);
+	bool _reallocate(const QList< ScreenInfo >& grabScreens, bool noRecursion = false);
 
-	virtual QList< ScreenInfo > * screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets);
-	QList< ScreenInfo > * __screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets, bool noRecursion = false);
+	virtual QList< ScreenInfo >* screensWithWidgets(QList< ScreenInfo >* result, const QList<GrabWidget*>& grabWidgets);
+	QList< ScreenInfo >* __screensWithWidgets(QList< ScreenInfo >* result, const QList<GrabWidget*>& grabWidgets, bool noRecursion = false);
 
-	virtual bool isReallocationNeeded(const QList< ScreenInfo > &grabScreens) const;
+	virtual bool isReallocationNeeded(const QList< ScreenInfo >& grabScreens) const;
 
 protected:
 	bool init();
@@ -105,6 +105,7 @@ private:
 	QList<ScreenInfo> m_threadReallocateArg;
 	bool m_threadReallocateResult;
 	bool m_isSessionLocked;
+	bool m_releaseFrame;
 };
 
 


### PR DESCRIPTION
According to the documentation ( https://docs.microsoft.com/en-us/windows/win32/api/dxgi1_2/nf-dxgi1_2-idxgioutputduplication-releaseframe ) the method releaseFrame should be called before the method acquireNextFrame.