### PR TITLE
Fix screen grabbing zones coordinates when screen scaling is used

### DIFF
--- a/Software/grab/GrabberBase.cpp
+++ b/Software/grab/GrabberBase.cpp
@@ -23,6 +23,7 @@
  *
  */
 
+#include <QGuiApplication>
 #include "GrabberContext.hpp"
 #include "GrabWidget.hpp"
 #include "GrabberBase.hpp"
@@ -140,12 +141,14 @@ void GrabberBase::grab()
 		++grabScreensCount;
 		_context->grabResult->clear();
 
-		for (int i = 0; i < _context->grabWidgets->size(); ++i) {
-			if (!_context->grabWidgets->at(i)->isAreaEnabled()) {
+		for (GrabWidget* grabWidget: *_context->grabWidgets) {
+			if (!grabWidget->isAreaEnabled()) {
 				_context->grabResult->append(qRgb(0,0,0));
 				continue;
 			}
-			QRect widgetRect = _context->grabWidgets->at(i)->frameGeometry();
+			QRect widgetRect = grabWidget->frameGeometry();
+			const qreal scale = qApp->devicePixelRatio();
+			widgetRect = QRect(widgetRect.topLeft() * scale, widgetRect.size() * scale);
 			getValidRect(widgetRect);
 
 			const GrabbedScreen *grabbedScreen = screenOfRect(widgetRect);


### PR DESCRIPTION
When the app is running on a system which uses screen scaling factor other
than "1.0", then grabber widget logical coordinates will differ from physical
coordinates. Physical coordinates could be calculated by multiplying logical
coordinates to a device pixel ratio.