### PR TITLE
Add a setting for dithering, default false.

### DIFF
--- a/Software/src/AbstractLedDevice.cpp
+++ b/Software/src/AbstractLedDevice.cpp
@@ -47,6 +47,12 @@ void AbstractLedDevice::setBrightnessCap(int value, bool updateColors) {
 		setColors(m_colorsSaved);
 }
 
+void AbstractLedDevice::setDitheringEnabled(bool value, bool updateColors) {
+	m_isDitheringEnabled = value;
+	if (updateColors)
+		setColors(m_colorsSaved);
+}
+
 void AbstractLedDevice::setLedMilliAmps(const int value, const bool updateColors) {
 	m_ledMilliAmps = value;
 	if (updateColors)
@@ -195,31 +201,33 @@ void AbstractLedDevice::applyDithering(QList<StructRgb>& colors, int colorDepth)
 		colors[i].g = (double)colors[i].g / k;
 		colors[i].b = (double)colors[i].b / k;
 
-		carryR += tempR - (double)colors[i].r * k;
-		carryG += tempG - (double)colors[i].g * k;
-		carryB += tempB - (double)colors[i].b * k;
+		if (m_isDitheringEnabled) {
+			carryR += tempR - (double)colors[i].r * k;
+			carryG += tempG - (double)colors[i].g * k;
+			carryB += tempB - (double)colors[i].b * k;
 
-		meanIndR += (tempR - (double)colors[i].r * k) * i;
-		meanIndG += (tempG - (double)colors[i].g * k) * i;
-		meanIndB += (tempB - (double)colors[i].b * k) * i;
+			meanIndR += (tempR - (double)colors[i].r * k) * i;
+			meanIndG += (tempG - (double)colors[i].g * k) * i;
+			meanIndB += (tempB - (double)colors[i].b * k) * i;
 
-		if (carryR >= k) {
-			int ind = (meanIndR - (carryR - k) * i) / k;
-			colors[ind].r++;
-			carryR -= k;
-			meanIndR = carryR * i;
-		}
-		if (carryG >= k) {
-			int ind = (meanIndG - (carryG - k) * i) / k;
-			colors[ind].g++;
-			carryG -= k;
-			meanIndG = carryG * i;
-		}
-		if (carryB >= k) {
-			int ind = (meanIndB - (carryB - k) * i) / k;
-			colors[ind].b++;
-			carryB -= k;
-			meanIndB = carryB * i;
+			if (carryR >= k) {
+				int ind = (meanIndR - (carryR - k) * i) / k;
+				colors[ind].r++;
+				carryR -= k;
+				meanIndR = carryR * i;
+			}
+			if (carryG >= k) {
+				int ind = (meanIndG - (carryG - k) * i) / k;
+				colors[ind].g++;
+				carryG -= k;
+				meanIndG = carryG * i;
+			}
+			if (carryB >= k) {
+				int ind = (meanIndB - (carryB - k) * i) / k;
+				colors[ind].b++;
+				carryB -= k;
+				meanIndB = carryB * i;
+			}
 		}
 	}
 }

--- a/Software/src/AbstractLedDevice.cpp
+++ b/Software/src/AbstractLedDevice.cpp
@@ -96,6 +96,7 @@ void AbstractLedDevice::updateDeviceSettings()
 	setBrightnessCap(Settings::getDeviceBrightnessCap(), false);
 	setLuminosityThreshold(Settings::getLuminosityThreshold(), false);
 	setMinimumLuminosityThresholdEnabled(Settings::isMinimumLuminosityEnabled(), false);
+	setDitheringEnabled(Settings::isDeviceDitheringEnabled(), false);
 	updateWBAdjustments(Settings::getLedCoefs(), false);
 
 	setColors(m_colorsSaved);

--- a/Software/src/AbstractLedDevice.hpp
+++ b/Software/src/AbstractLedDevice.hpp
@@ -72,6 +72,7 @@ public slots:
 	virtual void setGamma(double value, bool updateColors = true);
 	virtual void setBrightness(int value, bool updateColors = true);
 	virtual void setBrightnessCap(int value, bool updateColors = true);
+	virtual void setDitheringEnabled(bool value, bool updateColors = true);
 	virtual void setLedMilliAmps(const int value, const bool updateColors = true);
 	virtual void setPowerSupplyAmps(const double value, const bool updateColors = true);
 	virtual void setColorSequence(QString value) = 0;
@@ -107,6 +108,7 @@ protected:
 	double m_powerSupplyAmps{0.0};
 	int m_luminosityThreshold;
 	bool m_isMinimumLuminosityEnabled;
+	bool m_isDitheringEnabled;
 
 	QList<WBAdjustment> m_wbAdjustments;
 

--- a/Software/src/LedDeviceManager.hpp
+++ b/Software/src/LedDeviceManager.hpp
@@ -63,6 +63,7 @@ signals:
 	void ledDeviceSetBrightnessCap(int value, bool);
 	void ledDeviceSetLuminosityThreshold(int value, bool);
 	void ledDeviceSetMinimumLuminosityEnabled(bool, bool);
+	void ledDeviceSetDitheringEnabled(bool isEnabled);
 	void ledDeviceSetColorSequence(QString value);
 	void ledDeviceRequestFirmwareVersion();
 	void ledDeviceUpdateWBAdjustments();
@@ -86,6 +87,7 @@ public slots:
 	void setBrightnessCap(int value);
 	void setLuminosityThreshold(int value);
 	void setMinimumLuminosityEnabled(bool value);
+	void setDitheringEnabled(bool isEnabled);
 	void setColorSequence(QString value);
 	void requestFirmwareVersion();
 	void updateWBAdjustments();
@@ -124,6 +126,7 @@ private:
 	int m_savedBrightnessCap;
 	int m_savedLuminosityThreshold;
 	bool m_savedIsMinimumLuminosityEnabled;
+	bool m_savedDitheringEnabled;
 	QString m_savedColorSequence;
 
 	QList<AbstractLedDevice *> m_ledDevices;

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -646,6 +646,7 @@ void LightpackApplication::startLedDeviceManager()
 	connect(settings(), SIGNAL(deviceRefreshDelayChanged(int)),			m_ledDeviceManager, SLOT(setRefreshDelay(int)),					Qt::QueuedConnection);
 	connect(settings(), SIGNAL(deviceUsbPowerLedDisabledChanged(bool)), m_ledDeviceManager, SLOT(setUsbPowerLedDisabled(bool)),			Qt::QueuedConnection);
 	connect(settings(), SIGNAL(deviceGammaChanged(double)),				m_ledDeviceManager, SLOT(setGamma(double)),						Qt::QueuedConnection);
+	connect(settings(), SIGNAL(deviceDitheringEnabledChanged(bool)),	m_ledDeviceManager, SLOT(setDitheringEnabled(bool)),			Qt::QueuedConnection);
 	connect(settings(), SIGNAL(deviceBrightnessChanged(int)),			m_ledDeviceManager, SLOT(setBrightness(int)),					Qt::QueuedConnection);
 	connect(settings(), SIGNAL(deviceBrightnessCapChanged(int)),		m_ledDeviceManager, SLOT(setBrightnessCap(int)),				Qt::QueuedConnection);
 	connect(settings(), SIGNAL(luminosityThresholdChanged(int)),		m_ledDeviceManager, SLOT(setLuminosityThreshold(int)),			Qt::QueuedConnection);

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -229,6 +229,7 @@ static const QString Brightness = "Device/Brightness";
 static const QString BrightnessCap = "Device/BrightnessCap";
 static const QString ColorDepth = "Device/ColorDepth";
 static const QString Gamma = "Device/Gamma";
+static const QString IsDitheringEnabled = "Device/IsDitheringEnabled";
 }
 // [LED_i]
 namespace Led
@@ -289,7 +290,6 @@ Settings::Settings() : QObject(NULL) {
 	qRegisterMetaType<QColor>("QColor");
 	qRegisterMetaType<SupportedDevices::DeviceType>("SupportedDevices::DeviceType");
 	qRegisterMetaType<Lightpack::Mode>("Lightpack::Mode");
-
 }
 
 // Desktop should be initialized before call Settings::Initialize()
@@ -1488,6 +1488,18 @@ void Settings::setDeviceGamma(double gamma)
 	m_this->deviceGammaChanged(gamma);
 }
 
+bool Settings::isDeviceDitheringEnabled()
+{
+	return value(Profile::Key::Device::IsDitheringEnabled).toBool();
+}
+
+void Settings::setDeviceDitheringEnabled(bool isEnabled)
+{
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
+	setValue(Profile::Key::Device::IsDitheringEnabled, isEnabled);
+	m_this->deviceDitheringEnabledChanged(isEnabled);
+}
+
 Grab::GrabberType Settings::getGrabberType()
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
@@ -2105,12 +2117,13 @@ void Settings::initCurrentProfile(bool isResetDefault)
 #endif
 	// [Device]
 	setNewOption(Profile::Key::Device::RefreshDelay,				Profile::Device::RefreshDelayDefault, isResetDefault);
-	setNewOption(Profile::Key::Device::IsUsbPowerLedDisabled,		Profile::Device::IsUsbPowerLedDisabled, isResetDefault);
+	setNewOption(Profile::Key::Device::IsUsbPowerLedDisabled,		Profile::Device::IsUsbPowerLedDisabledDefault, isResetDefault);
 	setNewOption(Profile::Key::Device::Brightness,					Profile::Device::BrightnessDefault, isResetDefault);
 	setNewOption(Profile::Key::Device::BrightnessCap,				Profile::Device::BrightnessCapDefault, isResetDefault);
 	setNewOption(Profile::Key::Device::Smooth,						Profile::Device::SmoothDefault, isResetDefault);
 	setNewOption(Profile::Key::Device::Gamma,						Profile::Device::GammaDefault, isResetDefault);
 	setNewOption(Profile::Key::Device::ColorDepth,					Profile::Device::ColorDepthDefault, isResetDefault);
+	setNewOption(Profile::Key::Device::IsDitheringEnabled,			Profile::Device::IsDitheringEnabledDefault, isResetDefault);
 
 
 	QPoint ledPosition;

--- a/Software/src/Settings.hpp
+++ b/Software/src/Settings.hpp
@@ -199,6 +199,8 @@ public:
 	static void setDeviceColorDepth(int value);
 	static double getDeviceGamma();
 	static void setDeviceGamma(double gamma);
+	static bool isDeviceDitheringEnabled();
+	static void setDeviceDitheringEnabled(bool isEnabled);
 
 	static Grab::GrabberType getGrabberType();
 	static void setGrabberType(Grab::GrabberType grabMode);
@@ -363,6 +365,7 @@ signals:
 	void deviceSmoothChanged(int value);
 	void deviceColorDepthChanged(int value);
 	void deviceGammaChanged(double gamma);
+	void deviceDitheringEnabledChanged(bool isEnabled);
 	void deviceColorSequenceChanged(QString value);
 	void grabberTypeChanged(const Grab::GrabberType grabMode);
 #ifdef D3D10_GRAB_SUPPORT

--- a/Software/src/SettingsDefaults.hpp
+++ b/Software/src/SettingsDefaults.hpp
@@ -220,7 +220,7 @@ static const int RefreshDelayMin = 64;
 static const int RefreshDelayDefault = 100;
 static const int RefreshDelayMax = 1023;
 
-static const bool IsUsbPowerLedDisabled = false;
+static const bool IsUsbPowerLedDisabledDefault = false;
 
 static const int BrightnessMin = 0;
 static const int BrightnessDefault = 100;
@@ -241,6 +241,8 @@ static const int ColorDepthMax = 255;
 static const double GammaMin = 0.01;
 static const double GammaDefault = 2.0;
 static const double GammaMax = 10.0;
+
+static const bool IsDitheringEnabledDefault = false;
 }
 // [LED_i]
 namespace Led

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -150,7 +150,6 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
 
 	initGrabbersRadioButtonsVisibility();
 	initLanguages();
-	initVirtualLeds(Settings::getNumberOfLeds(SupportedDevices::DeviceTypeVirtual));
 
 	loadTranslation(Settings::getLanguage());
 
@@ -265,6 +264,7 @@ void SettingsWindow::connectSignalsSlots()
 	connect(ui->spinBox_DeviceBrightnessCap, SIGNAL(valueChanged(int)), this, SLOT(onDeviceBrightnessCap_valueChanged(int)));
 	connect(ui->spinBox_DeviceColorDepth, SIGNAL(valueChanged(int)), this, SLOT(onDeviceColorDepth_valueChanged(int)));
 	connect(ui->doubleSpinBox_DeviceGamma, SIGNAL(valueChanged(double)), this, SLOT(onDeviceGammaCorrection_valueChanged(double)));
+	connect(ui->checkBox_EnableDithering, SIGNAL(toggled(bool)), this, SLOT(onDeviceDitheringEnabled_toggled(bool)));
 	connect(ui->horizontalSlider_GammaCorrection, SIGNAL(valueChanged(int)), this, SLOT(onSliderDeviceGammaCorrection_valueChanged(int)));
 	connect(ui->checkBox_SendDataOnlyIfColorsChanges, SIGNAL(toggled(bool)), this, SLOT(onDeviceSendDataOnlyIfColorsChanged_toggled(bool)));
 
@@ -1393,6 +1393,13 @@ void SettingsWindow::onSliderDeviceGammaCorrection_valueChanged(int value)
 	emit updateGamma(Settings::getDeviceGamma());
 }
 
+void SettingsWindow::onDeviceDitheringEnabled_toggled(bool state) {
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO << state;
+
+	Settings::setDeviceDitheringEnabled(state);
+}
+
+
 void SettingsWindow::onLightpackModes_currentIndexChanged(int index)
 {
 	if (updatingFromSettings) return;
@@ -1926,7 +1933,7 @@ void SettingsWindow::updateUiFromSettings()
 
 	ui->pushButton_SelectColorSoundVizMin->setColor					(Settings::getSoundVisualizerMinColor());
 	ui->pushButton_SelectColorSoundVizMax->setColor					(Settings::getSoundVisualizerMaxColor());
-	ui->radioButton_SoundVizConstantMode->setChecked					(!Settings::isSoundVisualizerLiquidMode());
+	ui->radioButton_SoundVizConstantMode->setChecked				(!Settings::isSoundVisualizerLiquidMode());
 	ui->radioButton_SoundVizLiquidMode->setChecked					(Settings::isSoundVisualizerLiquidMode());
 	ui->horizontalSlider_SoundVizLiquidSpeed->setValue				(Settings::getSoundVisualizerLiquidSpeed());
 #endif
@@ -1934,17 +1941,18 @@ void SettingsWindow::updateUiFromSettings()
 	ui->checkBox_DisableUsbPowerLed->setChecked						(Settings::isDeviceUsbPowerLedDisabled());
 	ui->horizontalSlider_DeviceRefreshDelay->setValue				(Settings::getDeviceRefreshDelay());
 	ui->horizontalSlider_DeviceBrightness->setValue					(Settings::getDeviceBrightness());
-	ui->horizontalSlider_DeviceBrightnessCap->setValue					(Settings::getDeviceBrightnessCap());
+	ui->horizontalSlider_DeviceBrightnessCap->setValue				(Settings::getDeviceBrightnessCap());
 	ui->horizontalSlider_DeviceSmooth->setValue						(Settings::getDeviceSmooth());
 	ui->horizontalSlider_DeviceColorDepth->setValue					(Settings::getDeviceColorDepth());
 	ui->doubleSpinBox_DeviceGamma->setValue							(Settings::getDeviceGamma());
-	ui->horizontalSlider_GammaCorrection->setValue			(floor((Settings::getDeviceGamma() * 100 + 0.5)));
+	ui->horizontalSlider_GammaCorrection->setValue					(floor((Settings::getDeviceGamma() * 100 + 0.5)));
+	ui->checkBox_EnableDithering->setChecked						(Settings::isDeviceDitheringEnabled());
 
-	ui->groupBox_Api->setChecked										(Settings::isApiEnabled());
-	ui->checkBox_listenOnlyOnLoInterface->setChecked					(Settings::isListenOnlyOnLoInterface());
-	ui->lineEdit_ApiPort->setText					(QString::number(Settings::getApiPort()));
-	ui->lineEdit_ApiPort->setValidator(new QIntValidator(1, 49151));
-	ui->lineEdit_ApiKey->setText										(Settings::getApiAuthKey());
+	ui->groupBox_Api->setChecked									(Settings::isApiEnabled());
+	ui->checkBox_listenOnlyOnLoInterface->setChecked				(Settings::isListenOnlyOnLoInterface());
+	ui->lineEdit_ApiPort->setText									(QString::number(Settings::getApiPort()));
+	ui->lineEdit_ApiPort->setValidator								(new QIntValidator(1, 49151));
+	ui->lineEdit_ApiKey->setText									(Settings::getApiAuthKey());
 	ui->spinBox_LoggingLevel->setValue								(g_debugLevel);
 
 	if (g_debugLevel == Debug::DebugLevels::ZeroLevel) {
@@ -2123,6 +2131,11 @@ void SettingsWindow::on_pushButton_LightpackRefreshDelayHelp_clicked()
 void SettingsWindow::on_pushButton_GammaCorrectionHelp_clicked()
 {
 	showHelpOf(ui->horizontalSlider_GammaCorrection);
+}
+
+void SettingsWindow::on_pushButton_DitheringHelp_clicked()
+{
+	showHelpOf(ui->checkBox_EnableDithering);
 }
 
 void SettingsWindow::on_pushButton_BrightnessCapHelp_clicked()

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -183,6 +183,7 @@ private slots:
 	void onDeviceColorDepth_valueChanged(int value);
 	void onDeviceGammaCorrection_valueChanged(double value);
 	void onSliderDeviceGammaCorrection_valueChanged(int value);
+	void onDeviceDitheringEnabled_toggled(bool state);
 	void onDeviceSendDataOnlyIfColorsChanged_toggled(bool state);
 	void onDx1011CaptureEnabledChanged(bool isEnabled);
 	void onDx9CaptureEnabledChanged(bool isEnabled);
@@ -215,6 +216,7 @@ private slots:
 	void on_pushButton_LightpackRefreshDelayHelp_clicked();
 
 	void on_pushButton_GammaCorrectionHelp_clicked();
+	void on_pushButton_DitheringHelp_clicked();
 	void on_pushButton_BrightnessCapHelp_clicked();
 
 	void on_pushButton_lumosityThresholdHelp_clicked();

--- a/Software/src/SettingsWindow.ui
+++ b/Software/src/SettingsWindow.ui
@@ -7,8 +7,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>482</width>
-    <height>649</height>
+    <width>485</width>
+    <height>668</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -213,7 +213,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="tabSoftwareOptions">
        <property name="enabled">
@@ -1293,17 +1293,46 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
        <attribute name="title">
         <string>Device</string>
        </attribute>
-       <layout class="QGridLayout" name="gridLayout_12">
+       <layout class="QGridLayout" name="gridLayout_12" columnstretch="0,0,0,0,0,0">
         <property name="leftMargin">
          <number>20</number>
         </property>
         <property name="rightMargin">
          <number>20</number>
         </property>
-        <item row="7" column="0" colspan="4">
-         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterLockComputer">
+        <item row="7" column="4">
+         <widget class="QPushButton" name="pushButton_DitheringHelp">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">margin:0px;</string>
+          </property>
           <property name="text">
-           <string>Keep lights ON after lock computer</string>
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../res/LightpackResources.qrc">
+            <normaloff>:/icons/help.png</normaloff>:/icons/help.png</iconset>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Brightness cap:</string>
           </property>
          </widget>
         </item>
@@ -1338,42 +1367,22 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
          </widget>
         </item>
-        <item row="14" column="0" colspan="4">
-         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterExit">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Keep lights ON after exit</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0" colspan="4">
-         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterSuspend">
-          <property name="text">
-           <string>Keep lights ON after system suspend</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QSlider" name="horizontalSlider_DeviceBrightness">
+        <item row="4" column="0">
+         <widget class="QSlider" name="horizontalSlider_DeviceBrightnessCap">
           <property name="minimumSize">
            <size>
             <width>200</width>
             <height>0</height>
            </size>
           </property>
+          <property name="whatsThis">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Brightness Cap&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Lowers the brightness limit of LEDs (as opposed to overall brightness). Can be used to limit the power draw and the heat output. Defaults to 100% (no limit).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
           <property name="minimum">
-           <number>0</number>
+           <number>1</number>
           </property>
           <property name="maximum">
            <number>100</number>
-          </property>
-          <property name="pageStep">
-           <number>1</number>
           </property>
           <property name="value">
            <number>100</number>
@@ -1383,20 +1392,109 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
          </widget>
         </item>
-        <item row="17" column="0">
+        <item row="6" column="2">
+         <widget class="QDoubleSpinBox" name="doubleSpinBox_DeviceGamma">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="minimum">
+           <double>0.050000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.050000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.050000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="25" column="0">
          <spacer name="verticalSpacer_2">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>20</width>
-            <height>40</height>
+            <width>0</width>
+            <height>0</height>
            </size>
           </property>
          </spacer>
         </item>
-        <item row="15" column="0">
+        <item row="4" column="2">
+         <widget class="QSpinBox" name="spinBox_DeviceBrightnessCap">
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>29</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+        <item row="21" column="0">
+         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterScreenOff">
+          <property name="text">
+           <string>Keep lights ON after display sleep</string>
+          </property>
+         </widget>
+        </item>
+        <item row="22" column="0">
+         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterLockComputer">
+          <property name="text">
+           <string>Keep lights ON after lock computer</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_GammaCorrection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Gamma correction:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="17" column="0">
          <layout class="QHBoxLayout" name="horizontalLayout_8">
           <property name="bottomMargin">
            <number>13</number>
@@ -1423,7 +1521,88 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </item>
          </layout>
         </item>
-        <item row="4" column="5">
+        <item row="2" column="0">
+         <widget class="QSlider" name="horizontalSlider_DeviceBrightness">
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="pageStep">
+           <number>1</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="19" column="0" colspan="6">
+         <widget class="Line" name="line_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="20" column="0">
+         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterExit">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Keep lights ON after exit</string>
+          </property>
+         </widget>
+        </item>
+        <item row="23" column="0">
+         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterSuspend">
+          <property name="text">
+           <string>Keep lights ON after system suspend</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="4">
+         <widget class="QPushButton" name="pushButton_GammaCorrectionHelp">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">margin:0px;</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../res/LightpackResources.qrc">
+            <normaloff>:/icons/help.png</normaloff>:/icons/help.png</iconset>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="4">
          <widget class="QPushButton" name="pushButton_BrightnessCapHelp">
           <property name="maximumSize">
            <size>
@@ -1443,15 +1622,8 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
           </property>
          </widget>
         </item>
-        <item row="8" column="0">
-         <widget class="QCheckBox" name="checkBox_KeepLightsOnAfterScreenOff">
-          <property name="text">
-           <string>Keep lights ON after display sleep</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_GammaCorrection">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_5">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -1459,14 +1631,64 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Gamma correction:</string>
+           <string>Overall brightness:</string>
           </property>
          </widget>
         </item>
-        <item row="16" column="0" colspan="4">
+        <item row="7" column="0">
+         <widget class="QCheckBox" name="checkBox_EnableDithering">
+          <property name="whatsThis">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h4 style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;Dithering&lt;/span&gt;&lt;/h4&gt;&lt;p&gt;Increases color accuracy with some devices, but may introduce flickering.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Enable Dithering</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QSpinBox" name="spinBox_DeviceBrightness">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>45</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>9</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+        <item row="18" column="0" colspan="6">
          <widget class="QTabWidget" name="tabDevices">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -1478,14 +1700,14 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
            </size>
           </property>
           <property name="currentIndex">
-           <number>0</number>
+           <number>1</number>
           </property>
           <property name="documentMode">
            <bool>true</bool>
           </property>
           <widget class="QWidget" name="tabDeviceLightpack">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -1506,30 +1728,8 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
             <property name="rightMargin">
              <number>0</number>
             </property>
-            <item row="8" column="0">
-             <widget class="QSlider" name="horizontalSlider_DeviceRefreshDelay">
-              <property name="whatsThis">
-               <string>&lt;h4&gt;Refresh delay&lt;/h4&gt; This setting’s values are inversely proportional to the PWM’s frequency. It's affects to performance.</string>
-              </property>
-              <property name="minimum">
-               <number>64</number>
-              </property>
-              <property name="maximum">
-               <number>1023</number>
-              </property>
-              <property name="pageStep">
-               <number>1</number>
-              </property>
-              <property name="value">
-               <number>64</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="7" column="0">
-             <widget class="QLabel" name="label_DeviceRefreshDelay">
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_9">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -1537,22 +1737,66 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
                </sizepolicy>
               </property>
               <property name="text">
-               <string>Refresh delay (Lightpack 5 and below):</string>
+               <string>Smoothness:</string>
               </property>
              </widget>
             </item>
-            <item row="9" column="0">
-             <spacer name="verticalSpacer_8">
+            <item row="4" column="0">
+             <widget class="QSlider" name="horizontalSlider_DeviceColorDepth">
+              <property name="whatsThis">
+               <string>&lt;h4&gt;Color depth&lt;/h4&gt; Number of colors per channel, one RGB LED uses 3 channels (value in power of 3).</string>
+              </property>
+              <property name="minimum">
+               <number>32</number>
+              </property>
+              <property name="maximum">
+               <number>255</number>
+              </property>
+              <property name="pageStep">
+               <number>1</number>
+              </property>
+              <property name="value">
+               <number>100</number>
+              </property>
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_DeviceColorDepth">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
-             </spacer>
+              <property name="text">
+               <string>Color depth (Lightpack 5 and below):</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="0">
+             <widget class="QSlider" name="horizontalSlider_DeviceSmooth">
+              <property name="whatsThis">
+               <string>&lt;h4&gt;Smoothness&lt;/h4&gt; It defines how many steps will be color changed in</string>
+              </property>
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>255</number>
+              </property>
+              <property name="pageStep">
+               <number>1</number>
+              </property>
+              <property name="value">
+               <number>100</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
             </item>
             <item row="4" column="2">
              <widget class="QPushButton" name="pushButton_LightpackColorDepthHelp">
@@ -1577,8 +1821,68 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
               </property>
              </widget>
             </item>
-            <item row="8" column="2">
-             <widget class="QPushButton" name="pushButton_LightpackRefreshDelayHelp">
+            <item row="4" column="1">
+             <widget class="QSpinBox" name="spinBox_DeviceColorDepth">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>50</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>60</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="minimum">
+               <number>32</number>
+              </property>
+              <property name="maximum">
+               <number>255</number>
+              </property>
+              <property name="value">
+               <number>100</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QCheckBox" name="checkBox_DisableUsbPowerLed">
+              <property name="text">
+               <string>Disable USB Power LED</string>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="0">
+             <widget class="QSlider" name="horizontalSlider_DeviceRefreshDelay">
+              <property name="whatsThis">
+               <string>&lt;h4&gt;Refresh delay&lt;/h4&gt; This setting’s values are inversely proportional to the PWM’s frequency. It's affects to performance.</string>
+              </property>
+              <property name="minimum">
+               <number>64</number>
+              </property>
+              <property name="maximum">
+               <number>1023</number>
+              </property>
+              <property name="pageStep">
+               <number>1</number>
+              </property>
+              <property name="value">
+               <number>64</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="2">
+             <widget class="QPushButton" name="pushButton_LightpackSmoothnessHelp">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -1597,28 +1901,6 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
               </property>
               <property name="flat">
                <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <widget class="QSlider" name="horizontalSlider_DeviceColorDepth">
-              <property name="whatsThis">
-               <string>&lt;h4&gt;Color depth&lt;/h4&gt; Number of colors per channel, one RGB LED uses 3 channels (value in power of 3).</string>
-              </property>
-              <property name="minimum">
-               <number>32</number>
-              </property>
-              <property name="maximum">
-               <number>255</number>
-              </property>
-              <property name="pageStep">
-               <number>1</number>
-              </property>
-              <property name="value">
-               <number>100</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
               </property>
              </widget>
             </item>
@@ -1653,8 +1935,8 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
               </property>
              </widget>
             </item>
-            <item row="6" column="2">
-             <widget class="QPushButton" name="pushButton_LightpackSmoothnessHelp">
+            <item row="8" column="2">
+             <widget class="QPushButton" name="pushButton_LightpackRefreshDelayHelp">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -1707,8 +1989,8 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
               </property>
              </widget>
             </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="label_DeviceColorDepth">
+            <item row="7" column="0">
+             <widget class="QLabel" name="label_DeviceRefreshDelay">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -1716,107 +1998,24 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
                </sizepolicy>
               </property>
               <property name="text">
-               <string>Color depth (Lightpack 5 and below):</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QSpinBox" name="spinBox_DeviceColorDepth">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>50</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>60</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="minimum">
-               <number>32</number>
-              </property>
-              <property name="maximum">
-               <number>255</number>
-              </property>
-              <property name="value">
-               <number>100</number>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="0">
-             <widget class="QSlider" name="horizontalSlider_DeviceSmooth">
-              <property name="whatsThis">
-               <string>&lt;h4&gt;Smoothness&lt;/h4&gt; It defines how many steps will be color changed in</string>
-              </property>
-              <property name="minimum">
-               <number>0</number>
-              </property>
-              <property name="maximum">
-               <number>255</number>
-              </property>
-              <property name="pageStep">
-               <number>1</number>
-              </property>
-              <property name="value">
-               <number>100</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QCheckBox" name="checkBox_DisableUsbPowerLed">
-              <property name="text">
-               <string>Disable USB Power LED</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
-             <widget class="QLabel" name="label_9">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Smoothness:</string>
+               <string>Refresh delay (Lightpack 5 and below):</string>
               </property>
              </widget>
             </item>
            </layout>
           </widget>
           <widget class="QWidget" name="tabDeviceVirtual">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <attribute name="title">
             <string>Virtual</string>
            </attribute>
-           <layout class="QGridLayout" name="gridLayout_7">
-            <property name="horizontalSpacing">
-             <number>12</number>
-            </property>
-            <item row="1" column="0">
-             <spacer name="verticalSpacer_15">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="0" colspan="2">
+           <layout class="QVBoxLayout" name="verticalLayout_12">
+            <item>
              <widget class="QFrame" name="frame_VirtualLeds">
               <property name="frameShape">
                <enum>QFrame::StyledPanel</enum>
@@ -1831,184 +2030,15 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
               </layout>
              </widget>
             </item>
+            <item>
+             <spacer name="verticalSpacer_8">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+             </spacer>
+            </item>
            </layout>
           </widget>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QSlider" name="horizontalSlider_DeviceBrightnessCap">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="whatsThis">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Brightness Cap&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Lowers the brightness limit of LEDs (as opposed to overall brightness). Can be used to limit the power draw and the heat output. Defaults to 100% (no limit).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Overall brightness:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Brightness cap:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QSpinBox" name="spinBox_DeviceBrightnessCap">
-          <property name="maximumSize">
-           <size>
-            <width>60</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>29</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-          <property name="suffix">
-           <string>%</string>
-          </property>
-          </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QSpinBox" name="spinBox_DeviceBrightness">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>45</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>60</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>9</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="minimum">
-           <number>0</number>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-          <property name="suffix">
-           <string>%</string>
-          </property>
-          </widget>
-        </item>
-        <item row="6" column="5">
-         <widget class="QPushButton" name="pushButton_GammaCorrectionHelp">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">margin:0px;</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset resource="../res/LightpackResources.qrc">
-            <normaloff>:/icons/help.png</normaloff>:/icons/help.png</iconset>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
-         <widget class="QDoubleSpinBox" name="doubleSpinBox_DeviceGamma">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>60</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="minimum">
-           <double>0.050000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.050000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.050000000000000</double>
-          </property>
          </widget>
         </item>
        </layout>
@@ -3190,6 +3220,7 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
   <tabstop>comboBox_LightpackModes</tabstop>
   <tabstop>spinBox_GrabSlowdown</tabstop>
   <tabstop>checkBox_GrabIsAvgColors</tabstop>
+  <tabstop>checkBox_GrabApplyBlueLightReduction</tabstop>
   <tabstop>checkBox_GrabApplyColorTemperature</tabstop>
   <tabstop>pushButton_grabApplyColorTemperatureHelp</tabstop>
   <tabstop>horizontalSlider_GrabColorTemperature</tabstop>
@@ -3203,15 +3234,6 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
   <tabstop>radioButton_GrabWidgetsDontShow</tabstop>
   <tabstop>radioButton_Colored</tabstop>
   <tabstop>radioButton_White</tabstop>
-  <tabstop>radioButton_ConstantColorMoodLampMode</tabstop>
-  <tabstop>pushButton_SelectColorMoodLamp</tabstop>
-  <tabstop>radioButton_LiquidColorMoodLampMode</tabstop>
-  <tabstop>horizontalSlider_MoodLampSpeed</tabstop>
-  <tabstop>radioButton_SoundVizConstantMode</tabstop>
-  <tabstop>pushButton_SelectColorSoundVizMin</tabstop>
-  <tabstop>pushButton_SelectColorSoundVizMax</tabstop>
-  <tabstop>radioButton_SoundVizLiquidMode</tabstop>
-  <tabstop>horizontalSlider_SoundVizLiquidSpeed</tabstop>
   <tabstop>horizontalSlider_LuminosityThreshold</tabstop>
   <tabstop>spinBox_LuminosityThreshold</tabstop>
   <tabstop>pushButton_lumosityThresholdHelp</tabstop>
@@ -3219,11 +3241,15 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
   <tabstop>radioButton_LuminosityDeadZone</tabstop>
   <tabstop>pushButton_EnableDisableDevice</tabstop>
   <tabstop>horizontalSlider_DeviceBrightness</tabstop>
+  <tabstop>spinBox_DeviceBrightness</tabstop>
+  <tabstop>horizontalSlider_DeviceBrightnessCap</tabstop>
+  <tabstop>spinBox_DeviceBrightnessCap</tabstop>
+  <tabstop>pushButton_BrightnessCapHelp</tabstop>
   <tabstop>horizontalSlider_GammaCorrection</tabstop>
-  <tabstop>checkBox_KeepLightsOnAfterLockComputer</tabstop>
-  <tabstop>checkBox_KeepLightsOnAfterScreenOff</tabstop>
-  <tabstop>checkBox_KeepLightsOnAfterSuspend</tabstop>
-  <tabstop>checkBox_KeepLightsOnAfterExit</tabstop>
+  <tabstop>doubleSpinBox_DeviceGamma</tabstop>
+  <tabstop>pushButton_GammaCorrectionHelp</tabstop>
+  <tabstop>checkBox_EnableDithering</tabstop>
+  <tabstop>pushButton_DitheringHelp</tabstop>
   <tabstop>pbRunConfigurationWizard</tabstop>
   <tabstop>tabDevices</tabstop>
   <tabstop>checkBox_DisableUsbPowerLed</tabstop>
@@ -3236,6 +3262,10 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
   <tabstop>horizontalSlider_DeviceRefreshDelay</tabstop>
   <tabstop>spinBox_DeviceRefreshDelay</tabstop>
   <tabstop>pushButton_LightpackRefreshDelayHelp</tabstop>
+  <tabstop>checkBox_KeepLightsOnAfterExit</tabstop>
+  <tabstop>checkBox_KeepLightsOnAfterScreenOff</tabstop>
+  <tabstop>checkBox_KeepLightsOnAfterLockComputer</tabstop>
+  <tabstop>checkBox_KeepLightsOnAfterSuspend</tabstop>
   <tabstop>comboBox_Profiles</tabstop>
   <tabstop>pushButton_ProfileNew</tabstop>
   <tabstop>pushButton_ProfileResetToDefault</tabstop>
@@ -3256,6 +3286,7 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
   <tabstop>pushButton_GenerateNewApiKey</tabstop>
   <tabstop>radioButton_GrabX11</tabstop>
   <tabstop>radioButton_GrabMacCoreGraphics</tabstop>
+  <tabstop>radioButton_GrabMacAVFoundation</tabstop>
   <tabstop>radioButton_GrabWinAPI</tabstop>
   <tabstop>radioButton_GrabDDupl</tabstop>
   <tabstop>checkBox_EnableDx1011Capture</tabstop>
@@ -3267,6 +3298,19 @@ Internally emulates the effects of f.lux, redshift, Night Light, Night Shift...<
   <tabstop>checkBox_checkForUpdates</tabstop>
   <tabstop>checkBox_installUpdates</tabstop>
   <tabstop>textBrowser</tabstop>
+  <tabstop>comboBox_SoundVizVisualizer</tabstop>
+  <tabstop>pushButton_SoundVizDeviceHelp</tabstop>
+  <tabstop>radioButton_SoundVizConstantMode</tabstop>
+  <tabstop>radioButton_ConstantColorMoodLampMode</tabstop>
+  <tabstop>horizontalSlider_MoodLampSpeed</tabstop>
+  <tabstop>comboBox_SoundVizDevice</tabstop>
+  <tabstop>pushButton_SelectColorMoodLamp</tabstop>
+  <tabstop>radioButton_LiquidColorMoodLampMode</tabstop>
+  <tabstop>horizontalSlider_SoundVizLiquidSpeed</tabstop>
+  <tabstop>pushButton_SelectColorSoundVizMax</tabstop>
+  <tabstop>pushButton_SelectColorSoundVizMin</tabstop>
+  <tabstop>comboBox_MoodLampLamp</tabstop>
+  <tabstop>radioButton_SoundVizLiquidMode</tabstop>
  </tabstops>
  <resources>
   <include location="../res/LightpackResources.qrc"/>

--- a/Software/src/enums.hpp
+++ b/Software/src/enums.hpp
@@ -174,6 +174,7 @@ enum Cmd {
 	SetBrightnessCap,
 	SetLuminosityThreshold,
 	SetMinimumLuminosityEnabled,
+	SetDitheringEnabled,
 	SetColorSequence,
 	RequestFirmwareVersion,
 	UpdateWBAdjustments,


### PR DESCRIPTION
Fixes #398 by disabling dithering by default. The option exists in device settings now.