### PR TITLE
Do color blending after gamma correction and increase the resolution of color calculations to 16 bit

### DIFF
--- a/Software/grab/DDuplGrabber.cpp
+++ b/Software/grab/DDuplGrabber.cpp
@@ -43,8 +43,8 @@ _COM_SMARTPTR_TYPEDEF(ID3D11Texture2D, __uuidof(ID3D11Texture2D));
 _COM_SMARTPTR_TYPEDEF(ID3D11ShaderResourceView, __uuidof(ID3D11ShaderResourceView));
 
 
-typedef HRESULT(WINAPI* CreateDXGIFactory1Func)(REFIID riid, _Out_ void** ppFactory);
-typedef HRESULT(WINAPI* D3D11CreateDeviceFunc)(
+typedef HRESULT(WINAPI *CreateDXGIFactory1Func)(REFIID riid, _Out_ void **ppFactory);
+typedef HRESULT(WINAPI *D3D11CreateDeviceFunc)(
 	_In_opt_ IDXGIAdapter* pAdapter,
 	D3D_DRIVER_TYPE DriverType,
 	HMODULE Software,
@@ -79,16 +79,16 @@ struct DDuplScreenData
 		: output(_output), duplication(_duplication), device(_device), context(_context)
 	{}
 
-	IDXGIOutputPtr output{ nullptr };
-	IDXGIOutputDuplicationPtr duplication{ nullptr };
-	ID3D11DevicePtr device{ nullptr };
-	ID3D11DeviceContextPtr context{ nullptr };
+	IDXGIOutputPtr output{nullptr};
+	IDXGIOutputDuplicationPtr duplication{nullptr};
+	ID3D11DevicePtr device{nullptr};
+	ID3D11DeviceContextPtr context{nullptr};
 
-	ID3D11Texture2DPtr textureCopy{ nullptr };
+	ID3D11Texture2DPtr textureCopy{nullptr};
 	DXGI_MAPPED_RECT surfaceMap;
 };
 
-DDuplGrabber::DDuplGrabber(QObject* parent, GrabberContext* context)
+DDuplGrabber::DDuplGrabber(QObject * parent, GrabberContext *context)
 	: GrabberBase(parent, context),
 	m_state(Uninitialized),
 	m_accessDeniedLastCheck(0),
@@ -162,7 +162,6 @@ bool DDuplGrabber::init()
 	}
 
 	m_state = Ready;
-	m_releaseFrame = false;
 	return true;
 }
 
@@ -221,7 +220,7 @@ bool DDuplGrabber::runThreadCommand(DWORD timeout) {
 	}
 }
 
-bool anyWidgetOnThisMonitor(HMONITOR monitor, const QList<GrabWidget*>& grabWidgets)
+bool anyWidgetOnThisMonitor(HMONITOR monitor, const QList<GrabWidget *> &grabWidgets)
 {
 	for (GrabWidget* widget : grabWidgets)
 	{
@@ -235,12 +234,12 @@ bool anyWidgetOnThisMonitor(HMONITOR monitor, const QList<GrabWidget*>& grabWidg
 	return false;
 }
 
-QList< ScreenInfo >* DDuplGrabber::screensWithWidgets(QList< ScreenInfo >* result, const QList<GrabWidget*>& grabWidgets)
+QList< ScreenInfo > * DDuplGrabber::screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets)
 {
 	return __screensWithWidgets(result, grabWidgets);
 }
 
-QList< ScreenInfo >* DDuplGrabber::__screensWithWidgets(QList< ScreenInfo >* result, const QList<GrabWidget*>& grabWidgets, bool noRecursion)
+QList< ScreenInfo > * DDuplGrabber::__screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets, bool noRecursion)
 {
 	result->clear();
 
@@ -262,8 +261,7 @@ QList< ScreenInfo >* DDuplGrabber::__screensWithWidgets(QList< ScreenInfo >* res
 					qWarning() << Q_FUNC_INFO << "Found a monitor with NULL handle. Recreating adapters";
 					recreateAdapters();
 					return __screensWithWidgets(result, grabWidgets, true);
-				}
-				else {
+				} else {
 					qWarning() << Q_FUNC_INFO << "Found a monitor with NULL handle (after recreation)";
 					continue;
 				}
@@ -298,7 +296,7 @@ void DDuplGrabber::onSessionChange(int change)
 	}
 }
 
-bool DDuplGrabber::isReallocationNeeded(const QList< ScreenInfo >& grabScreens) const
+bool DDuplGrabber::isReallocationNeeded(const QList< ScreenInfo > &grabScreens) const
 {
 	if (m_state != Allocated)
 	{
@@ -352,7 +350,7 @@ void DDuplGrabber::freeScreens()
 	_screensWithWidgets.clear();
 }
 
-bool DDuplGrabber::reallocate(const QList< ScreenInfo >& grabScreens)
+bool DDuplGrabber::reallocate(const QList< ScreenInfo > &grabScreens)
 {
 	// Reallocate on the dedicated thread to be able to SetThreadDesktop to the currently active input desktop
 	// once the duplication is created, it seems like it can be used from the normal thread.
@@ -360,14 +358,13 @@ bool DDuplGrabber::reallocate(const QList< ScreenInfo >& grabScreens)
 	m_threadReallocateArg = grabScreens;
 	if (runThreadCommand(INFINITE)) {
 		return m_threadReallocateResult;
-	}
-	else {
+	} else {
 		return false;
 	}
 }
 
 // Must be called from DDuplGrabberThreadProc !
-bool DDuplGrabber::_reallocate(const QList< ScreenInfo >& grabScreens, bool noRecursion)
+bool DDuplGrabber::_reallocate(const QList< ScreenInfo > &grabScreens, bool noRecursion)
 {
 	if (m_state == Uninitialized)
 	{
@@ -387,8 +384,7 @@ bool DDuplGrabber::_reallocate(const QList< ScreenInfo >& grabScreens, bool noRe
 			m_accessDeniedLastCheck = GetTickCount();
 			qWarning(Q_FUNC_INFO " Access to input desktop denied, retry later");
 			return true;
-		}
-		else {
+		} else {
 			qCritical(Q_FUNC_INFO " Failed to open input desktop: %x", GetLastError());
 			return true;
 		}
@@ -453,8 +449,7 @@ bool DDuplGrabber::_reallocate(const QList< ScreenInfo >& grabScreens, bool noRe
 								return false;
 							}
 							return _reallocate(grabScreens, true);
-						}
-						else {
+						} else {
 							qCritical(Q_FUNC_INFO " Failed to reallocate: DXGI mode change in progress (after recreation)");
 							return false;
 						}
@@ -466,7 +461,7 @@ bool DDuplGrabber::_reallocate(const QList< ScreenInfo >& grabScreens, bool noRe
 					}
 
 					GrabbedScreen grabScreen;
-					grabScreen.imgData = (unsigned char*)NULL;
+					grabScreen.imgData = (unsigned char *)NULL;
 					grabScreen.imgFormat = BufferFormatArgb;
 					grabScreen.screenInfo = screenInfo;
 					grabScreen.scale = 1.0;
@@ -518,15 +513,15 @@ BufferFormat mapDXGIFormatToBufferFormat(DXGI_FORMAT format)
 {
 	switch (format)
 	{
-	case DXGI_FORMAT_B8G8R8A8_UNORM:
-	case DXGI_FORMAT_B8G8R8A8_TYPELESS:
-		return BufferFormatArgb;
-	case DXGI_FORMAT_R8G8B8A8_UINT:
-	case DXGI_FORMAT_R8G8B8A8_UNORM:
-	case DXGI_FORMAT_R8G8B8A8_TYPELESS:
-		return BufferFormatAbgr;
-	default:
-		return BufferFormatUnknown;
+		case DXGI_FORMAT_B8G8R8A8_UNORM:
+		case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+			return BufferFormatArgb;
+		case DXGI_FORMAT_R8G8B8A8_UINT:
+		case DXGI_FORMAT_R8G8B8A8_UNORM:
+		case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+			return BufferFormatAbgr;
+		default:
+			return BufferFormatUnknown;
 	}
 }
 
@@ -609,11 +604,6 @@ GrabResult DDuplGrabber::grabScreens()
 			DDuplScreenData* screenData = (DDuplScreenData*)screen.associatedData;
 			DXGI_OUTDUPL_FRAME_INFO frameInfo;
 			IDXGIResourcePtr resource;
-			if (m_releaseFrame)
-			{
-				screenData->duplication->ReleaseFrame();
-				m_releaseFrame = false;
-			}
 			HRESULT hr = screenData->duplication->AcquireNextFrame(ACQUIRE_TIMEOUT_INTERVAL, &frameInfo, &resource);
 			if (hr == DXGI_ERROR_WAIT_TIMEOUT)
 			{
@@ -637,7 +627,6 @@ GrabResult DDuplGrabber::grabScreens()
 				return GrabResultError;
 			}
 			anyUpdate = true;
-			m_releaseFrame = true;
 
 			ID3D11Texture2DPtr texture;
 			hr = resource->QueryInterface(IID_ID3D11Texture2D, (void**)&texture);
@@ -679,8 +668,7 @@ GrabResult DDuplGrabber::grabScreens()
 			// reset texture and data before getting new one
 			if (screenData->textureCopy) {
 				screenData->textureCopy = nullptr;
-			}
-			else if (screen.imgData) {
+			} else if (screen.imgData) {
 				free((void*)screen.imgData);
 			}
 
@@ -753,6 +741,7 @@ GrabResult DDuplGrabber::grabScreens()
 			screen.scale = 1.0 / (1 << DownscaleMipLevel);
 			screen.bytesPerRow = screenData->surfaceMap.Pitch;
 
+			screenData->duplication->ReleaseFrame();
 		}
 
 		if (!anyUpdate)

--- a/Software/grab/include/BlueLightReduction.hpp
+++ b/Software/grab/include/BlueLightReduction.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <QList>
 #include <QRgb>
+#include <QRgba64>
 #include <cassert>
 
 namespace BlueLightReduction
@@ -10,6 +11,7 @@ namespace BlueLightReduction
 	public:
 		static bool isSupported() { assert(("BlueLightReduction::isSupported() is not implemented", false)); return false; }
 		virtual void apply(QList<QRgb>& colors, const double gamma = 1.2) = 0;
+		virtual void apply(QList<QRgba64>& colors, const double gamma = 1.2) = 0;
 		virtual ~Client() = default;
 	};
 

--- a/Software/grab/include/DDuplGrabber.hpp
+++ b/Software/grab/include/DDuplGrabber.hpp
@@ -63,7 +63,7 @@ class DDuplGrabber : public GrabberBase
 {
 	Q_OBJECT
 public:
-	DDuplGrabber(QObject* parent, GrabberContext* context);
+	DDuplGrabber(QObject * parent, GrabberContext *context);
 	virtual ~DDuplGrabber();
 
 	DECLARE_GRABBER_NAME("DDuplGrabber")
@@ -73,13 +73,13 @@ public slots:
 
 protected slots:
 	virtual GrabResult grabScreens();
-	virtual bool reallocate(const QList< ScreenInfo >& grabScreens);
-	bool _reallocate(const QList< ScreenInfo >& grabScreens, bool noRecursion = false);
+	virtual bool reallocate(const QList< ScreenInfo > &grabScreens);
+	bool _reallocate(const QList< ScreenInfo > &grabScreens, bool noRecursion = false);
 
-	virtual QList< ScreenInfo >* screensWithWidgets(QList< ScreenInfo >* result, const QList<GrabWidget*>& grabWidgets);
-	QList< ScreenInfo >* __screensWithWidgets(QList< ScreenInfo >* result, const QList<GrabWidget*>& grabWidgets, bool noRecursion = false);
+	virtual QList< ScreenInfo > * screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets);
+	QList< ScreenInfo > * __screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets, bool noRecursion = false);
 
-	virtual bool isReallocationNeeded(const QList< ScreenInfo >& grabScreens) const;
+	virtual bool isReallocationNeeded(const QList< ScreenInfo > &grabScreens) const;
 
 protected:
 	bool init();
@@ -105,7 +105,6 @@ private:
 	QList<ScreenInfo> m_threadReallocateArg;
 	bool m_threadReallocateResult;
 	bool m_isSessionLocked;
-	bool m_releaseFrame;
 };
 
 

--- a/Software/grab/include/DDuplGrabber.hpp
+++ b/Software/grab/include/DDuplGrabber.hpp
@@ -63,7 +63,7 @@ class DDuplGrabber : public GrabberBase
 {
 	Q_OBJECT
 public:
-	DDuplGrabber(QObject * parent, GrabberContext *context);
+	DDuplGrabber(QObject* parent, GrabberContext* context);
 	virtual ~DDuplGrabber();
 
 	DECLARE_GRABBER_NAME("DDuplGrabber")
@@ -73,13 +73,13 @@ public slots:
 
 protected slots:
 	virtual GrabResult grabScreens();
-	virtual bool reallocate(const QList< ScreenInfo > &grabScreens);
-	bool _reallocate(const QList< ScreenInfo > &grabScreens, bool noRecursion = false);
+	virtual bool reallocate(const QList< ScreenInfo >& grabScreens);
+	bool _reallocate(const QList< ScreenInfo >& grabScreens, bool noRecursion = false);
 
-	virtual QList< ScreenInfo > * screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets);
-	QList< ScreenInfo > * __screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets, bool noRecursion = false);
+	virtual QList< ScreenInfo >* screensWithWidgets(QList< ScreenInfo >* result, const QList<GrabWidget*>& grabWidgets);
+	QList< ScreenInfo >* __screensWithWidgets(QList< ScreenInfo >* result, const QList<GrabWidget*>& grabWidgets, bool noRecursion = false);
 
-	virtual bool isReallocationNeeded(const QList< ScreenInfo > &grabScreens) const;
+	virtual bool isReallocationNeeded(const QList< ScreenInfo >& grabScreens) const;
 
 protected:
 	bool init();
@@ -105,6 +105,7 @@ private:
 	QList<ScreenInfo> m_threadReallocateArg;
 	bool m_threadReallocateResult;
 	bool m_isSessionLocked;
+	bool m_releaseFrame;
 };
 
 

--- a/Software/grab/include/GrabberBase.hpp
+++ b/Software/grab/include/GrabberBase.hpp
@@ -27,6 +27,7 @@
 
 #include <QSharedPointer>
 #include <QColor>
+#include <QRgba64>
 #include <QTimer>
 #include "src/GrabWidget.hpp"
 #include "calculations.hpp"
@@ -90,6 +91,7 @@ public:
 	virtual ~GrabberBase() {}
 
 	virtual const char * name() const = 0;
+	virtual void setGammaDecodeValue(double value);
 
 public slots:
 	virtual void startGrabbing();
@@ -124,6 +126,7 @@ protected slots:
 
 	virtual bool isReallocationNeeded(const QList< ScreenInfo > &grabScreens) const;
 
+
 protected:
 	const GrabbedScreen * screenOfRect(const QRect &rect) const;
 
@@ -141,4 +144,5 @@ protected:
 	int grabScreensCount;
 	QList<GrabbedScreen> _screensWithWidgets;
 	QScopedPointer<QTimer> m_timer;
+	quint16 gammaDecodeArray[256];
 };

--- a/Software/grab/include/GrabberContext.hpp
+++ b/Software/grab/include/GrabberContext.hpp
@@ -29,6 +29,7 @@
 
 #include <QList>
 #include <QRgb>
+#include <QRgba64>
 
 class GrabWidget;
 
@@ -96,7 +97,7 @@ public:
 	}
 public:
 	QList<GrabWidget *> *grabWidgets;
-	QList<QRgb> *grabResult;
+	QList<QRgba64> *grabResult;
 
 
 private:

--- a/Software/grab/include/WinUtils.hpp
+++ b/Software/grab/include/WinUtils.hpp
@@ -38,6 +38,7 @@
 #include <windows.h>
 #include <QList>
 #include <QRgb>
+#include <QRgba64>
 #include "BlueLightReduction.hpp"
 
 #if defined(NIGHTLIGHT_SUPPORT)
@@ -76,6 +77,7 @@ VOID FreeRestrictedSD(PVOID ptr);
 		NightLight();
 		~NightLight();
 		void apply(QList<QRgb>& colors, const double gamma);
+		void apply(QList<QRgba64>& colors, const double gamma);
 		static bool isSupported();
 	private:
 		NightLightLibrary::NightLightWrapper* _client;
@@ -87,11 +89,14 @@ VOID FreeRestrictedSD(PVOID ptr);
 		GammaRamp() = default;
 		~GammaRamp() = default;
 		void apply(QList<QRgb>& colors, const double/*gamma*/);
+		void apply(QList<QRgba64>& colors, const double/*gamma*/);
 		static bool isSupported();
 	private:
 		time_t _gammaAge = 0;
 		WORD _gammaArray[3][256];
+		WORD _gammaArray16[3][65536];
 		static bool loadGamma(LPVOID gamma, HDC* dc);
+		void interpolateGamma();
 	};
 }
 

--- a/Software/grab/include/calculations.hpp
+++ b/Software/grab/include/calculations.hpp
@@ -27,11 +27,13 @@
 
 #include <QRect>
 #include <QRgb>
+#include <QRgba64>
 #include <QList>
 #include "common/BufferFormat.h"
 
 namespace Grab {
 	namespace Calculations {
 		QRgb calculateAvgColor(const unsigned char * const buffer, BufferFormat bufferFormat, const size_t pitch, const QRect &rect);
+		QRgba64 calculateAvgColor(const unsigned char* const buffer, BufferFormat bufferFormat, const size_t pitch, const QRect& rect, const quint16* gamma);
 	}
 }

--- a/Software/math/PrismatikMath.cpp
+++ b/Software/math/PrismatikMath.cpp
@@ -50,9 +50,9 @@ namespace PrismatikMath
 
 	void gammaCorrection(double gamma, StructRgb & eRgb)
 	{
-		eRgb.r = 4095 * pow(eRgb.r / 4095.0, gamma);
-		eRgb.g = 4095 * pow(eRgb.g / 4095.0, gamma);
-		eRgb.b = 4095 * pow(eRgb.b / 4095.0, gamma);
+		eRgb.r = 65535 * pow(eRgb.r / 65535.0, gamma);
+		eRgb.g = 65535 * pow(eRgb.g / 65535.0, gamma);
+		eRgb.b = 65535 * pow(eRgb.b / 65535.0, gamma);
 	}
 
 	void brightnessCorrection(unsigned int brightness, StructRgb & eRgb) {
@@ -74,13 +74,24 @@ namespace PrismatikMath
 		gamma = 1.0 / gamma; // encoding
 		for (QRgb& color : colors)
 		{
-			quint8 r = ::pow((qRed(color)   * wp.r) / (double)USHRT_MAX, gamma) * UCHAR_MAX;
-			quint8 g = ::pow((qGreen(color) * wp.g) / (double)USHRT_MAX, gamma) * UCHAR_MAX;
-			quint8 b = ::pow((qBlue(color)  * wp.b) / (double)USHRT_MAX, gamma) * UCHAR_MAX;
+			quint8 r = ::pow(((double)qRed(color)   * wp.r) / (double)USHRT_MAX, gamma) * UCHAR_MAX;
+			quint8 g = ::pow(((double)qGreen(color) * wp.g) / (double)USHRT_MAX, gamma) * UCHAR_MAX;
+			quint8 b = ::pow(((double)qBlue(color)  * wp.b) / (double)USHRT_MAX, gamma) * UCHAR_MAX;
 			color = qRgb(r, g, b);
 		}
 	}
 
+	void applyColorTemperature(QList<QRgba64>& colors, const quint16 colorTemperature, double gamma) {
+		StructRgb wp = whitePoint(colorTemperature);
+		gamma = 1.0 / gamma; // encoding
+		for (QRgba64& color : colors)
+		{
+			quint16 r = ::pow(((double)color.red()   * wp.r) / (double)(65535 * 255), gamma) * 65535;
+			quint16 g = ::pow(((double)color.green() * wp.g) / (double)(65535 * 255), gamma) * 65535;
+			quint16 b = ::pow(((double)color.blue()  * wp.b) / (double)(65535 * 255), gamma) * 65535;
+			color = qRgba64(r, g, b, 0);
+		}
+	}
 
 	int getValueHSV(const QRgb rgb) {
 		return max(rgb);
@@ -194,10 +205,10 @@ namespace PrismatikMath
 	}
 
 	StructXyz toXyz(const StructRgb & rgb) {
-		//12bit RGB from 0 to 4095
-		double r = ( rgb.r / 4095.0 );
-		double g = ( rgb.g / 4095.0 );
-		double b = ( rgb.b / 4095.0 );
+		//16bit RGB from 0 to 65535
+		double r = ( rgb.r / 65535.0 );
+		double g = ( rgb.g / 65535.0);
+		double b = ( rgb.b / 65535.0);
 
 		if ( r > 0.04045 )
 			r = pow( (r + 0.055)/1.055, 2.4);
@@ -319,9 +330,9 @@ namespace PrismatikMath
 
 		StructRgb eRgb;
 
-		eRgb.r = round(r*4095);
-		eRgb.g = round(g*4095);
-		eRgb.b = round(b*4095);
+		eRgb.r = round(r * 65535);
+		eRgb.g = round(g * 65535);
+		eRgb.b = round(b * 65535);
 
 		return eRgb;
 	}

--- a/Software/math/include/PrismatikMath.hpp
+++ b/Software/math/include/PrismatikMath.hpp
@@ -27,6 +27,7 @@
 
 #include <QList>
 #include <QRgb>
+#include <QRgba64>
 #include <cmath>
 #include "colorspace_types.h"
 #include "../../common/defs.h"
@@ -43,6 +44,7 @@ namespace PrismatikMath
 	QRgb withValueHSV(const QRgb, int);
 	QRgb withChromaHSV(const QRgb, int);
 	void applyColorTemperature(QList<QRgb>&, const quint16, double gamma);
+	void applyColorTemperature(QList<QRgba64>&, const quint16, double gamma);
 	StructRgb whitePoint(const quint16 colorTemperature);
 	StructRgb avgColor(const QList<StructRgb> &);
 	StructXyz toXyz(const StructRgb &);

--- a/Software/math/include/colorspace_types.h
+++ b/Software/math/include/colorspace_types.h
@@ -28,10 +28,10 @@
 #define COLORSPACE_TYPES_H
 
 /*!
-	36bit RGB, 12 bit per channel!
+	48bit RGB, 16 bit per channel!
 	*/
 struct StructRgb {
-	unsigned r, g, b;
+	unsigned int r, g, b;
 	StructRgb() { r = g = b = 0;}
 };
 

--- a/Software/src/AbstractLedDevice.cpp
+++ b/Software/src/AbstractLedDevice.cpp
@@ -169,4 +169,33 @@ void AbstractLedDevice::applyColorModifications(const QList<QRgb> &inColors, QLi
 			color.b *= powerRatio;
 		}
 	}
+
+	double carryR = 0;
+	double carryG = 0;
+	double carryB = 0;
+
+	for (int i = 0; i < outColors.count(); ++i)	{
+		double tempR = outColors[i].r + carryR;
+		double tempG = outColors[i].g + carryG;
+		double tempB = outColors[i].b + carryB;
+
+		const constexpr double k = 4095 / 255.0;
+		const constexpr double kinv = 255.0 / 4095;
+
+		if ((tempR * kinv) > 255)	outColors[i].r = 255 << 4;
+		else if (tempR < 0)			outColors[i].r = 0;
+		else						outColors[i].r = (int)(tempR * kinv + 0.5) << 4;
+
+		if ((tempG * kinv) > 255)	outColors[i].g = 255 << 4;
+		else if (tempG < 0)			outColors[i].g = 0;
+		else						outColors[i].g = (int)(tempG * kinv + 0.5) << 4;
+
+		if ((tempB * kinv) > 255)	outColors[i].b = 255 << 4;
+		else if (tempB < 0) 		outColors[i].b = 0;
+		else						outColors[i].b = (int)(tempB * kinv + 0.5) << 4;
+
+		carryR = tempR - ((double)(outColors[i].r >> 4) * k);
+		carryG = tempG - ((double)(outColors[i].g >> 4) * k);
+		carryB = tempB - ((double)(outColors[i].b >> 4) * k);
+	}
 }

--- a/Software/src/AbstractLedDevice.cpp
+++ b/Software/src/AbstractLedDevice.cpp
@@ -100,24 +100,22 @@ void AbstractLedDevice::updateDeviceSettings()
 	All modifications are made over extended 12bit RGB, so \code outColors \endcode will contain 12bit
 	RGB instead of 8bit.
 */
-void AbstractLedDevice::applyColorModifications(const QList<QRgb> &inColors, QList<StructRgb> &outColors) {
+void AbstractLedDevice::applyColorModifications(const QList<QRgba64> &inColors, QList<StructRgb> &outColors) {
 
 	const bool isApplyWBAdjustments = m_wbAdjustments.count() == inColors.count();
 
 	for(int i = 0; i < inColors.count(); i++) {
 
-		//renormalize to 12bit
-		const constexpr double k = 4095/255.0;
-		outColors[i].r = qRed(inColors[i]) * k;
-		outColors[i].g = qGreen(inColors[i]) * k;
-		outColors[i].b = qBlue(inColors[i]) * k;
+		outColors[i].r = inColors[i].red();
+		outColors[i].g = inColors[i].green();
+		outColors[i].b = inColors[i].blue();
 
 		PrismatikMath::gammaCorrection(m_gamma, outColors[i]);
 	}
 
 	const StructLab avgColor = PrismatikMath::toLab(PrismatikMath::avgColor(outColors));
 
-	const double ampCoef = m_ledMilliAmps / (4095.0 * 3.0) / 1000.0;
+	const double ampCoef = m_ledMilliAmps / (65535.0 * 3.0) / 1000.0;
 	double estimatedTotalAmps = 0.0;
 
 	for (int i = 0; i < outColors.count(); ++i) {
@@ -150,7 +148,7 @@ void AbstractLedDevice::applyColorModifications(const QList<QRgb> &inColors, QLi
 			outColors[i].b *= m_wbAdjustments[i].blue;
 		}
 		if (m_brightnessCap < SettingsScope::Profile::Device::BrightnessCapMax) {
-			const double bcapFactor = (m_brightnessCap / 100.0 * 4095 * 3) / (outColors[i].r + outColors[i].g + outColors[i].b);
+			const double bcapFactor = (m_brightnessCap / 100.0 * 65535 * 3) / (outColors[i].r + outColors[i].g + outColors[i].b);
 			if (bcapFactor < 1.0) {
 				outColors[i].r *= bcapFactor;
 				outColors[i].g *= bcapFactor;
@@ -179,23 +177,23 @@ void AbstractLedDevice::applyColorModifications(const QList<QRgb> &inColors, QLi
 		double tempG = outColors[i].g + carryG;
 		double tempB = outColors[i].b + carryB;
 
-		const constexpr double k = 4095 / 255.0;
-		const constexpr double kinv = 255.0 / 4095;
+		const constexpr double k = 65535 / 255.0;
+		const constexpr double kinv = 255.0 / 65535;
 
-		if ((tempR * kinv) > 255)	outColors[i].r = 255 << 4;
+		if ((tempR * kinv) > 255)	outColors[i].r = 255 << 8;
 		else if (tempR < 0)			outColors[i].r = 0;
-		else						outColors[i].r = (int)(tempR * kinv + 0.5) << 4;
+		else						outColors[i].r = (int)(tempR * kinv + 0.5) << 8;
 
-		if ((tempG * kinv) > 255)	outColors[i].g = 255 << 4;
+		if ((tempG * kinv) > 255)	outColors[i].g = 255 << 8;
 		else if (tempG < 0)			outColors[i].g = 0;
-		else						outColors[i].g = (int)(tempG * kinv + 0.5) << 4;
+		else						outColors[i].g = (int)(tempG * kinv + 0.5) << 8;
 
-		if ((tempB * kinv) > 255)	outColors[i].b = 255 << 4;
+		if ((tempB * kinv) > 255)	outColors[i].b = 255 << 8;
 		else if (tempB < 0) 		outColors[i].b = 0;
-		else						outColors[i].b = (int)(tempB * kinv + 0.5) << 4;
+		else						outColors[i].b = (int)(tempB * kinv + 0.5) << 8;
 
-		carryR = tempR - ((double)(outColors[i].r >> 4) * k);
-		carryG = tempG - ((double)(outColors[i].g >> 4) * k);
-		carryB = tempB - ((double)(outColors[i].b >> 4) * k);
+		carryR = tempR - ((double)(outColors[i].r >> 8) * k);
+		carryG = tempG - ((double)(outColors[i].g >> 8) * k);
+		carryB = tempB - ((double)(outColors[i].b >> 8) * k);
 	}
 }

--- a/Software/src/AbstractLedDevice.hpp
+++ b/Software/src/AbstractLedDevice.hpp
@@ -53,13 +53,13 @@ signals:
 		\param ok is command completed successfully
 	*/
 	void commandCompleted(bool ok);
-	void colorsUpdated(QList<QRgb> colors);
+	void colorsUpdated(QList<QRgba64> colors);
 
 public slots:
 	virtual const QString name() const = 0;
 	virtual void open() = 0;
 	virtual void close() = 0;
-	virtual void setColors(const QList<QRgb> & colors) = 0;
+	virtual void setColors(const QList<QRgba64> & colors) = 0;
 	virtual void switchOffLeds() = 0;
 
 	/*!
@@ -95,7 +95,7 @@ public slots:
 	virtual void setUsbPowerLedDisabled(bool isDisabled) { Q_UNUSED(isDisabled) emit commandCompleted(true); };
 
 protected:
-	virtual void applyColorModifications(const QList<QRgb> & inColors, QList<StructRgb> & outColors);
+	virtual void applyColorModifications(const QList<QRgba64> & inColors, QList<StructRgb> & outColors);
 
 protected:
 	QString m_colorSequence;
@@ -109,6 +109,6 @@ protected:
 
 	QList<WBAdjustment> m_wbAdjustments;
 
-	QList<QRgb> m_colorsSaved;
+	QList<QRgba64> m_colorsSaved;
 	QList<StructRgb> m_colorsBuffer;
 };

--- a/Software/src/ApiServer.cpp
+++ b/Software/src/ApiServer.cpp
@@ -496,7 +496,7 @@ void ApiServer::clientProcessCommands()
 			API_DEBUG_OUT << CmdGetColors;
 			result = ApiServer::CmdResultGetColors;
 
-			QList<QRgb> curentColors = lightpack->GetColors();
+			QList<QRgba64> curentColors = lightpack->GetColors();
 
 			for (int i = 0; i < curentColors.count(); i++)
 			{

--- a/Software/src/GrabManager.hpp
+++ b/Software/src/GrabManager.hpp
@@ -45,7 +45,7 @@ public:
 	virtual ~GrabManager();
 
 signals:
-	void updateLedsColors(const QList<QRgb> & colors);
+	void updateLedsColors(const QList<QRgba64> & colors);
 	void ambilightTimeOfUpdatingColors(double ms);
 	void changeScreen();
 	void onSessionChange(int change);
@@ -80,6 +80,7 @@ public slots:
 	void setColoredLedWidgets(bool state);
 	void setWhiteLedWidgets(bool state);
 	void onGrabberStateChangeRequested(bool isStartRequested);
+	void onDeviceGammaChanged(double value);
 
 private slots:
 	void handleGrabbedColors();
@@ -96,6 +97,7 @@ private:
 	GrabberBase *queryGrabber(Grab::GrabberType grabber);
 	void initGrabbers();
 	GrabberBase *initGrabber(GrabberBase *grabber);
+	void calcGammaEncodeArray(double gamma);
 #ifdef D3D10_GRAB_SUPPORT
 	void reinitDx1011Grabber();
 #endif
@@ -119,12 +121,12 @@ private:
 	QTimer *m_timerFakeGrab;
 	QWidget *m_parentWidget;
 	QList<GrabWidget *> m_ledWidgets;
-	QList<QRgb> m_grabResult;
+	QList<QRgba64> m_grabResult;
 	const static QColor m_backgroundAndTextColors[10][2];
 
-	QList<QRgb> m_colorsCurrent;
-	QList<QRgb> m_colorsNew;
-	QList<QRgb> m_colorsProcessing;
+	QList<QRgba64> m_colorsCurrent;
+	QList<QRgba64> m_colorsNew;
+	QList<QRgba64> m_colorsProcessing;
 
 	QRect m_screenSavedRect;
 	int m_screenSavedIndex;
@@ -145,4 +147,6 @@ private:
 
 	bool m_isGrabWidgetsVisible;
 	GrabberContext * m_grabberContext;
+
+	quint16 m_gammaEncodeArray[65536];
 };

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -73,7 +73,7 @@ void LedDeviceAdalight::close()
 	m_AdalightDevice = NULL;
 }
 
-void LedDeviceAdalight::setColors(const QList<QRgb> & colors)
+void LedDeviceAdalight::setColors(const QList<QRgba64> & colors)
 {
 	// Save colors for showing changes of the brightness
 	m_colorsSaved = colors;
@@ -90,9 +90,9 @@ void LedDeviceAdalight::setColors(const QList<QRgb> & colors)
 	{
 		StructRgb color = m_colorsBuffer[i];
 
-		color.r = color.r >> 4;
-		color.g = color.g >> 4;
-		color.b = color.b >> 4;
+		color.r = color.r >> 8;
+		color.g = color.g >> 8;
+		color.b = color.b >> 8;
 
 		if (m_colorSequence == "RBG")
 		{
@@ -143,7 +143,7 @@ void LedDeviceAdalight::switchOffLeds()
 	m_colorsSaved.clear();
 
 	for (int i = 0; i < count; i++)
-		m_colorsSaved << 0;
+		m_colorsSaved << qRgba64(0);
 
 	m_writeBuffer.clear();
 	m_writeBuffer.append(m_writeBufferHeader);

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -86,28 +86,13 @@ void LedDeviceAdalight::setColors(const QList<QRgb> & colors)
 	m_writeBuffer.clear();
 	m_writeBuffer.append(m_writeBufferHeader);
 
-	double carryR = 0;
-	double carryG = 0;
-	double carryB = 0;
-
 	for (int i = 0; i < m_colorsBuffer.count(); i++)
 	{
 		StructRgb color = m_colorsBuffer[i];
 
-		double tempR = color.r + carryR;
-		double tempG = color.g + carryG;
-		double tempB = color.b + carryB;
-
-		const constexpr double k = 4095 / 255.0;
-		const constexpr double kinv = 255.0 / 4095;
-
-		color.r = ((tempR * kinv) > 255) ? 255 : (tempR * kinv);
-		color.g = ((tempG * kinv) > 255) ? 255 : (tempG * kinv);
-		color.b = ((tempB * kinv) > 255) ? 255 : (tempB * kinv);
-
-		carryR = tempR - ((double)color.r * k);
-		carryG = tempG - ((double)color.g * k);
-		carryB = tempB - ((double)color.b * k);
+		color.r = color.r >> 4;
+		color.g = color.g >> 4;
+		color.b = color.b >> 4;
 
 		if (m_colorSequence == "RBG")
 		{

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -86,13 +86,28 @@ void LedDeviceAdalight::setColors(const QList<QRgb> & colors)
 	m_writeBuffer.clear();
 	m_writeBuffer.append(m_writeBufferHeader);
 
+	double carryR = 0;
+	double carryG = 0;
+	double carryB = 0;
+
 	for (int i = 0; i < m_colorsBuffer.count(); i++)
 	{
 		StructRgb color = m_colorsBuffer[i];
 
-		color.r = color.r >> 4;
-		color.g = color.g >> 4;
-		color.b = color.b >> 4;
+		double tempR = color.r + carryR;
+		double tempG = color.g + carryG;
+		double tempB = color.b + carryB;
+
+		const constexpr double k = 4095 / 255.0;
+		const constexpr double kinv = 255.0 / 4095;
+
+		color.r = ((tempR * kinv) > 255) ? 255 : (tempR * kinv);
+		color.g = ((tempG * kinv) > 255) ? 255 : (tempG * kinv);
+		color.b = ((tempB * kinv) > 255) ? 255 : (tempB * kinv);
+
+		carryR = tempR - ((double)color.r * k);
+		carryG = tempG - ((double)color.g * k);
+		carryB = tempB - ((double)color.b * k);
 
 		if (m_colorSequence == "RBG")
 		{

--- a/Software/src/LedDeviceAdalight.hpp
+++ b/Software/src/LedDeviceAdalight.hpp
@@ -41,7 +41,7 @@ public slots:
 	const QString name() const { return "adalight"; }
 	void open();
 	void close();
-	void setColors(const QList<QRgb> & /*colors*/);
+	void setColors(const QList<QRgba64> & /*colors*/);
 	void switchOffLeds();
 	void setRefreshDelay(int /*value*/);
 	void setColorDepth(int /*value*/);

--- a/Software/src/LedDeviceAlienFx.cpp
+++ b/Software/src/LedDeviceAlienFx.cpp
@@ -105,7 +105,7 @@ LedDeviceAlienFx::~LedDeviceAlienFx()
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << "destroy LedDeviceAlienFx : ILedDevice complete";
 }
 
-void LedDeviceAlienFx::setColors(const QList<QRgb> & colors)
+void LedDeviceAlienFx::setColors(const QList<QRgba64> & colors)
 {
 	DEBUG_MID_LEVEL << Q_FUNC_INFO;
 	if (m_isInitialized)
@@ -141,8 +141,8 @@ void LedDeviceAlienFx::setColors(const QList<QRgb> & colors)
 void LedDeviceAlienFx::switchOffLeds()
 {
 	// TODO: fill it with current leds count
-	QList<QRgb> blackColor;
-	blackColor << 0;
+	QList<QRgba64> blackColor;
+	blackColor << qRgba64(0);
 	setColors(blackColor);
 }
 

--- a/Software/src/LedDeviceAlienFx.hpp
+++ b/Software/src/LedDeviceAlienFx.hpp
@@ -43,7 +43,7 @@ public slots:
 	const QString name() const { return "lightfx"; }
 	void open();
 	void close(){};
-	void setColors(const QList<QRgb> & colors);
+	void setColors(const QList<QRgba64> & colors);
 	void switchOffLeds();
 	void setRefreshDelay(int /*value*/);
 	void setColorDepth(int /*value*/);

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -76,10 +76,8 @@ void LedDeviceArdulight::close()
 	m_ArdulightDevice = NULL;
 }
 
-void LedDeviceArdulight::setColors(const QList<QRgb> & colors)
+void LedDeviceArdulight::setColors(const QList<QRgba64> & colors)
 {
-	DEBUG_MID_LEVEL << Q_FUNC_INFO << colors;
-
 	// Save colors for showing changes of the brightness
 	m_colorsSaved = colors;
 
@@ -88,9 +86,9 @@ void LedDeviceArdulight::setColors(const QList<QRgb> & colors)
 	applyColorModifications(colors, m_colorsBuffer);
 
 	for(int i=0; i < m_colorsBuffer.count(); i++) {
-		m_colorsBuffer[i].r = m_colorsBuffer[i].r >> 4;
-		m_colorsBuffer[i].g = m_colorsBuffer[i].g >> 4;
-		m_colorsBuffer[i].b = m_colorsBuffer[i].b >> 4;
+		m_colorsBuffer[i].r = m_colorsBuffer[i].r >> 8;
+		m_colorsBuffer[i].g = m_colorsBuffer[i].g >> 8;
+		m_colorsBuffer[i].b = m_colorsBuffer[i].b >> 8;
 		PrismatikMath::maxCorrection(254, m_colorsBuffer[i]);
 	}
 
@@ -150,7 +148,7 @@ void LedDeviceArdulight::switchOffLeds()
 	m_colorsSaved.clear();
 
 	for (int i = 0; i < count; i++)
-		m_colorsSaved << 0;
+		m_colorsSaved << qRgba64(0);
 
 	m_writeBuffer.clear();
 	m_writeBuffer.append(m_writeBufferHeader);

--- a/Software/src/LedDeviceArdulight.hpp
+++ b/Software/src/LedDeviceArdulight.hpp
@@ -41,7 +41,7 @@ public slots:
 	const QString name() const { return "ardulight"; }
 	void open();
 	void close();
-	void setColors(const QList<QRgb> & /*colors*/);
+	void setColors(const QList<QRgba64> & /*colors*/);
 	void switchOffLeds();
 	void setRefreshDelay(int /*value*/);
 	void setColorDepth(int /*value*/);

--- a/Software/src/LedDeviceDnrgb.cpp
+++ b/Software/src/LedDeviceDnrgb.cpp
@@ -41,7 +41,7 @@ int LedDeviceDnrgb::maxLedsCount()
 	return MaximumNumberOfLeds::Dnrgb;
 }
 
-void LedDeviceDnrgb::setColors(const QList<QRgb> & colors)
+void LedDeviceDnrgb::setColors(const QList<QRgba64> & colors)
 {
 	bool ok = true;
 
@@ -76,10 +76,10 @@ void LedDeviceDnrgb::setColors(const QList<QRgb> & colors)
 		{
 			StructRgb color = m_colorsBuffer[i];
 
-			// Reduce 12-bit colour information
-			color.r = color.r >> 4;
-			color.g = color.g >> 4;
-			color.b = color.b >> 4;
+			// Reduce 16-bit colour information
+			color.r = color.r >> 8;
+			color.g = color.g >> 8;
+			color.b = color.b >> 8;
 
 			m_writeBuffer.append(color.r);
 			m_writeBuffer.append(color.g);
@@ -100,7 +100,7 @@ void LedDeviceDnrgb::switchOffLeds()
 	m_colorsSaved.clear();
 
 	for (int i = 0; i < count; i++) {
-		m_colorsSaved << 0;
+		m_colorsSaved << qRgba64(0);
 	}
 
 	// Send multiple buffers

--- a/Software/src/LedDeviceDnrgb.hpp
+++ b/Software/src/LedDeviceDnrgb.hpp
@@ -36,7 +36,7 @@ public:
 
 public slots:
     const QString name() const;
-	void setColors(const QList<QRgb> & colors);
+	void setColors(const QList<QRgba64> & colors);
 	void switchOffLeds();
     void requestFirmwareVersion();
     int maxLedsCount();

--- a/Software/src/LedDeviceDrgb.cpp
+++ b/Software/src/LedDeviceDrgb.cpp
@@ -41,7 +41,7 @@ int LedDeviceDrgb::maxLedsCount()
 	return MaximumNumberOfLeds::Drgb;
 }
 
-void LedDeviceDrgb::setColors(const QList<QRgb> & colors)
+void LedDeviceDrgb::setColors(const QList<QRgba64> & colors)
 {
 	m_colorsSaved = colors;
 
@@ -56,10 +56,10 @@ void LedDeviceDrgb::setColors(const QList<QRgb> & colors)
 	{
 		StructRgb color = m_colorsBuffer[i];
 
-		// Reduce 12-bit colour information
-		color.r = color.r >> 4;
-		color.g = color.g >> 4;
-		color.b = color.b >> 4;
+		// Reduce 16-bit colour information
+		color.r = color.r >> 8;
+		color.g = color.g >> 8;
+		color.b = color.b >> 8;
 
 		m_writeBuffer.append(color.r);
 		m_writeBuffer.append(color.g);
@@ -76,7 +76,7 @@ void LedDeviceDrgb::switchOffLeds()
 	m_colorsSaved.clear();
 
 	for (int i = 0; i < count; i++) {
-		m_colorsSaved << 0;
+		m_colorsSaved << qRgba64(0);
 	}
 
 	m_writeBuffer.clear();

--- a/Software/src/LedDeviceDrgb.hpp
+++ b/Software/src/LedDeviceDrgb.hpp
@@ -36,7 +36,7 @@ public:
 
 public slots:
     const QString name() const;
-	void setColors(const QList<QRgb> & colors);
+	void setColors(const QList<QRgba64> & colors);
 	void switchOffLeds();
     void requestFirmwareVersion();
     int maxLedsCount();

--- a/Software/src/LedDeviceLightpack.cpp
+++ b/Software/src/LedDeviceLightpack.cpp
@@ -63,7 +63,7 @@ LedDeviceLightpack::~LedDeviceLightpack()
 	closeDevices();
 }
 
-void LedDeviceLightpack::setColors(const QList<QRgb> & colors)
+void LedDeviceLightpack::setColors(const QList<QRgba64> & colors)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
 	DEBUG_MID_LEVEL << Q_FUNC_INFO << Qt::hex << (colors.isEmpty() ? -1 : colors.first());
@@ -109,15 +109,15 @@ void LedDeviceLightpack::setColors(const QList<QRgb> & colors)
 		buffIndex = WRITE_BUFFER_INDEX_DATA_START + kLedRemap[i % 10] * kSizeOfLedColor;
 
 		// Send main 8 bits for compability with existing devices
-		m_writeBuffer[buffIndex++] = (color.r & 0x0FF0) >> 4;
-		m_writeBuffer[buffIndex++] = (color.g & 0x0FF0) >> 4;
-		m_writeBuffer[buffIndex++] = (color.b & 0x0FF0) >> 4;
+		m_writeBuffer[buffIndex++] = (color.r & 0xFF00) >> 8;
+		m_writeBuffer[buffIndex++] = (color.g & 0xFF00) >> 8;
+		m_writeBuffer[buffIndex++] = (color.b & 0xFF00) >> 8;
 
 		// Send over 4 bits for devices revision >= 6
 		// All existing devices ignore it
-		m_writeBuffer[buffIndex++] = (color.r & 0x000F);
-		m_writeBuffer[buffIndex++] = (color.g & 0x000F);
-		m_writeBuffer[buffIndex++] = (color.b & 0x000F);
+		m_writeBuffer[buffIndex++] = (color.r & 0x00F0) >> 4;
+		m_writeBuffer[buffIndex++] = (color.g & 0x00F0) >> 4;
+		m_writeBuffer[buffIndex++] = (color.b & 0x00F0) >> 4;
 
 		if ((i+1) % kLedsPerDevice == 0 || i == m_colorsBuffer.size() - 1) {
 			if (m_devices.empty() || !writeBufferToDeviceWithCheck(CMD_UPDATE_LEDS, m_devices[(i+kLedsPerDevice)/kLedsPerDevice - 1])) {
@@ -149,7 +149,7 @@ void LedDeviceLightpack::switchOffLeds()
 	if (m_colorsSaved.empty())
 	{
 		for (size_t i = 0; i < maxLedsCount(); ++i)
-			m_colorsSaved << 0;
+			m_colorsSaved << qRgba64(0);
 	} else {
 		for (int i = 0; i < m_colorsSaved.count(); i++)
 			m_colorsSaved[i] = 0;

--- a/Software/src/LedDeviceLightpack.hpp
+++ b/Software/src/LedDeviceLightpack.hpp
@@ -53,7 +53,7 @@ public slots:
 	virtual const QString name() const { return "lightpack"; }
 	virtual void open();
 	virtual void close();
-	virtual void setColors(const QList<QRgb> & colors);
+	virtual void setColors(const QList<QRgba64> & colors);
 	virtual void switchOffLeds();
 	virtual void setUsbPowerLedDisabled(bool isDisabled);
 	virtual void setRefreshDelay(int value);

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -118,7 +118,7 @@ void LedDeviceManager::switchOnLeds()
 		emit ledDeviceSetColors(m_savedColors);
 }
 
-void LedDeviceManager::setColors(const QList<QRgb> & colors)
+void LedDeviceManager::setColors(const QList<QRgba64> & colors)
 {
 	DEBUG_HIGH_LEVEL << Q_FUNC_INFO << "Is last command completed:" << m_isLastCommandCompleted
 					<< " m_backlightStatus = " << m_backlightStatus;
@@ -528,10 +528,10 @@ void LedDeviceManager::connectSignalSlotsLedDevice()
 
 	connect(m_ledDevice, SIGNAL(firmwareVersion(QString)),			this, SIGNAL(firmwareVersion(QString)),						Qt::QueuedConnection);
 	connect(m_ledDevice, SIGNAL(firmwareVersionUnofficial(int)),	this, SIGNAL(firmwareVersionUnofficial(int)),				Qt::QueuedConnection);
-	connect(m_ledDevice, SIGNAL(colorsUpdated(QList<QRgb>)),		this, SIGNAL(setColors_VirtualDeviceCallback(QList<QRgb>)),	Qt::QueuedConnection);
+	connect(m_ledDevice, SIGNAL(colorsUpdated(QList<QRgba64>)),		this, SIGNAL(setColors_VirtualDeviceCallback(QList<QRgba64>)),	Qt::QueuedConnection);
 
 	connect(this, SIGNAL(ledDeviceOpen()),								m_ledDevice, SLOT(open()),										Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetColors(QList<QRgb>)),				m_ledDevice, SLOT(setColors(QList<QRgb>)),						Qt::QueuedConnection);
+	connect(this, SIGNAL(ledDeviceSetColors(QList<QRgba64>)),			m_ledDevice, SLOT(setColors(QList<QRgba64>)),				Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceOffLeds()),							m_ledDevice, SLOT(switchOffLeds()),								Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceSetUsbPowerLedDisabled(bool)),		m_ledDevice, SLOT(setUsbPowerLedDisabled(bool)),				Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceSetRefreshDelay(int)),				m_ledDevice, SLOT(setRefreshDelay(int)),						Qt::QueuedConnection);
@@ -562,10 +562,10 @@ void LedDeviceManager::disconnectSignalSlotsLedDevice()
 
 	disconnect(m_ledDevice, SIGNAL(firmwareVersion(QString)),		this, SIGNAL(firmwareVersion(QString)));
 	disconnect(m_ledDevice, SIGNAL(firmwareVersionUnofficial(int)), this, SIGNAL(firmwareVersionUnofficial(int)));
-	disconnect(m_ledDevice, SIGNAL(colorsUpdated(QList<QRgb>)),		this, SIGNAL(setColors_VirtualDeviceCallback(QList<QRgb>)));
+	disconnect(m_ledDevice, SIGNAL(colorsUpdated(QList<QRgba64>)),		this, SIGNAL(setColors_VirtualDeviceCallback(QList<QRgba64>)));
 
 	disconnect(this, SIGNAL(ledDeviceOpen()),								m_ledDevice, SLOT(open()));
-	disconnect(this, SIGNAL(ledDeviceSetColors(QList<QRgb>)),				m_ledDevice, SLOT(setColors(QList<QRgb>)));
+	disconnect(this, SIGNAL(ledDeviceSetColors(QList<QRgba64>)),			m_ledDevice, SLOT(setColors(QList<QRgba64>)));
 	disconnect(this, SIGNAL(ledDeviceOffLeds()),							m_ledDevice, SLOT(switchOffLeds()));
 	disconnect(this, SIGNAL(ledDeviceSetUsbPowerLedDisabled(bool)),			m_ledDevice, SLOT(setUsbPowerLedDisabled(bool)));
 	disconnect(this, SIGNAL(ledDeviceSetRefreshDelay(int)),					m_ledDevice, SLOT(setRefreshDelay(int)));

--- a/Software/src/LedDeviceManager.hpp
+++ b/Software/src/LedDeviceManager.hpp
@@ -48,11 +48,11 @@ signals:
 	void ioDeviceSuccess(bool isSuccess);
 	void firmwareVersion(const QString & fwVersion);
 	void firmwareVersionUnofficial(const int version);
-	void setColors_VirtualDeviceCallback(const QList<QRgb> & colors);
+	void setColors_VirtualDeviceCallback(const QList<QRgba64> & colors);
 
 	// This signals are directly connected to ILedDevice. Don't use outside.
 	void ledDeviceOpen();
-	void ledDeviceSetColors(const QList<QRgb> & colors);
+	void ledDeviceSetColors(const QList<QRgba64> & colors);
 	void ledDeviceOffLeds();
 	void ledDeviceSetUsbPowerLedDisabled(bool isDisabled);
 	void ledDeviceSetRefreshDelay(int value);
@@ -74,7 +74,7 @@ public slots:
 	void recreateLedDevice();
 
 	// This slots are protected from the overflow of queries
-	void setColors(const QList<QRgb> & colors);
+	void setColors(const QList<QRgba64> & colors);
 	void switchOffLeds();
 	void switchOnLeds();
 	void setUsbPowerLedDisabled(bool isDisabled);
@@ -114,7 +114,7 @@ private:
 
 	QList<LedDeviceCommands::Cmd> m_cmdQueue;
 
-	QList<QRgb> m_savedColors;
+	QList<QRgba64> m_savedColors;
 	bool m_savedUsbPowerLedDisabled;
 	int m_savedRefreshDelay;
 	int m_savedColorDepth;

--- a/Software/src/LedDeviceVirtual.cpp
+++ b/Software/src/LedDeviceVirtual.cpp
@@ -40,13 +40,13 @@ LedDeviceVirtual::LedDeviceVirtual(QObject * parent) : AbstractLedDevice(parent)
 	m_brightness = Settings::getDeviceBrightness();
 }
 
-void LedDeviceVirtual::setColors(const QList<QRgb> & colors)
+void LedDeviceVirtual::setColors(const QList<QRgba64> & colors)
 {
 	if(colors.size()> 0)
 	{
 		m_colorsSaved = colors;
 
-		QList<QRgb> callbackColors;
+		QList<QRgba64> callbackColors;
 
 		resizeColorsBuffer(colors.count());
 
@@ -54,7 +54,7 @@ void LedDeviceVirtual::setColors(const QList<QRgb> & colors)
 
 		for (int i = 0; i < m_colorsBuffer.count(); i++)
 		{
-			callbackColors.append(qRgb(m_colorsBuffer[i].r>>4, m_colorsBuffer[i].g>>4, m_colorsBuffer[i].b>>4));
+			callbackColors.append(qRgba64(m_colorsBuffer[i].r<<4, m_colorsBuffer[i].g<<4, m_colorsBuffer[i].b<<4, 0));
 		}
 
 		emit colorsUpdated(callbackColors);
@@ -68,7 +68,7 @@ void LedDeviceVirtual::switchOffLeds()
 	m_colorsSaved.clear();
 
 	for (int i = 0; i < count; i++) {
-		m_colorsSaved << 0;
+		m_colorsSaved << qRgba64(0);
 	}
 	emit colorsUpdated(m_colorsSaved);
 	emit commandCompleted(true);

--- a/Software/src/LedDeviceVirtual.hpp
+++ b/Software/src/LedDeviceVirtual.hpp
@@ -40,7 +40,7 @@ public slots:
 	const QString name() const { return "virtual"; }
 	void open();
 	void close(){}
-	void setColors(const QList<QRgb> & colors);
+	void setColors(const QList<QRgba64> & colors);
 	void switchOffLeds();
 	void setRefreshDelay(int /*value*/);
 	void setColorDepth(int /*value*/);

--- a/Software/src/LedDeviceWarls.cpp
+++ b/Software/src/LedDeviceWarls.cpp
@@ -41,7 +41,7 @@ int LedDeviceWarls::maxLedsCount()
 	return MaximumNumberOfLeds::Warls;
 }
 
-void LedDeviceWarls::setColors(const QList<QRgb> & colors)
+void LedDeviceWarls::setColors(const QList<QRgba64> & colors)
 {
 	resizeColorsBuffer(colors.count());
 
@@ -56,10 +56,10 @@ void LedDeviceWarls::setColors(const QList<QRgb> & colors)
 		{
 			StructRgb color = m_colorsBuffer[i];
 
-			// Reduce 12-bit colour information
-			color.r = color.r >> 4;
-			color.g = color.g >> 4;
-			color.b = color.b >> 4;
+			// Reduce 16-bit colour information
+			color.r = color.r >> 8;
+			color.g = color.g >> 8;
+			color.b = color.b >> 8;
 
 			m_writeBuffer.append(i);
 			m_writeBuffer.append(color.r);
@@ -81,7 +81,7 @@ void LedDeviceWarls::switchOffLeds()
 	m_colorsSaved.clear();
 
 	for (int i = 0; i < count; i++) {
-		m_colorsSaved << 0;
+		m_colorsSaved << qRgba64(0);
 	}
 
 	m_writeBuffer.clear();
@@ -122,7 +122,7 @@ void LedDeviceWarls::resizeColorsBuffer(int buffSize)
 	for (int i = 0; i < buffSize; i++)
 	{
 		m_colorsBuffer << StructRgb();
-		m_colorsSaved << 0;
+		m_colorsSaved << qRgba64(0);
 	}
 
 	reinitBufferHeader();

--- a/Software/src/LedDeviceWarls.hpp
+++ b/Software/src/LedDeviceWarls.hpp
@@ -36,7 +36,7 @@ public:
 
 public slots:
     const QString name() const;
-	void setColors(const QList<QRgb> & colors);
+	void setColors(const QList<QRgba64> & colors);
 	void switchOffLeds();
     void requestFirmwareVersion();
     int maxLedsCount();

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -145,6 +145,7 @@ void LightpackApplication::initializeAll(const QString & appDirPath)
 	}
 	// Register QMetaType for Qt::QueuedConnection
 	qRegisterMetaType< QList<QRgb> >("QList<QRgb>");
+	qRegisterMetaType< QList<QRgba64> >("QList<QRgba64>");
 	qRegisterMetaType< QList<QString> >("QList<QString>");
 	qRegisterMetaType<Lightpack::Mode>("Lightpack::Mode");
 	qRegisterMetaType<Backlight::Status>("Backlight::Status");
@@ -588,7 +589,7 @@ void LightpackApplication::startApiServer()
 		connect(m_apiServer, SIGNAL(errorOnStartListening(QString)), m_settingsWindow, SLOT(onApiServer_ErrorOnStartListening(QString)));
 	}
 
-	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetColors(const QList<QRgb> &)),	m_pluginInterface, SLOT(updateColorsCache(const QList<QRgb> &)),	Qt::QueuedConnection);
+	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetColors(const QList<QRgba64> &)),	m_pluginInterface, SLOT(updateColorsCache(const QList<QRgba64> &)),	Qt::QueuedConnection);
 	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetSmoothSlowdown(int)),			m_pluginInterface, SLOT(updateSmoothCache(int)),					Qt::QueuedConnection);
 	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetGamma(double)),					m_pluginInterface, SLOT(updateGammaCache(double)),					Qt::QueuedConnection);
 	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetBrightness(int)),				m_pluginInterface, SLOT(updateBrightnessCache(int)),				Qt::QueuedConnection);
@@ -614,11 +615,11 @@ void LightpackApplication::startLedDeviceManager()
 //	connect(settings(), SIGNAL(connectedDeviceChanged(const SupportedDevices::DeviceType)), this, SLOT(handleConnectedDeviceChange(const SupportedDevices::DeviceType)), Qt::DirectConnection);
 //	connect(settings(), SIGNAL(adalightSerialPortNameChanged(QString)),				m_ledDeviceManager, SLOT(recreateLedDevice()), Qt::DirectConnection);
 //	connect(settings(), SIGNAL(adalightSerialPortBaudRateChanged(QString)),			m_ledDeviceManager, SLOT(recreateLedDevice()), Qt::DirectConnection);
-//	connect(m_settingsWindow, SIGNAL(updateLedsColors(const QList<QRgb> &)),			m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+//	connect(m_settingsWindow, SIGNAL(updateLedsColors(const QList<QRgba64> &)),			m_ledDeviceManager, SLOT(setColors(QList<QRgba64>)), Qt::QueuedConnection);
 	m_pluginInterface = new LightpackPluginInterface(NULL);
 
 	connect(m_pluginInterface, SIGNAL(updateDeviceLockStatus(DeviceLocked::DeviceLockStatus, QList<QString>)), this, SLOT(setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus, QList<QString>)));
-	connect(m_pluginInterface, SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+	connect(m_pluginInterface, SIGNAL(updateLedsColors(const QList<QRgba64> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgba64>)), Qt::QueuedConnection);
 	connect(m_pluginInterface, SIGNAL(updateGamma(double)),		m_ledDeviceManager, SLOT(setGamma(double)),		Qt::QueuedConnection);
 	connect(m_pluginInterface, SIGNAL(updateBrightness(int)),	m_ledDeviceManager, SLOT(setBrightness(int)),		Qt::QueuedConnection);
 	connect(m_pluginInterface, SIGNAL(updateSmooth(int)),		m_ledDeviceManager, SLOT(setSmoothSlowdown(int)), Qt::QueuedConnection);
@@ -630,7 +631,7 @@ void LightpackApplication::startLedDeviceManager()
 
 	if (!m_noGui)
 	{
-		connect(m_pluginInterface, SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_settingsWindow, SLOT(updateVirtualLedsColors(QList<QRgb>)));
+		connect(m_pluginInterface, SIGNAL(updateLedsColors(const QList<QRgba64> &)),	m_settingsWindow, SLOT(updateVirtualLedsColors(QList<QRgba64>)));
 		connect(m_pluginInterface, SIGNAL(updateDeviceLockStatus(DeviceLocked::DeviceLockStatus, QList<QString>)), m_settingsWindow, SLOT(setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus, QList<QString>)));
 		connect(m_pluginInterface, SIGNAL(updateProfile(QString)),						m_settingsWindow, SLOT(profileSwitch(QString)));
 		connect(m_pluginInterface, SIGNAL(updateStatus(Backlight::Status)),				m_settingsWindow, SLOT(setBacklightStatus(Backlight::Status)));
@@ -664,7 +665,7 @@ void LightpackApplication::startLedDeviceManager()
 		connect(m_ledDeviceManager, SIGNAL(ioDeviceSuccess(bool)),			m_settingsWindow,	SLOT(ledDeviceCallSuccess(bool)),						Qt::QueuedConnection);
 		connect(m_ledDeviceManager, SIGNAL(firmwareVersion(QString)),		m_settingsWindow,	SLOT(ledDeviceFirmwareVersionResult(QString)),			Qt::QueuedConnection);
 		connect(m_ledDeviceManager, SIGNAL(firmwareVersionUnofficial(int)), m_settingsWindow,	SLOT(ledDeviceFirmwareVersionUnofficialResult(int)),	Qt::QueuedConnection);
-		connect(m_ledDeviceManager, SIGNAL(setColors_VirtualDeviceCallback(QList<QRgb>)), m_settingsWindow, SLOT(updateVirtualLedsColors(QList<QRgb>)), Qt::QueuedConnection);
+		connect(m_ledDeviceManager, SIGNAL(setColors_VirtualDeviceCallback(QList<QRgba64>)), m_settingsWindow, SLOT(updateVirtualLedsColors(QList<QRgba64>)), Qt::QueuedConnection);
 	}
 	m_ledDeviceManager->moveToThread(m_ledDeviceManagerThread);
 	m_ledDeviceManagerThread->start();
@@ -719,6 +720,7 @@ void LightpackApplication::initGrabManager()
 	connect(settings(), SIGNAL(grabApplyColorTemperatureChanged(bool)),         m_grabManager,      SLOT(onGrabApplyColorTemperatureChanged(bool)),           Qt::QueuedConnection);
 	connect(settings(), SIGNAL(grabColorTemperatureChanged(int)),               m_grabManager,      SLOT(onGrabColorTemperatureChanged(int)),                 Qt::QueuedConnection);
 	connect(settings(), SIGNAL(grabGammaChanged(double)),                       m_grabManager,      SLOT(onGrabGammaChanged(double)),                         Qt::QueuedConnection);
+	connect(settings(), SIGNAL(deviceGammaChanged(double)),						m_grabManager,		SLOT(onDeviceGammaChanged(double)),						Qt::QueuedConnection);
 	connect(settings(), SIGNAL(sendDataOnlyIfColorsChangesChanged(bool)),		m_grabManager,		SLOT(onSendDataOnlyIfColorsEnabledChanged(bool)),		Qt::QueuedConnection);
 #ifdef D3D10_GRAB_SUPPORT
 	connect(settings(), SIGNAL(dx1011GrabberEnabledChanged(bool)),				m_grabManager,		SLOT(onDx1011GrabberEnabledChanged(bool)),				Qt::QueuedConnection);
@@ -781,15 +783,15 @@ void LightpackApplication::initGrabManager()
 
 	connect(m_grabManager, SIGNAL(ambilightTimeOfUpdatingColors(double)), m_pluginInterface, SLOT(refreshAmbilightEvaluated(double)));
 
-	connect(m_grabManager,		SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
-	connect(m_moodlampManager,	SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+	connect(m_grabManager,		SIGNAL(updateLedsColors(const QList<QRgba64> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgba64>)), Qt::QueuedConnection);
+	connect(m_moodlampManager,	SIGNAL(updateLedsColors(const QList<QRgba64> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgba64>)), Qt::QueuedConnection);
 	if (!m_noGui && m_settingsWindow)
 		connect(m_moodlampManager,	SIGNAL(moodlampFrametime(const double)),		m_settingsWindow, 	SLOT(refreshAmbilightEvaluated(double)), Qt::QueuedConnection);
 	connect(m_ledDeviceManager,	SIGNAL(openDeviceSuccess(bool)),				m_grabManager,		SLOT(ledDeviceOpenSuccess(bool)), Qt::QueuedConnection);
 	connect(m_ledDeviceManager,	SIGNAL(ioDeviceSuccess(bool)),					m_grabManager,		SLOT(ledDeviceCallSuccess(bool)), Qt::QueuedConnection);
 #ifdef SOUNDVIZ_SUPPORT
 	if (m_soundManager) {
-		connect(m_soundManager,		SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+		connect(m_soundManager,		SIGNAL(updateLedsColors(const QList<QRgba64> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgba64>)), Qt::QueuedConnection);
 		if (!m_noGui && m_settingsWindow)
 			connect(m_soundManager,		SIGNAL(visualizerFrametime(const double)),	m_settingsWindow, SLOT(refreshAmbilightEvaluated(double)), Qt::QueuedConnection);
 	}
@@ -805,8 +807,8 @@ void LightpackApplication::commitData(QSessionManager &sessionManager)
 	if (m_ledDeviceManager != NULL)
 	{
 		// Disable signals with new colors
-		disconnect(m_settingsWindow, SIGNAL(updateLedsColors(QList<QRgb>)), m_ledDeviceManager, SLOT(setColors(QList<QRgb>)));
-		disconnect(m_apiServer, SIGNAL(updateLedsColors(QList<QRgb>)), m_ledDeviceManager, SLOT(setColors(QList<QRgb>)));
+		disconnect(m_settingsWindow, SIGNAL(updateLedsColors(QList<QRgba64>)), m_ledDeviceManager, SLOT(setColors(QList<QRgba64>)));
+		disconnect(m_apiServer, SIGNAL(updateLedsColors(QList<QRgba64>)), m_ledDeviceManager, SLOT(setColors(QList<QRgba64>)));
 
 		// Process all currently pending signals
 		QApplication::processEvents(QEventLoop::AllEvents, 1000);

--- a/Software/src/LightpackPluginInterface.cpp
+++ b/Software/src/LightpackPluginInterface.cpp
@@ -101,8 +101,8 @@ void LightpackPluginInterface::initColors(int numberOfLeds)
 	m_setColors.clear();
 	for (int i = 0; i < numberOfLeds; i++)
 	{
-		m_setColors << 0;
-		m_curColors << 0;
+		m_setColors << qRgba64(0);
+		m_curColors << qRgba64(0);
 	}
 }
 
@@ -157,7 +157,7 @@ void LightpackPluginInterface::refreshScreenRect(QRect rect)
 	screen = rect;
 }
 
-void LightpackPluginInterface::updateColorsCache(const QList<QRgb> & colors)
+void LightpackPluginInterface::updateColorsCache(const QList<QRgba64> & colors)
 {
 	DEBUG_HIGH_LEVEL << Q_FUNC_INFO;
 	m_curColors = colors;
@@ -328,7 +328,7 @@ bool LightpackPluginInterface::SetColors(QString sessionKey, int r, int g, int b
 		lockAlive = true;
 	for (int i = 0; i < m_setColors.size(); i++)
 	{
-			m_setColors[i] = qRgb(r,g,b);
+		m_setColors[i] = qRgba64(r * 257, g * 257, b * 257, 0);
 	}
 	m_curColors = m_setColors;
 	emit updateLedsColors(m_setColors);
@@ -641,7 +641,7 @@ QList<QRect> LightpackPluginInterface::GetLeds()
 	return leds;
 }
 
-QList<QRgb> LightpackPluginInterface::GetColors()
+QList<QRgba64> LightpackPluginInterface::GetColors()
 {
 	return m_curColors;
 }

--- a/Software/src/LightpackPluginInterface.hpp
+++ b/Software/src/LightpackPluginInterface.hpp
@@ -51,7 +51,7 @@ public:
 	QStringList GetProfiles();
 	QString GetProfile();
 	QList<QRect> GetLeds();
-	QList<QRgb> GetColors();
+	QList<QRgba64> GetColors();
 	double GetFPS();
 	QRect GetScreenSize();
 	int GetBacklight();
@@ -84,7 +84,7 @@ signals:
 signals:
 	void requestBacklightStatus();
 	void updateDeviceLockStatus(DeviceLocked::DeviceLockStatus status, QList<QString> modules);
-	void updateLedsColors(const QList<QRgb> & colors);
+	void updateLedsColors(const QList<QRgba64> & colors);
 	void updateGamma(double value);
 	void updateBrightness(int value);
 	void updateSmooth(int value);
@@ -106,7 +106,7 @@ public slots:
 	void changeProfile(QString profile);
 	void refreshAmbilightEvaluated(double updateResultMs);
 	void refreshScreenRect(QRect rect);
-	void updateColorsCache(const QList<QRgb> & colors);
+	void updateColorsCache(const QList<QRgba64> & colors);
 	void updateGammaCache(double value);
 	void updateBrightnessCache(int value);
 	void updateSmoothCache(int value);
@@ -132,8 +132,8 @@ private:
 	QRect screen;
 
 	QList<QString> lockSessionKeys;
-	QList<QRgb> m_setColors;
-	QList<QRgb> m_curColors;
+	QList<QRgba64> m_setColors;
+	QList<QRgba64> m_curColors;
 	QTimer *m_timerLock;
 
 	double m_gamma;

--- a/Software/src/MoodLamp.cpp
+++ b/Software/src/MoodLamp.cpp
@@ -115,12 +115,12 @@ DECLARE_LAMP(Static, "Static (default)",
 public:
 	int interval() const { return 50; };
 
-	bool shine(const QColor& newColor, QList<QRgb>& colors)
+	bool shine(const QColor& newColor, QList<QRgba64>& colors)
 	{
 		bool changed = false;
 		for (int i = 0; i < colors.size(); i++)
 		{
-			QRgb rgb = Settings::isLedEnabled(i) ? newColor.rgb() : 0;
+			QRgba64 rgb = Settings::isLedEnabled(i) ? newColor.rgba64() : qRgba64(0);
 			changed = changed || (colors[i] != rgb);
 			colors[i] = rgb;
 		}
@@ -134,7 +134,7 @@ public:
 		m_rnd.seed(QTime(0, 0, 0).secsTo(QTime::currentTime()));
 	};
 
-	bool shine(const QColor& newColor, QList<QRgb>& colors) {
+	bool shine(const QColor& newColor, QList<QRgba64>& colors) {
 		if (colors.size() < 2)
 			return false;
 
@@ -189,7 +189,7 @@ public:
 		{
 			QColor color(newColor);
 			color.setHsl(color.hue(), color.saturation(), m_lightness[i]);
-			colors[i] = Settings::isLedEnabled(i) ? color.rgb() : 0;
+			colors[i] = Settings::isLedEnabled(i) ? color.rgba64() : qRgba64(0);
 		}
 		return true;
 	};
@@ -205,7 +205,7 @@ private:
 
 DECLARE_LAMP(RGBLife, "RGB is Life",
 public:
-	bool shine(const QColor& newColor, QList<QRgb>& colors)
+	bool shine(const QColor& newColor, QList<QRgba64>& colors)
 	{
 		bool changed = false;
 		const int degrees = 360 / colors.size();
@@ -214,7 +214,7 @@ public:
 		{
 			QColor color(newColor);
 			color.setHsl(color.hue() + degrees * i + step, color.saturation(), color.lightness());
-			QRgb rgb = Settings::isLedEnabled(i) ? color.rgb() : 0;
+			QRgba64 rgb = Settings::isLedEnabled(i) ? color.rgba64() : qRgba64(0);
 			changed = changed || (colors[i] != rgb);
 			colors[i] = rgb;
 		}

--- a/Software/src/MoodLamp.hpp
+++ b/Software/src/MoodLamp.hpp
@@ -27,6 +27,7 @@
 
 #include <QObject>
 #include <QColor>
+#include <QRgba64>
 
 class MoodLampBase;
 
@@ -54,7 +55,7 @@ public:
 
 	virtual void init() {};
 	virtual int interval() const { return DefaultInterval; };
-	virtual bool shine(const QColor& newColor, QList<QRgb>& colors) = 0;
+	virtual bool shine(const QColor& newColor, QList<QRgba64>& colors) = 0;
 protected:
 	size_t m_frames{ 0 };
 private:

--- a/Software/src/MoodLampManager.cpp
+++ b/Software/src/MoodLampManager.cpp
@@ -190,7 +190,7 @@ void MoodLampManager::initColors(int numberOfLeds)
 	m_colors.clear();
 
 	for (int i = 0; i < numberOfLeds; i++)
-		m_colors << 0;
+		m_colors << qRgba64(0);
 }
 
 void MoodLampManager::requestLampList()

--- a/Software/src/MoodLampManager.hpp
+++ b/Software/src/MoodLampManager.hpp
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <QObject>
-#include <QColor>
+#include <QRgba64>
 #include <QTimer>
 #include <QElapsedTimer>
 #include "LiquidColorGenerator.hpp"
@@ -40,7 +40,7 @@ public:
 	~MoodLampManager();
 
 signals:
-	void updateLedsColors(const QList<QRgb> & colors);
+	void updateLedsColors(const QList<QRgba64> & colors);
 	void lampList(const QList<MoodLampLampInfo> &, int);
 	void moodlampFrametime(const double frameMs);
 
@@ -71,7 +71,7 @@ private:
 	MoodLampBase* m_lamp{ nullptr };
 
 	LiquidColorGenerator m_generator;
-	QList<QRgb> m_colors;
+	QList<QRgba64> m_colors;
 
 	bool	m_isMoodLampEnabled;
 	QColor  m_currentColor;

--- a/Software/src/wizard/GlobalColorCoefPage.cpp
+++ b/Software/src/wizard/GlobalColorCoefPage.cpp
@@ -85,7 +85,7 @@ void GlobalColorCoefPage::initializePage()
 
 	resetDeviceSettings();
 	onCoefValueChanged();
-	turnLightsOn(qRgb(255, 255, 255));
+	turnLightsOn(qRgba64(65535, 65535, 65535, 0));
 }
 
 bool GlobalColorCoefPage::validatePage()

--- a/Software/src/wizard/WizardPageUsingDevice.cpp
+++ b/Software/src/wizard/WizardPageUsingDevice.cpp
@@ -70,20 +70,20 @@ AbstractLedDevice * WizardPageUsingDevice::device()
 
 void WizardPageUsingDevice::turnLightOn(int id)
 {
-	QList<QRgb> lights;
+	QList<QRgba64> lights;
 	for (int i = 0; i < _transSettings->ledCount; i++)
 	{
 		if (i == id)
-			lights.append(qRgb(255, 255, 255));
+			lights.append(qRgba64(65535, 65535, 65535, 0));
 		else
-			lights.append(0);
+			lights.append(qRgba64(0));
 	}
 	device()->setColors(lights);
 }
 
-void WizardPageUsingDevice::turnLightsOn(QRgb color)
+void WizardPageUsingDevice::turnLightsOn(QRgba64 color)
 {
-	QList<QRgb> lights;
+	QList<QRgba64> lights;
 	for (int i = 0; i < _transSettings->ledCount; i++)
 	{
 		lights.append(color);
@@ -93,10 +93,10 @@ void WizardPageUsingDevice::turnLightsOn(QRgb color)
 
 void WizardPageUsingDevice::turnLightsOff()
 {
-	QList<QRgb> lights;
+	QList<QRgba64> lights;
 	for (int i = 0; i < _transSettings->ledCount; i++)
 	{
-		lights.append(0);
+		lights.append(qRgba64(0));
 	}
 	device()->setColors(lights);
 }

--- a/Software/src/wizard/WizardPageUsingDevice.hpp
+++ b/Software/src/wizard/WizardPageUsingDevice.hpp
@@ -43,7 +43,7 @@ public:
 
 protected slots:
 	void turnLightOn(int id);
-	void turnLightsOn(QRgb color);
+	void turnLightsOn(QRgba64 color);
 	void turnLightsOff();
 
 


### PR DESCRIPTION
Color blending should be done after gamma correction so I used the "Device Gamma" value to gamma correct the screen color values before they are averaged the LEDs. As I have no idea how SSE4.1 and AVX2 work, the averaging function is pretty basic. The averaged color values are then reencoded with the device gamma to maintain compatibility. I also increased the resolution of all color calculations to 16 bit per channel to have more data to work with when performing dithering calculations. This might also be useful for LEDs that have more than 8 bit of resolution.