### PR TITLE
a lot of housekeeping

### DIFF
--- a/Software/build-config.prf
+++ b/Software/build-config.prf
@@ -7,7 +7,7 @@ exists(build-vars.prf) {
 #------------------------------------------------------------------------------
 # Parsing configuration
 #------------------------------------------------------------------------------
-win32: {
+win32 {
     # Target architecture
     QMAKE_TARGET.arch = $$TARGET_ARCH
     _TARGET_ARCH = $$(TARGET_ARCH)

--- a/Software/build-vars.prf.default
+++ b/Software/build-vars.prf.default
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 # General
 #------------------------------------------------------------------------------
-win32: {
+win32 {
 	# Set this to -Win32 for 32-bit
 	OPENSSL_DIR = "C:\\OpenSSL-Win64\\bin"
 	# Set this to run without openssl. The updatecheck won't work.

--- a/Software/build-vars.prf.default
+++ b/Software/build-vars.prf.default
@@ -47,8 +47,8 @@ macx {
 	# DEFINES += SAVE_FRAME_TO_FILE
 
 	# CONFIG += debug
-	# QMAKE_CC += clang
-	# QMAKE_CXX += clang++
+	# QMAKE_CC = clang
+	# QMAKE_CXX = clang++
 	# QMAKE_CFLAGS_DEBUG += -ggdb
 	# QMAKE_CFLAGS_RELEASE += -march=native
 	# QMAKE_CXXFLAGS_DEBUG += -ggdb

--- a/Software/common/WinDXUtils.cpp
+++ b/Software/common/WinDXUtils.cpp
@@ -154,7 +154,7 @@ UINT GetDxgiPresentOffset(HWND hwnd) {
 	int presentFuncOffset = static_cast<UINT>(presentFuncPtr - hDxgi);
 
 #ifndef NO_QT
-	sprintf(buf, "presentFuncOffset=%llx", presentFuncOffset);
+	sprintf(buf, "presentFuncOffset=%x", presentFuncOffset);
 	DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 
@@ -234,7 +234,7 @@ UINT GetD3D9PresentOffset(HWND hWnd){
 		UINT presentFuncOffset = (presentFuncPtr - reinterpret_cast<UINT>(hD3d9));
 
 #ifndef NO_QT
-		sprintf(buf, "presentFuncOffset=%llx", presentFuncOffset);
+		sprintf(buf, "presentFuncOffset=%x", presentFuncOffset);
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 
@@ -314,7 +314,7 @@ UINT GetD3D9SCPresentOffset(HWND hWnd){
 		UINT presentFuncOffset = (presentFuncPtr - reinterpret_cast<UINT>(pD3d9));
 
 #ifndef NO_QT
-		sprintf(buf, "presentFuncOffset=%llx", presentFuncOffset);
+		sprintf(buf, "presentFuncOffset=%x", presentFuncOffset);
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 
@@ -394,7 +394,7 @@ UINT GetD3D9ResetOffset(HWND hWnd){
 		UINT resetFuncOffset = (resetFuncPtr - reinterpret_cast<UINT>(hD3d9));
 
 #ifndef NO_QT
-		sprintf(buf, "resetFuncOffset=%llx", resetFuncOffset);
+		sprintf(buf, "resetFuncOffset=%x", resetFuncOffset);
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 

--- a/Software/common/WinDXUtils.cpp
+++ b/Software/common/WinDXUtils.cpp
@@ -146,7 +146,7 @@ UINT GetDxgiPresentOffset(HWND hwnd) {
 
 #ifndef NO_QT
 	char buf[100];
-	sprintf(buf, "presentFuncPtr=%x", presentFuncPtr);
+	sprintf(buf, "presentFuncPtr=%llx", presentFuncPtr);
 	DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 
@@ -154,7 +154,7 @@ UINT GetDxgiPresentOffset(HWND hwnd) {
 	int presentFuncOffset = static_cast<UINT>(presentFuncPtr - hDxgi);
 
 #ifndef NO_QT
-	sprintf(buf, "presentFuncOffset=%x", presentFuncOffset);
+	sprintf(buf, "presentFuncOffset=%llx", presentFuncOffset);
 	DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 
@@ -227,14 +227,14 @@ UINT GetD3D9PresentOffset(HWND hWnd){
 		uintptr_t presentFuncPtr = pvtbl[D3D9_PRESENT_FUNC_ORD];
 #ifndef NO_QT
 		char buf[100];
-		sprintf(buf, "presentFuncPtr=%x", presentFuncPtr);
+		sprintf(buf, "presentFuncPtr=%llx", presentFuncPtr);
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 
 		UINT presentFuncOffset = (presentFuncPtr - reinterpret_cast<UINT>(hD3d9));
 
 #ifndef NO_QT
-		sprintf(buf, "presentFuncOffset=%x", presentFuncOffset);
+		sprintf(buf, "presentFuncOffset=%llx", presentFuncOffset);
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 
@@ -306,7 +306,7 @@ UINT GetD3D9SCPresentOffset(HWND hWnd){
 		uintptr_t presentFuncPtr = pvtbl[D3D9_SCPRESENT_FUNC_ORD];
 #ifndef NO_QT
 		char buf[100];
-		sprintf(buf, "presentFuncPtr=%x", presentFuncPtr);
+		sprintf(buf, "presentFuncPtr=%llx", presentFuncPtr);
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 
@@ -314,7 +314,7 @@ UINT GetD3D9SCPresentOffset(HWND hWnd){
 		UINT presentFuncOffset = (presentFuncPtr - reinterpret_cast<UINT>(pD3d9));
 
 #ifndef NO_QT
-		sprintf(buf, "presentFuncOffset=%x", presentFuncOffset);
+		sprintf(buf, "presentFuncOffset=%llx", presentFuncOffset);
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 
@@ -387,14 +387,14 @@ UINT GetD3D9ResetOffset(HWND hWnd){
 		uintptr_t resetFuncPtr = pvtbl[D3D9_RESET_FUNC_ORD];
 #ifndef NO_QT
 		char buf[100];
-		sprintf(buf, "resetFuncPtr=%x", resetFuncPtr);
+		sprintf(buf, "resetFuncPtr=%llx", resetFuncPtr);
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 
 		UINT resetFuncOffset = (resetFuncPtr - reinterpret_cast<UINT>(hD3d9));
 
 #ifndef NO_QT
-		sprintf(buf, "resetFuncOffset=%x", resetFuncOffset);
+		sprintf(buf, "resetFuncOffset=%llx", resetFuncOffset);
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << buf;
 #endif
 

--- a/Software/grab/D3D10Grabber.cpp
+++ b/Software/grab/D3D10Grabber.cpp
@@ -651,7 +651,7 @@ void D3D10Grabber::init() {
 	connect(m_impl.data(), SIGNAL(frameGrabbed()), this, SLOT(grab()));
 	_screensWithWidgets.clear();
 	GrabbedScreen grabbedScreen;
-	grabbedScreen.screenInfo.handle = reinterpret_cast<void *>(QApplication::desktop()->primaryScreen());
+	grabbedScreen.screenInfo.handle = IntToPtr(QApplication::desktop()->primaryScreen());
 	grabbedScreen.screenInfo.rect = QApplication::desktop()->screenGeometry(QApplication::desktop()->primaryScreen());
 	_screensWithWidgets.append(grabbedScreen);
 

--- a/Software/grab/D3D10Grabber.cpp
+++ b/Software/grab/D3D10Grabber.cpp
@@ -366,19 +366,19 @@ public:
 		}
 		m_worker->moveToThread(m_workerThread.data());
 		m_workerThread->start();
-		connect(m_worker.data(), SIGNAL(frameGrabbed()), this, SIGNAL(frameGrabbed()), Qt::QueuedConnection);
+		connect(m_worker.data(), &D3D10GrabberWorker::frameGrabbed, this, &D3D10GrabberImpl::frameGrabbed, Qt::QueuedConnection);
 		QMetaObject::invokeMethod(m_worker.data(), "runLoop", Qt::QueuedConnection);
 
 		m_processesScanAndInfectTimer.reset(new QTimer(this));
 		m_processesScanAndInfectTimer->setInterval(5000);
 		m_processesScanAndInfectTimer->setSingleShot(false);
-		connect(m_processesScanAndInfectTimer.data(), SIGNAL(timeout()), m_injector.data(), SLOT(infectCleanDxProcesses()));
+		connect(m_processesScanAndInfectTimer.data(), &QTimer::timeout, m_injector.data(), &D3D10GrabberInjector::infectCleanDxProcesses);
 		m_processesScanAndInfectTimer->start();
 
 		m_checkIfFrameGrabbedTimer.reset(new QTimer(this));
 		m_checkIfFrameGrabbedTimer->setSingleShot(false);
 		m_checkIfFrameGrabbedTimer->setInterval(1000);
-		connect(m_checkIfFrameGrabbedTimer.data(), SIGNAL(timeout()), SLOT(handleIfFrameGrabbed()));
+		connect(m_checkIfFrameGrabbedTimer.data(), &QTimer::timeout, this, &D3D10GrabberImpl::handleIfFrameGrabbed);
 		m_checkIfFrameGrabbedTimer->start();
 		m_isInited = true;
 		return m_isInited;
@@ -610,7 +610,7 @@ private:
 		m_injectorThread->wait();
 
 
-		disconnect(this, SLOT(handleIfFrameGrabbed()));
+		disconnect(this, &D3D10GrabberImpl::handleIfFrameGrabbed, nullptr, nullptr);
 		freeIPC();
 		CoUninitialize();
 		m_isInited = false;
@@ -648,7 +648,7 @@ D3D10Grabber::D3D10Grabber(QObject *parent, GrabberContext *context, GetHwndCall
 
 void D3D10Grabber::init() {
 	m_impl->init();
-	connect(m_impl.data(), SIGNAL(frameGrabbed()), this, SLOT(grab()));
+	connect(m_impl.data(), &D3D10GrabberImpl::frameGrabbed, this, &D3D10Grabber::grab);
 	_screensWithWidgets.clear();
 	GrabbedScreen grabbedScreen;
 	grabbedScreen.screenInfo.handle = IntToPtr(QApplication::desktop()->primaryScreen());

--- a/Software/grab/D3D10Grabber.cpp
+++ b/Software/grab/D3D10Grabber.cpp
@@ -660,7 +660,7 @@ void D3D10Grabber::init() {
 		qWarning() << Q_FUNC_INFO << "DX hooking is enabled but application not running elevated";
 		// Do not show the message box during initialization (creating a unwanted message loop)
 		// Show as soon as the message loop is established
-		QTimer::singleShot(0, this, SLOT(showAdminMessage()));
+		QTimer::singleShot(0, this, &D3D10Grabber::showAdminMessage);
 	}
 }
 

--- a/Software/grab/D3D10Grabber.cpp
+++ b/Software/grab/D3D10Grabber.cpp
@@ -77,7 +77,7 @@ namespace {
 
 	const unsigned kBytesPerPixel = 4;
 
-	D3D10GrabberWorker::D3D10GrabberWorker(QObject *parent, LPSECURITY_ATTRIBUTES lpsa) : 
+	D3D10GrabberWorker::D3D10GrabberWorker(QObject *parent, LPSECURITY_ATTRIBUTES lpsa) :
 		QObject(parent),
 		m_lpsa(lpsa)
 	{
@@ -171,7 +171,7 @@ namespace {
 		if (m_libraryInjector) {
 			m_libraryInjector->Release();
 			CoUninitialize();
-		}	
+		}
 	}
 
 	void D3D10GrabberInjector::infectCleanDxProcesses() {
@@ -375,7 +375,7 @@ public:
 		connect(m_processesScanAndInfectTimer.data(), SIGNAL(timeout()), m_injector.data(), SLOT(infectCleanDxProcesses()));
 		m_processesScanAndInfectTimer->start();
 
-		m_checkIfFrameGrabbedTimer.reset(new QTimer());
+		m_checkIfFrameGrabbedTimer.reset(new QTimer(this));
 		m_checkIfFrameGrabbedTimer->setSingleShot(false);
 		m_checkIfFrameGrabbedTimer->setInterval(1000);
 		connect(m_checkIfFrameGrabbedTimer.data(), SIGNAL(timeout()), SLOT(handleIfFrameGrabbed()));

--- a/Software/grab/D3D10Grabber.cpp
+++ b/Software/grab/D3D10Grabber.cpp
@@ -369,15 +369,16 @@ public:
 		connect(m_worker.data(), &D3D10GrabberWorker::frameGrabbed, this, &D3D10GrabberImpl::frameGrabbed, Qt::QueuedConnection);
 		QMetaObject::invokeMethod(m_worker.data(), "runLoop", Qt::QueuedConnection);
 
+		using namespace std::chrono_literals;
 		m_processesScanAndInfectTimer.reset(new QTimer(this));
-		m_processesScanAndInfectTimer->setInterval(5000);
+		m_processesScanAndInfectTimer->setInterval(5s);
 		m_processesScanAndInfectTimer->setSingleShot(false);
 		connect(m_processesScanAndInfectTimer.data(), &QTimer::timeout, m_injector.data(), &D3D10GrabberInjector::infectCleanDxProcesses);
 		m_processesScanAndInfectTimer->start();
 
 		m_checkIfFrameGrabbedTimer.reset(new QTimer(this));
 		m_checkIfFrameGrabbedTimer->setSingleShot(false);
-		m_checkIfFrameGrabbedTimer->setInterval(1000);
+		m_checkIfFrameGrabbedTimer->setInterval(1s);
 		connect(m_checkIfFrameGrabbedTimer.data(), &QTimer::timeout, this, &D3D10GrabberImpl::handleIfFrameGrabbed);
 		m_checkIfFrameGrabbedTimer->start();
 		m_isInited = true;

--- a/Software/grab/D3D10Grabber.cpp
+++ b/Software/grab/D3D10Grabber.cpp
@@ -33,8 +33,8 @@
 
 #include <QObject>
 #include <QThread>
-#include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
+#include <QGuiApplication>
 #include <QMessageBox>
 #include <cstdlib>
 #include <stdio.h>
@@ -652,8 +652,8 @@ void D3D10Grabber::init() {
 	connect(m_impl.data(), &D3D10GrabberImpl::frameGrabbed, this, &D3D10Grabber::grab);
 	_screensWithWidgets.clear();
 	GrabbedScreen grabbedScreen;
-	grabbedScreen.screenInfo.handle = IntToPtr(QApplication::desktop()->primaryScreen());
-	grabbedScreen.screenInfo.rect = QApplication::desktop()->screenGeometry(QApplication::desktop()->primaryScreen());
+	grabbedScreen.screenInfo.handle = QGuiApplication::primaryScreen();// unused?
+	grabbedScreen.screenInfo.rect = QGuiApplication::primaryScreen()->geometry();
 	_screensWithWidgets.append(grabbedScreen);
 
 	if (!WinUtils::IsUserAdmin()) {

--- a/Software/grab/DDuplGrabber.cpp
+++ b/Software/grab/DDuplGrabber.cpp
@@ -618,7 +618,7 @@ GrabResult DDuplGrabber::grabScreens()
 				// in theory, DXGI_ERROR_INVALID_CALL is returned if the frame was not released
 				// it also happens in conjunction with secure desktop (even though the frame was properly released)
 				m_state = LostAccess;
-				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Lost Access to desktop" << screen.screenInfo.handle << ":" << (void*)(0xffffffff & hr) << ", requesting realloc";
+				DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Lost Access to desktop" << screen.screenInfo.handle << ":" << IntToPtr(0xffffffff & hr) << ", requesting realloc";
 				return GrabResultFrameNotReady;
 			}
 			else if (FAILED(hr))

--- a/Software/grab/GrabberBase.cpp
+++ b/Software/grab/GrabberBase.cpp
@@ -60,7 +60,7 @@ GrabberBase::GrabberBase(QObject *parent, GrabberContext *grabberContext) : QObj
 		m_timer->stop();
 	m_timer.reset(new QTimer(this));
 	m_timer->setTimerType(Qt::PreciseTimer);
-	connect(m_timer.data(), SIGNAL(timeout()), this, SLOT(grab()));
+	connect(m_timer.data(), &QTimer::timeout, this, &GrabberBase::grab);
 }
 
 void GrabberBase::setGrabInterval(int msec)

--- a/Software/grab/grab.pro
+++ b/Software/grab/grab.pro
@@ -9,7 +9,7 @@ QT       += widgets
 DESTDIR = ../lib
 TARGET = grab
 TEMPLATE = lib
-CONFIG += staticlib
+CONFIG += staticlib c++17
 
 include(../build-config.prf)
 
@@ -27,7 +27,6 @@ QMAKE_CFLAGS = $$(CFLAGS)
 QMAKE_CXXFLAGS = $$(CXXFLAGS)
 QMAKE_LFLAGS = $$(LDFLAGS)
 
-QMAKE_CXXFLAGS += -std=c++17
 CONFIG(clang) {
     QMAKE_CXXFLAGS += -stdlib=libc++
     LIBS += -stdlib=libc++

--- a/Software/grab/grab.pro
+++ b/Software/grab/grab.pro
@@ -44,7 +44,7 @@ unix:!macx {
 
 # Mac platform
 macx {
-    contains(DEFINES, MAC_OS_CG_GRAB_SUPPORT) || contains(DEFINES, MAC_OS_AV_GRAB_SUPPORT) {
+    contains(DEFINES, MAC_OS_CG_GRAB_SUPPORT) | contains(DEFINES, MAC_OS_AV_GRAB_SUPPORT) {
         GRABBERS_HEADERS += include/MacOSGrabberBase.hpp
         GRABBERS_SOURCES += MacOSGrabberBase.mm
     }

--- a/Software/grab/include/BlueLightReduction.hpp
+++ b/Software/grab/include/BlueLightReduction.hpp
@@ -1,14 +1,13 @@
 #pragma once
 #include <QList>
 #include <QRgb>
-#include <cassert>
 
 namespace BlueLightReduction
 {
 	class Client
 	{
 	public:
-		static bool isSupported() { assert(("BlueLightReduction::isSupported() is not implemented", false)); return false; }
+		static bool isSupported() { Q_ASSERT_X(false, "BlueLightReduction::isSupported()", "not implemented"); return false; }
 		virtual void apply(QList<QRgb>& colors, const double gamma = 1.2) = 0;
 		virtual ~Client() = default;
 	};

--- a/Software/grab/include/BlueLightReduction.hpp
+++ b/Software/grab/include/BlueLightReduction.hpp
@@ -6,6 +6,7 @@ namespace BlueLightReduction
 {
 	class Client
 	{
+		Q_DISABLE_COPY(Client)
 	public:
 		static bool isSupported() { Q_ASSERT_X(false, "BlueLightReduction::isSupported()", "not implemented"); return false; }
 		virtual void apply(QList<QRgb>& colors, const double gamma = 1.2) = 0;

--- a/Software/grab/include/BlueLightReduction.hpp
+++ b/Software/grab/include/BlueLightReduction.hpp
@@ -11,6 +11,7 @@ namespace BlueLightReduction
 		static bool isSupported() { Q_ASSERT_X(false, "BlueLightReduction::isSupported()", "not implemented"); return false; }
 		virtual void apply(QList<QRgb>& colors, const double gamma = 1.2) = 0;
 		virtual ~Client() = default;
+		Client() = default;
 	};
 
 	Client* create();

--- a/Software/grab/include/GrabberBase.hpp
+++ b/Software/grab/include/GrabberBase.hpp
@@ -91,22 +91,21 @@ public:
 
 	virtual const char * name() const = 0;
 
-public slots:
 	virtual void startGrabbing();
 	virtual void stopGrabbing();
 	virtual bool isGrabbingStarted() const;
-	virtual void setGrabInterval(int msec);
+public slots:
 
+	virtual void setGrabInterval(int msec);
 	virtual void grab();
 
-protected slots:
+protected:
 	/*!
 		Grabs screens and saves them to \a GrabberBase#_screensWithWidgets field. Called by
 		\a GrabberBase#grab() slot. Needs to be implemented in derived classes.
 		\return GrabResult
 	*/
 	virtual GrabResult grabScreens() = 0;
-
 	/*!
 		* Frees unnecessary resources and allocates needed ones based on \a ScreenInfo
 		* \param grabScreens
@@ -121,10 +120,7 @@ protected slots:
 		* \return
 		*/
 	virtual QList< ScreenInfo > * screensWithWidgets(QList< ScreenInfo > * result, const QList<GrabWidget *> &grabWidgets) = 0;
-
 	virtual bool isReallocationNeeded(const QList< ScreenInfo > &grabScreens) const;
-
-protected:
 	const GrabbedScreen * screenOfRect(const QRect &rect) const;
 
 signals:

--- a/Software/grab/include/GrabberContext.hpp
+++ b/Software/grab/include/GrabberContext.hpp
@@ -79,7 +79,7 @@ public:
 	}
 
 	void releaseAllBufs() {
-		for (QList<AllocatedBuf*>::const_iterator iter = _allocatedBufs.cbegin(); iter != _allocatedBufs.end(); ++iter) {
+		for (QList<AllocatedBuf*>::const_iterator iter = _allocatedBufs.cbegin(); iter != _allocatedBufs.cend(); ++iter) {
 			(*iter)->isAvail = true;
 		}
 	}

--- a/Software/hooks/hooks.pro
+++ b/Software/hooks/hooks.pro
@@ -30,6 +30,7 @@ LIBS += -ldxguid
 QMAKE_LFLAGS_EXCEPTIONS_ON -= -mthreads
 QMAKE_CXXFLAGS_EXCEPTIONS_ON -= -mthreads
 
+CONFIG += c++17
 CONFIG -= rtti
 
 DEFINES += HOOKSDLL_EXPORTS UNICODE
@@ -43,7 +44,6 @@ CONFIG(msvc) {
     # Place *.lib and *.exp files in ../lib
     QMAKE_LFLAGS += /INCREMENTAL:NO /IMPLIB:..\\lib\\$(TargetName).lib
 } else {
-    QMAKE_CXXFLAGS += -std=c++17
     QMAKE_LFLAGS += -static
 }
 

--- a/Software/hooks/hooks.pro
+++ b/Software/hooks/hooks.pro
@@ -43,7 +43,7 @@ CONFIG(msvc) {
     # Place *.lib and *.exp files in ../lib
     QMAKE_LFLAGS += /INCREMENTAL:NO /IMPLIB:..\\lib\\$(TargetName).lib
 } else {
-    QMAKE_CXXFLAGS += -std=c++11
+    QMAKE_CXXFLAGS += -std=c++17
     QMAKE_LFLAGS += -static
 }
 

--- a/Software/hooks/hooks32.pro
+++ b/Software/hooks/hooks32.pro
@@ -36,6 +36,7 @@ LIBS += -ldxguid
 QMAKE_LFLAGS_EXCEPTIONS_ON -= -mthreads
 QMAKE_CXXFLAGS_EXCEPTIONS_ON -= -mthreads
 
+CONFIG += c++17
 CONFIG -= rtti
 
 DEFINES += HOOKSDLL_EXPORTS UNICODE
@@ -49,7 +50,6 @@ CONFIG(msvc) {
     # Place *.lib and *.exp files in ../lib
     QMAKE_LFLAGS += /INCREMENTAL:NO /IMPLIB:..\\lib\\$(TargetName).lib
 } else {
-    QMAKE_CXXFLAGS += -std=c++17
     QMAKE_LFLAGS += -static
 }
 

--- a/Software/hooks/hooks32.pro
+++ b/Software/hooks/hooks32.pro
@@ -49,7 +49,7 @@ CONFIG(msvc) {
     # Place *.lib and *.exp files in ../lib
     QMAKE_LFLAGS += /INCREMENTAL:NO /IMPLIB:..\\lib\\$(TargetName).lib
 } else {
-    QMAKE_CXXFLAGS += -std=c++11
+    QMAKE_CXXFLAGS += -std=c++17
     QMAKE_LFLAGS += -static
 }
 

--- a/Software/math/math.pro
+++ b/Software/math/math.pro
@@ -7,7 +7,7 @@
 DESTDIR = ../lib
 TARGET = prismatik-math
 TEMPLATE = lib
-CONFIG += staticlib
+CONFIG += staticlib c++17
 
 include(../build-config.prf)
 

--- a/Software/src/AbstractLedDevice.cpp
+++ b/Software/src/AbstractLedDevice.cpp
@@ -29,6 +29,11 @@
 #include "PrismatikMath.hpp"
 #include "Settings.hpp"
 
+void AbstractLedDevice::setUsbPowerLedDisabled(bool isDisabled) {
+	Q_UNUSED(isDisabled);
+	emit commandCompleted(true);
+}
+
 void AbstractLedDevice::setGamma(double value, bool updateColors) {
 	m_gamma = value;
 	if (updateColors)

--- a/Software/src/AbstractLedDevice.hpp
+++ b/Software/src/AbstractLedDevice.hpp
@@ -41,6 +41,8 @@ public:
 	AbstractLedDevice(QObject * parent) : QObject(parent) {}
 	virtual ~AbstractLedDevice(){}
 	virtual QString name() const = 0;
+	virtual int defaultLedsCount() = 0;
+	virtual int maxLedsCount() = 0;
 
 signals:
 	void openDeviceSuccess(bool isSuccess);
@@ -83,8 +85,6 @@ public slots:
 	virtual void requestFirmwareVersion() = 0;
 	virtual void updateDeviceSettings();
 
-	virtual int maxLedsCount() = 0;
-	virtual int defaultLedsCount() = 0;
 
 	/*!
 		\obsolete only form compatibility with Lightpack ver.<=5.5 hardware

--- a/Software/src/AbstractLedDevice.hpp
+++ b/Software/src/AbstractLedDevice.hpp
@@ -93,7 +93,7 @@ public slots:
 	virtual void setColorDepth(int value) = 0;
 
 
-	virtual void setUsbPowerLedDisabled(bool isDisabled) { Q_UNUSED(isDisabled) emit commandCompleted(true); };
+	virtual void setUsbPowerLedDisabled(bool isDisabled);
 
 protected:
 	virtual void applyColorModifications(const QList<QRgb> & inColors, QList<StructRgb> & outColors);

--- a/Software/src/AbstractLedDevice.hpp
+++ b/Software/src/AbstractLedDevice.hpp
@@ -40,6 +40,7 @@ class AbstractLedDevice : public QObject
 public:
 	AbstractLedDevice(QObject * parent) : QObject(parent) {}
 	virtual ~AbstractLedDevice(){}
+	virtual QString name() const = 0;
 
 signals:
 	void openDeviceSuccess(bool isSuccess);
@@ -56,7 +57,6 @@ signals:
 	void colorsUpdated(QList<QRgb> colors);
 
 public slots:
-	virtual const QString name() const = 0;
 	virtual void open() = 0;
 	virtual void close() = 0;
 	virtual void setColors(const QList<QRgb> & colors) = 0;
@@ -75,7 +75,7 @@ public slots:
 	virtual void setDitheringEnabled(bool value, bool updateColors = true);
 	virtual void setLedMilliAmps(const int value, const bool updateColors = true);
 	virtual void setPowerSupplyAmps(const double value, const bool updateColors = true);
-	virtual void setColorSequence(QString value) = 0;
+	virtual void setColorSequence(const QString& value) = 0;
 	virtual void setLuminosityThreshold(int value, bool updateColors = true);
 	virtual void setMinimumLuminosityThresholdEnabled(bool value, bool updateColors = true);
 	virtual void updateWBAdjustments(); // Reads from settings

--- a/Software/src/AbstractLedDeviceUdp.cpp
+++ b/Software/src/AbstractLedDeviceUdp.cpp
@@ -77,7 +77,7 @@ void AbstractLedDeviceUdp::setSmoothSlowdown(int /*value*/)
 	emit commandCompleted(true);
 }
 
-void AbstractLedDeviceUdp::setColorSequence(QString value)
+void AbstractLedDeviceUdp::setColorSequence(const QString& value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value;
 
@@ -87,20 +87,22 @@ void AbstractLedDeviceUdp::setColorSequence(QString value)
 	emit commandCompleted(true);
 }
 
-void AbstractLedDeviceUdp::setGamma(double value)
+void AbstractLedDeviceUdp::setGamma(double value, const bool update = true)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value;
 
 	m_gamma = value;
-	setColors(m_colorsSaved);
+	if (update)
+		setColors(m_colorsSaved);
 }
 
-void AbstractLedDeviceUdp::setBrightness(int percent)
+void AbstractLedDeviceUdp::setBrightness(int percent, const bool update = true)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << percent;
 
 	m_brightness = percent;
-	setColors(m_colorsSaved);
+	if (update)
+		setColors(m_colorsSaved);
 }
 
 void AbstractLedDeviceUdp::open()

--- a/Software/src/AbstractLedDeviceUdp.cpp
+++ b/Software/src/AbstractLedDeviceUdp.cpp
@@ -79,6 +79,30 @@ void AbstractLedDeviceUdp::open()
 	reinitBufferHeader();
 }
 
+void AbstractLedDeviceUdp::setRefreshDelay(int value)
+{
+	Q_UNUSED(value);
+	emit commandCompleted(true);
+}
+
+void AbstractLedDeviceUdp::setSmoothSlowdown(int value)
+{
+	Q_UNUSED(value);
+	emit commandCompleted(true);
+}
+
+void AbstractLedDeviceUdp::setColorSequence(const QString& value)
+{
+	Q_UNUSED(value);
+	emit commandCompleted(true);
+}
+
+void AbstractLedDeviceUdp::setColorDepth(int value)
+{
+	Q_UNUSED(value);
+	emit commandCompleted(true);
+}
+
 void AbstractLedDeviceUdp::switchOffLeds()
 {
 	const int count = m_colorsSaved.count();

--- a/Software/src/AbstractLedDeviceUdp.hpp
+++ b/Software/src/AbstractLedDeviceUdp.hpp
@@ -34,34 +34,34 @@ class AbstractLedDeviceUdp : public AbstractLedDevice
 {
 	Q_OBJECT
 public:
-    AbstractLedDeviceUdp(const QString& address, const QString& port, const int timeout, QObject * parent = 0);
-    virtual ~AbstractLedDeviceUdp();
+	AbstractLedDeviceUdp(const QString& address, const QString& port, const uint8_t timeout, QObject * parent = 0);
+	virtual ~AbstractLedDeviceUdp();
+	int defaultLedsCount() { return 10; }
 
 public slots:
 	void open();
-    void close();
-	void setRefreshDelay(int /*value*/);
-	void setColorDepth(int /*value*/);
-	void setSmoothSlowdown(int /*value*/);
-	void setColorSequence(const QString& /*value*/);
-	void setGamma(double value, bool update);
-	void setBrightness(int value, bool update);
-	int defaultLedsCount() { return 10; }
+	void close();
+	virtual void setRefreshDelay(int value) {Q_UNUSED(value); emit commandCompleted(true); };
+	virtual void setSmoothSlowdown(int value) {Q_UNUSED(value); emit commandCompleted(true); };
+	virtual void setColorSequence(const QString& value) {Q_UNUSED(value); emit commandCompleted(true); };
+	virtual void setColorDepth(int value) {Q_UNUSED(value); emit commandCompleted(true); };
+	virtual void requestFirmwareVersion();
+	void switchOffLeds();
 
 protected:
-    QByteArray m_writeBufferHeader;
-    QByteArray m_writeBuffer;
+	QByteArray m_writeBufferHeader;
+	QByteArray m_writeBuffer;
 
-    virtual void resizeColorsBuffer(int buffSize) = 0;
-    virtual void reinitBufferHeader() = 0;
-    bool writeBuffer(const QByteArray& buff);
+	void resizeColorsBuffer(int buffSize);
+	virtual void reinitBufferHeader() = 0;
+	bool writeBuffer(const QByteArray& buff);
 
-    int m_timeout;
-    constexpr static const unsigned char InfiniteTimeout = (unsigned char)255;
+	uint8_t m_timeout;
+	constexpr static const uint8_t InfiniteTimeout = (uint8_t)255;
 
 private:
-    QUdpSocket* m_Socket;
+	QUdpSocket* m_Socket;
 
-    QString m_address;
-    int m_port;
+	QString m_address;
+	uint16_t m_port {21324};
 };

--- a/Software/src/AbstractLedDeviceUdp.hpp
+++ b/Software/src/AbstractLedDeviceUdp.hpp
@@ -41,10 +41,10 @@ public:
 public slots:
 	void open();
 	void close();
-	virtual void setRefreshDelay(int value) {Q_UNUSED(value); emit commandCompleted(true); };
-	virtual void setSmoothSlowdown(int value) {Q_UNUSED(value); emit commandCompleted(true); };
-	virtual void setColorSequence(const QString& value) {Q_UNUSED(value); emit commandCompleted(true); };
-	virtual void setColorDepth(int value) {Q_UNUSED(value); emit commandCompleted(true); };
+	virtual void setRefreshDelay(int value);
+	virtual void setSmoothSlowdown(int value);
+	virtual void setColorSequence(const QString& value);
+	virtual void setColorDepth(int value);
 	virtual void requestFirmwareVersion();
 	void switchOffLeds();
 

--- a/Software/src/AbstractLedDeviceUdp.hpp
+++ b/Software/src/AbstractLedDeviceUdp.hpp
@@ -43,9 +43,9 @@ public slots:
 	void setRefreshDelay(int /*value*/);
 	void setColorDepth(int /*value*/);
 	void setSmoothSlowdown(int /*value*/);
-	void setColorSequence(QString /*value*/);
-	void setGamma(double value);
-	void setBrightness(int value);
+	void setColorSequence(const QString& /*value*/);
+	void setGamma(double value, bool update);
+	void setBrightness(int value, bool update);
 	int defaultLedsCount() { return 10; }
 
 protected:
@@ -57,7 +57,7 @@ protected:
     bool writeBuffer(const QByteArray& buff);
 
     int m_timeout;
-    constexpr static const char InfiniteTimeout = 255;
+    constexpr static const unsigned char InfiniteTimeout = (unsigned char)255;
 
 private:
     QUdpSocket* m_Socket;

--- a/Software/src/ApiServer.cpp
+++ b/Software/src/ApiServer.cpp
@@ -38,146 +38,146 @@
 using namespace SettingsScope;
 
 // Immediatly after successful connection server sends to client -- ApiVersion
-const char * ApiServer::ApiVersion = "Lightpack API v1.4 - Prismatik API v" API_VERSION " (type \"help\" for more info)\r\n";
-const char * ApiServer::CmdUnknown = "unknown command\r\n";
-const char * ApiServer::CmdDeprecated = "deprecated command, not supported\r\n";
-const char * ApiServer::CmdExit = "exit";
-const char * ApiServer::CmdHelp = "help";
-const char * ApiServer::CmdHelpShort = "?";
+const char * const ApiServer::ApiVersion = "Lightpack API v1.4 - Prismatik API v" API_VERSION " (type \"help\" for more info)\r\n";
+const char * const ApiServer::CmdUnknown = "unknown command\r\n";
+const char * const ApiServer::CmdDeprecated = "deprecated command, not supported\r\n";
+const char * const ApiServer::CmdExit = "exit";
+const char * const ApiServer::CmdHelp = "help";
+const char * const ApiServer::CmdHelpShort = "?";
 
-const char * ApiServer::CmdApiKey = "apikey:";
-const char * ApiServer::CmdApiKeyResult_Ok = "ok\r\n";
-const char * ApiServer::CmdApiKeyResult_Fail = "fail\r\n";
-const char * ApiServer::CmdApiCheck_AuthRequired = "authorization required\r\n";
+const char * const ApiServer::CmdApiKey = "apikey:";
+const char * const ApiServer::CmdApiKeyResult_Ok = "ok\r\n";
+const char * const ApiServer::CmdApiKeyResult_Fail = "fail\r\n";
+const char * const ApiServer::CmdApiCheck_AuthRequired = "authorization required\r\n";
 
-const char * ApiServer::CmdGetStatus = "getstatus";
-const char * ApiServer::CmdResultStatus_On = "status:on\r\n";
-const char * ApiServer::CmdResultStatus_Off = "status:off\r\n";
-const char * ApiServer::CmdResultStatus_DeviceError = "status:device error\r\n";
-const char * ApiServer::CmdResultStatus_Unknown = "status:unknown\r\n";
+const char * const ApiServer::CmdGetStatus = "getstatus";
+const char * const ApiServer::CmdResultStatus_On = "status:on\r\n";
+const char * const ApiServer::CmdResultStatus_Off = "status:off\r\n";
+const char * const ApiServer::CmdResultStatus_DeviceError = "status:device error\r\n";
+const char * const ApiServer::CmdResultStatus_Unknown = "status:unknown\r\n";
 
-const char * ApiServer::CmdGetStatusAPI = "getstatusapi";
-const char * ApiServer::CmdResultStatusAPI_Busy = "statusapi:busy\r\n";
-const char * ApiServer::CmdResultStatusAPI_Idle = "statusapi:idle\r\n";
+const char * const ApiServer::CmdGetStatusAPI = "getstatusapi";
+const char * const ApiServer::CmdResultStatusAPI_Busy = "statusapi:busy\r\n";
+const char * const ApiServer::CmdResultStatusAPI_Idle = "statusapi:idle\r\n";
 
-const char * ApiServer::CmdGetProfiles = "getprofiles";
+const char * const ApiServer::CmdGetProfiles = "getprofiles";
 // Necessary to add a new line after filling results!
-const char * ApiServer::CmdResultProfiles = "profiles:";
+const char * const ApiServer::CmdResultProfiles = "profiles:";
 
-const char * ApiServer::CmdGetProfile = "getprofile";
+const char * const ApiServer::CmdGetProfile = "getprofile";
 // Necessary to add a new line after filling results!
-const char * ApiServer::CmdResultProfile = "profile:";
+const char * const ApiServer::CmdResultProfile = "profile:";
 
-const char * ApiServer::CmdGetDevices = "getdevices";
-const char * ApiServer::CmdResultDevices = "devices:";
-const char * ApiServer::CmdGetDevice = "getdevice";
-const char * ApiServer::CmdResultDevice = "device:";
+const char * const ApiServer::CmdGetDevices = "getdevices";
+const char * const ApiServer::CmdResultDevices = "devices:";
+const char * const ApiServer::CmdGetDevice = "getdevice";
+const char * const ApiServer::CmdResultDevice = "device:";
 
-const char * ApiServer::CmdGetMaxLeds = "getmaxleds";
-const char * ApiServer::CmdResultMaxLeds = "maxleds:";
+const char * const ApiServer::CmdGetMaxLeds = "getmaxleds";
+const char * const ApiServer::CmdResultMaxLeds = "maxleds:";
 
-const char * ApiServer::CmdGetCountLeds = "getcountleds";
+const char * const ApiServer::CmdGetCountLeds = "getcountleds";
 // Necessary to add a new line after filling results!
-const char * ApiServer::CmdResultCountLeds = "countleds:";
+const char * const ApiServer::CmdResultCountLeds = "countleds:";
 
-const char * ApiServer::CmdGetLeds = "getleds";
-const char * ApiServer::CmdResultLeds = "leds:";
+const char * const ApiServer::CmdGetLeds = "getleds";
+const char * const ApiServer::CmdResultLeds = "leds:";
 
-const char * ApiServer::CmdGetColors = "getcolors";
-const char * ApiServer::CmdResultGetColors = "colors:";
+const char * const ApiServer::CmdGetColors = "getcolors";
+const char * const ApiServer::CmdResultGetColors = "colors:";
 
-const char * ApiServer::CmdGetFPS = "getfps";
-const char * ApiServer::CmdResultFPS = "fps:";
+const char * const ApiServer::CmdGetFPS = "getfps";
+const char * const ApiServer::CmdResultFPS = "fps:";
 
-const char * ApiServer::CmdGetScreenSize = "getscreensize";
-const char * ApiServer::CmdResultScreenSize = "screensize:";
+const char * const ApiServer::CmdGetScreenSize = "getscreensize";
+const char * const ApiServer::CmdResultScreenSize = "screensize:";
 
-const char * ApiServer::CmdGetCountMonitor = "getcountmonitors";
-const char * ApiServer::CmdResultCountMonitor = "countmonitors:";
+const char * const ApiServer::CmdGetCountMonitor = "getcountmonitors";
+const char * const ApiServer::CmdResultCountMonitor = "countmonitors:";
 
-const char * ApiServer::CmdGetSizeMonitor = "getsizemonitor:";
-const char * ApiServer::CmdResultSizeMonitor = "sizemonitor:";
+const char * const ApiServer::CmdGetSizeMonitor = "getsizemonitor:";
+const char * const ApiServer::CmdResultSizeMonitor = "sizemonitor:";
 
-const char * ApiServer::CmdGetBacklight = "getmode";
-const char * ApiServer::CmdResultBacklight_Ambilight = "mode:ambilight\r\n";
-const char * ApiServer::CmdResultBacklight_Moodlamp = "mode:moodlamp\r\n";
+const char * const ApiServer::CmdGetBacklight = "getmode";
+const char * const ApiServer::CmdResultBacklight_Ambilight = "mode:ambilight\r\n";
+const char * const ApiServer::CmdResultBacklight_Moodlamp = "mode:moodlamp\r\n";
 #ifdef SOUNDVIZ_SUPPORT
-const char * ApiServer::CmdResultBacklight_SoundViz = "mode:soundviz\r\n";
+const char * const ApiServer::CmdResultBacklight_SoundViz = "mode:soundviz\r\n";
 #endif
 
-const char * ApiServer::CmdGetGamma = "getgamma";
-const char * ApiServer::CmdResultGamma = "gamma:";
+const char * const ApiServer::CmdGetGamma = "getgamma";
+const char * const ApiServer::CmdResultGamma = "gamma:";
 
-const char * ApiServer::CmdGetBrightness = "getbrightness";
-const char * ApiServer::CmdResultBrightness = "brightness:";
+const char * const ApiServer::CmdGetBrightness = "getbrightness";
+const char * const ApiServer::CmdResultBrightness = "brightness:";
 
-const char * ApiServer::CmdGetSmooth = "getsmooth";
-const char * ApiServer::CmdResultSmooth = "smooth:";
+const char * const ApiServer::CmdGetSmooth = "getsmooth";
+const char * const ApiServer::CmdResultSmooth = "smooth:";
 
 #ifdef SOUNDVIZ_SUPPORT
-const char * ApiServer::CmdGetSoundVizColors = "getsoundvizcolors";
-const char * ApiServer::CmdResultSoundVizColors = "soundvizcolors:";
+const char * const ApiServer::CmdGetSoundVizColors = "getsoundvizcolors";
+const char * const ApiServer::CmdResultSoundVizColors = "soundvizcolors:";
 
-const char * ApiServer::CmdGetSoundVizLiquid = "getsoundvizliquid";
-const char * ApiServer::CmdResultSoundVizLiquid = "soundvizliquid:";
+const char * const ApiServer::CmdGetSoundVizLiquid = "getsoundvizliquid";
+const char * const ApiServer::CmdResultSoundVizLiquid = "soundvizliquid:";
 #endif
-const char * ApiServer::CmdGetPersistOnUnlock = "getpersistonunlock";
-const char * ApiServer::CmdGetPersistOnUnlock_On = "persistonunlock:on\r\n";
-const char * ApiServer::CmdGetPersistOnUnlock_Off = "persistonunlock:off\r\n";
+const char * const ApiServer::CmdGetPersistOnUnlock = "getpersistonunlock";
+const char * const ApiServer::CmdGetPersistOnUnlock_On = "persistonunlock:on\r\n";
+const char * const ApiServer::CmdGetPersistOnUnlock_Off = "persistonunlock:off\r\n";
 
-const char * ApiServer::CmdGuid = "guid:";
+const char * const ApiServer::CmdGuid = "guid:";
 
-const char * ApiServer::CmdLockStatus = "getlockstatus";
+const char * const ApiServer::CmdLockStatus = "getlockstatus";
 
-const char * ApiServer::CmdLock = "lock";
-const char * ApiServer::CmdResultLock_Success = "lock:success\r\n";
-const char * ApiServer::CmdResultLock_Busy = "lock:busy\r\n";
+const char * const ApiServer::CmdLock = "lock";
+const char * const ApiServer::CmdResultLock_Success = "lock:success\r\n";
+const char * const ApiServer::CmdResultLock_Busy = "lock:busy\r\n";
 
-const char * ApiServer::CmdUnlock = "unlock";
-const char * ApiServer::CmdResultUnlock_Success = "unlock:success\r\n";
-const char * ApiServer::CmdResultUnlock_NotLocked = "unlock:not locked\r\n";
+const char * const ApiServer::CmdUnlock = "unlock";
+const char * const ApiServer::CmdResultUnlock_Success = "unlock:success\r\n";
+const char * const ApiServer::CmdResultUnlock_NotLocked = "unlock:not locked\r\n";
 
 // Set-commands works only after success lock
 // Set-commands can return, after self-name, only this results:
-const char * ApiServer::CmdSetResult_Ok = "ok\r\n";
-const char * ApiServer::CmdSetResult_Error = "error\r\n";
-const char * ApiServer::CmdSetResult_Busy = "busy\r\n";
-const char * ApiServer::CmdSetResult_NotLocked = "not locked\r\n";
+const char * const ApiServer::CmdSetResult_Ok = "ok\r\n";
+const char * const ApiServer::CmdSetResult_Error = "error\r\n";
+const char * const ApiServer::CmdSetResult_Busy = "busy\r\n";
+const char * const ApiServer::CmdSetResult_NotLocked = "not locked\r\n";
 
 // Set-commands contains at end semicolon!!!
-const char * ApiServer::CmdSetColor = "setcolor:";
-const char * ApiServer::CmdSetGamma = "setgamma:";
-const char * ApiServer::CmdSetBrightness = "setbrightness:";
-const char * ApiServer::CmdSetSmooth = "setsmooth:";
-const char * ApiServer::CmdSetProfile = "setprofile:";
+const char * const ApiServer::CmdSetColor = "setcolor:";
+const char * const ApiServer::CmdSetGamma = "setgamma:";
+const char * const ApiServer::CmdSetBrightness = "setbrightness:";
+const char * const ApiServer::CmdSetSmooth = "setsmooth:";
+const char * const ApiServer::CmdSetProfile = "setprofile:";
 
 #ifdef SOUNDVIZ_SUPPORT
-const char * ApiServer::CmdSetSoundVizColors = "setsoundvizcolors:";
-const char * ApiServer::CmdSetSoundVizLiquid = "setsoundvizliquid:";
+const char * const ApiServer::CmdSetSoundVizColors = "setsoundvizcolors:";
+const char * const ApiServer::CmdSetSoundVizLiquid = "setsoundvizliquid:";
 #endif
 
-const char * ApiServer::CmdSetDevice = "setdevice:";
+const char * const ApiServer::CmdSetDevice = "setdevice:";
 
-const char * ApiServer::CmdSetCountLeds = "setcountleds:";
-const char * ApiServer::CmdSetLeds = "setleds:";
+const char * const ApiServer::CmdSetCountLeds = "setcountleds:";
+const char * const ApiServer::CmdSetLeds = "setleds:";
 
-const char * ApiServer::CmdNewProfile = "newprofile:";
-const char * ApiServer::CmdDeleteProfile = "deleteprofile:";
+const char * const ApiServer::CmdNewProfile = "newprofile:";
+const char * const ApiServer::CmdDeleteProfile = "deleteprofile:";
 
-const char * ApiServer::CmdSetStatus = "setstatus:";
-const char * ApiServer::CmdSetStatus_On = "on";
-const char * ApiServer::CmdSetStatus_Off = "off";
+const char * const ApiServer::CmdSetStatus = "setstatus:";
+const char * const ApiServer::CmdSetStatus_On = "on";
+const char * const ApiServer::CmdSetStatus_Off = "off";
 
-const char * ApiServer::CmdSetBacklight = "setmode:";
-const char * ApiServer::CmdSetBacklight_Ambilight = "ambilight";
-const char * ApiServer::CmdSetBacklight_Moodlamp = "moodlamp";
+const char * const ApiServer::CmdSetBacklight = "setmode:";
+const char * const ApiServer::CmdSetBacklight_Ambilight = "ambilight";
+const char * const ApiServer::CmdSetBacklight_Moodlamp = "moodlamp";
 #ifdef SOUNDVIZ_SUPPORT
-const char * ApiServer::CmdSetBacklight_SoundViz = "soundviz";
+const char * const ApiServer::CmdSetBacklight_SoundViz = "soundviz";
 #endif
 
-const char * ApiServer::CmdSetPersistOnUnlock = "setpersistonunlock:";
-const char * ApiServer::CmdSetPersistOnUnlock_On = "on";
-const char * ApiServer::CmdSetPersistOnUnlock_Off = "off";
+const char * const ApiServer::CmdSetPersistOnUnlock = "setpersistonunlock:";
+const char * const ApiServer::CmdSetPersistOnUnlock_On = "on";
+const char * const ApiServer::CmdSetPersistOnUnlock_Off = "off";
 
 const int ApiServer::SignalWaitTimeoutMs = 1000; // 1 second
 

--- a/Software/src/ApiServer.cpp
+++ b/Software/src/ApiServer.cpp
@@ -269,7 +269,7 @@ void ApiServer::incomingConnection(qintptr socketDescriptor)
 	ClientInfo cs;
 	cs.isAuthorized = !m_isAuthEnabled;
 	// set default sessionkey (disable lock priority)
-	cs.sessionKey = QStringLiteral("API")+lightpack->GetSessionKey(QStringLiteral("API"))+QString(m_clients.count());
+	cs.sessionKey = QStringLiteral("API%1%2").arg(lightpack->GetSessionKey(QStringLiteral("API")), QString::number(m_clients.count()));
 
 	m_clients.insert(client, cs);
 

--- a/Software/src/ApiServer.cpp
+++ b/Software/src/ApiServer.cpp
@@ -220,7 +220,7 @@ void ApiServer::setInterface(LightpackPluginInterface *lightpackInterface)
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << test;
 	lightpack = lightpackInterface;
 	connect(m_apiSetColorTask, SIGNAL(taskParseSetColorDone(QList<QRgb>)), lightpack, SIGNAL(updateLedsColors(QList<QRgb>)), Qt::QueuedConnection);
-	connect(m_apiSetColorTask, SIGNAL(taskParseSetColorDone(const QList<QRgb> &)), lightpack, SLOT(updateColorsCache(const QList<QRgb> &)), Qt::QueuedConnection);
+	connect(m_apiSetColorTask, SIGNAL(taskParseSetColorDone(QList<QRgb>)), lightpack, SLOT(updateColorsCache(QList<QRgb>)), Qt::QueuedConnection);
 
 }
 

--- a/Software/src/ApiServer.cpp
+++ b/Software/src/ApiServer.cpp
@@ -255,7 +255,7 @@ void ApiServer::updateApiKey(const QString &key)
 
 	m_apiAuthKey = key;
 
-	if (key == "")
+	if (key.isEmpty())
 		m_isAuthEnabled = false;
 	else
 		m_isAuthEnabled = true;
@@ -269,7 +269,7 @@ void ApiServer::incomingConnection(qintptr socketDescriptor)
 	ClientInfo cs;
 	cs.isAuthorized = !m_isAuthEnabled;
 	// set default sessionkey (disable lock priority)
-	cs.sessionKey = "API"+lightpack->GetSessionKey("API")+QString(m_clients.count());
+	cs.sessionKey = QStringLiteral("API")+lightpack->GetSessionKey(QStringLiteral("API"))+QString(m_clients.count());
 
 	m_clients.insert(client, cs);
 
@@ -283,7 +283,7 @@ void ApiServer::incomingConnection(qintptr socketDescriptor)
 
 void ApiServer::clientDisconnected()
 {
-	QTcpSocket *client = dynamic_cast<QTcpSocket*>(sender());
+	QTcpSocket *client = qobject_cast<QTcpSocket*>(sender());
 
 	DEBUG_LOW_LEVEL << "Client disconnected:" << client->peerAddress().toString();
 
@@ -303,7 +303,7 @@ void ApiServer::clientProcessCommands()
 {
 	API_DEBUG_OUT << Q_FUNC_INFO << "ApiServer thread id:" << this->thread()->currentThreadId();
 
-	QTcpSocket *client = dynamic_cast<QTcpSocket*>(sender());
+	QTcpSocket *client = qobject_cast<QTcpSocket*>(sender());
 
 	while (m_clients.contains(client) && client->canReadLine())
 	{
@@ -322,7 +322,7 @@ void ApiServer::clientProcessCommands()
 		}
 		else if (cmdBuffer == CmdExit)
 		{
-			writeData(client, "Goodbye!\r\n");
+			writeData(client, QStringLiteral("Goodbye!\r\n"));
 			if (m_clients.contains(client))
 				client->close();
 			return;
@@ -407,14 +407,14 @@ void ApiServer::clientProcessCommands()
 			result = ApiServer::CmdResultProfiles;
 
 			for (int i = 0; i < profiles.count(); i++)
-				result += profiles[i] + ";";
-			result += "\r\n";
+				result += profiles[i] + QStringLiteral(";");
+			result += QStringLiteral("\r\n");
 		}
 		else if (cmdBuffer == CmdGetProfile)
 		{
 			API_DEBUG_OUT << CmdGetProfile;
 
-			result = CmdResultProfile + lightpack->GetProfile() + "\r\n";
+			result = CmdResultProfile + lightpack->GetProfile() + QStringLiteral("\r\n");
 		}
 		else if (cmdBuffer == CmdGetDevices)
 		{
@@ -424,15 +424,15 @@ void ApiServer::clientProcessCommands()
 
 			result = ApiServer::CmdResultDevices;
 			for (int i = 0; i < devices.count(); i++)
-				result += devices[i] + ";";
-			result += "\r\n";
+				result += devices[i] + QStringLiteral(";");
+			result += QStringLiteral("\r\n");
 		}
 		else if (cmdBuffer == CmdGetDevice)
 		{
 			API_DEBUG_OUT << CmdGetDevice;
 			result = ApiServer::CmdResultDevice;
 			result += Settings::getConnectedDeviceName();
-			result += "\r\n";
+			result += QStringLiteral("\r\n");
 		}
 		else if (cmdBuffer == CmdGetMaxLeds)
 		{
@@ -468,13 +468,13 @@ void ApiServer::clientProcessCommands()
 			default:
 				max = MaximumNumberOfLeds::Default;
 			}
-			result = QString("%1%2\r\n").arg(CmdResultMaxLeds).arg(max);
+			result = QStringLiteral("%1%2\r\n").arg(CmdResultMaxLeds, max);
 		}
 		else if (cmdBuffer == CmdGetCountLeds)
 		{
 			API_DEBUG_OUT << CmdGetCountLeds;
 
-			result = QString("%1%2\r\n").arg(CmdResultCountLeds).arg(lightpack->GetCountLeds());
+			result = QStringLiteral("%1%2\r\n").arg(CmdResultCountLeds, lightpack->GetCountLeds());
 		}
 		else if (cmdBuffer == CmdGetLeds)
 		{
@@ -486,9 +486,9 @@ void ApiServer::clientProcessCommands()
 			{
 				QSize size = Settings::getLedSize(i);
 				QPoint pos = Settings::getLedPosition(i);
-				result += QString("%1-%2,%3,%4,%5;").arg(i).arg(pos.x()).arg(pos.y()).arg(size.width()).arg(size.height());
+				result += QStringLiteral("%1-%2,%3,%4,%5;").arg(i).arg(pos.x()).arg(pos.y()).arg(size.width()).arg(size.height());
 			}
-			result += "\r\n";
+			result += QStringLiteral("\r\n");
 
 		}
 		else if (cmdBuffer == CmdGetColors)
@@ -501,15 +501,15 @@ void ApiServer::clientProcessCommands()
 			for (int i = 0; i < curentColors.count(); i++)
 			{
 				QColor color(curentColors[i]);
-				result += QString("%1-%2,%3,%4;").arg(i).arg(color.red()).arg(color.green()).arg(color.blue());
+				result += QStringLiteral("%1-%2,%3,%4;").arg(i).arg(color.red()).arg(color.green()).arg(color.blue());
 			}
-			result += "\r\n";
+			result += QStringLiteral("\r\n");
 		}
 		else if (cmdBuffer == CmdGetFPS)
 		{
 			API_DEBUG_OUT << CmdGetFPS;
 
-			result = QString("%1%2\r\n").arg(CmdResultFPS).arg(lightpack->GetFPS());
+			result = QStringLiteral("%1%2\r\n").arg(CmdResultFPS).arg(lightpack->GetFPS());
 		}
 		else if (cmdBuffer == CmdGetScreenSize)
 		{
@@ -517,7 +517,7 @@ void ApiServer::clientProcessCommands()
 
 			QRect screen = lightpack->GetScreenSize();
 
-			result = QString("%1%2,%3,%4,%5\r\n").arg(CmdResultScreenSize).arg(screen.x()).arg(screen.y()).arg(screen.width()).arg(screen.height());
+			result = QStringLiteral("%1%2,%3,%4,%5\r\n").arg(CmdResultScreenSize).arg(screen.x()).arg(screen.y()).arg(screen.width()).arg(screen.height());
 		}
 		else if (cmdBuffer == CmdGetCountMonitor)
 		{
@@ -525,7 +525,7 @@ void ApiServer::clientProcessCommands()
 
 			int count = QGuiApplication::screens().count();
 
-			result = QString("%1%2\r\n").arg(CmdResultCountMonitor).arg(count);
+			result = QStringLiteral("%1%2\r\n").arg(CmdResultCountMonitor).arg(count);
 		}
 		else if (cmdBuffer.startsWith(CmdGetSizeMonitor))
 		{
@@ -547,7 +547,7 @@ void ApiServer::clientProcessCommands()
 					{
 						QRect geom = screen->geometry();
 
-						result = QString("%1%2,%3,%4,%5\r\n").arg(CmdResultSizeMonitor).arg(geom.x()).arg(geom.y()).arg(geom.width()).arg(geom.height());
+						result = QStringLiteral("%1%2,%3,%4,%5\r\n").arg(CmdResultSizeMonitor).arg(geom.x()).arg(geom.y()).arg(geom.width()).arg(geom.height());
 					}
 					else
 					{
@@ -588,19 +588,19 @@ void ApiServer::clientProcessCommands()
 		{
 			API_DEBUG_OUT << CmdGetGamma;
 
-			result = QString("%1%2\r\n").arg(CmdResultGamma).arg(lightpack->GetGamma());
+			result = QStringLiteral("%1%2\r\n").arg(CmdResultGamma).arg(lightpack->GetGamma());
 		}
 		else if (cmdBuffer == CmdGetBrightness)
 		{
 			API_DEBUG_OUT << CmdGetBrightness;
 
-			result = QString("%1%2\r\n").arg(CmdResultBrightness).arg(lightpack->GetBrightness());
+			result = QStringLiteral("%1%2\r\n").arg(CmdResultBrightness).arg(lightpack->GetBrightness());
 		}
 		else if (cmdBuffer == CmdGetSmooth)
 		{
 			API_DEBUG_OUT << CmdGetSmooth;
 
-			result = QString("%1%2\r\n").arg(CmdResultSmooth).arg(lightpack->GetSmooth());
+			result = QStringLiteral("%1%2\r\n").arg(CmdResultSmooth).arg(lightpack->GetSmooth());
 		}
 #ifdef SOUNDVIZ_SUPPORT
 		else if (cmdBuffer == CmdGetSoundVizColors)
@@ -608,7 +608,7 @@ void ApiServer::clientProcessCommands()
 			API_DEBUG_OUT << CmdGetSoundVizColors;
 
 			QPair<QColor, QColor> colors = lightpack->GetSoundVizColors();
-			result = QString("%1%2,%3,%4;%5,%6,%7\r\n").arg(CmdResultSoundVizColors)
+			result = QStringLiteral("%1%2,%3,%4;%5,%6,%7\r\n").arg(CmdResultSoundVizColors)
 				.arg(colors.first.red()).arg(colors.first.green()).arg(colors.first.blue())
 				.arg(colors.second.red()).arg(colors.second.green()).arg(colors.second.blue());
 		}
@@ -616,7 +616,7 @@ void ApiServer::clientProcessCommands()
 		{
 			API_DEBUG_OUT << CmdGetSoundVizColors;
 
-			result = QString("%1%2\r\n").arg(CmdResultSoundVizLiquid).arg(lightpack->GetSoundVizLiquidMode() ? 1 : 0);
+			result = QStringLiteral("%1%2\r\n").arg(CmdResultSoundVizLiquid).arg(lightpack->GetSoundVizLiquidMode() ? 1 : 0);
 		}
 #endif
 		else if (cmdBuffer == CmdGetPersistOnUnlock)
@@ -648,13 +648,13 @@ void ApiServer::clientProcessCommands()
 			API_DEBUG_OUT << CmdLockStatus;
 
 			int res = lightpack->CheckLock(sessionKey);
-			QString status = "no";
+			QString status = QStringLiteral("no");
 			if (res == -1)
-				status = "busy";
+				status = QStringLiteral("busy");
 			if (res == 1)
-				status = "ok";
+				status = QStringLiteral("ok");
 
-			result = QString("lockstatus:%1\r\n").arg(status);
+			result = QStringLiteral("lockstatus:%1\r\n").arg(status);
 		}
 		else if (cmdBuffer == CmdLock)
 		{
@@ -883,10 +883,10 @@ void ApiServer::clientProcessCommands()
 				QString s = QString(cmdBuffer);
 				API_DEBUG_OUT << s;
 
-				QStringList colors = s.split(";");
+				QStringList colors = s.split(';');
 				if (colors.size() == 2) {
-					QStringList colorMin = colors.at(0).split(",");
-					QStringList colorMax = colors.at(1).split(",");
+					QStringList colorMin = colors.at(0).split(',');
+					QStringList colorMax = colors.at(1).split(',');
 
 					if (colorMin.size() == 3 && colorMax.size() == 3) {
 						bool ok;
@@ -1058,21 +1058,21 @@ void ApiServer::clientProcessCommands()
 				API_DEBUG_OUT << QString(cmdBuffer);
 				int countleds = lightpack->GetCountLeds();
 				QList<QRect> rectLeds;
-				QStringList leds = ((QString)cmdBuffer).split(";");
+				QStringList leds = ((QString)cmdBuffer).split(';');
 				for (int i = 0; i < leds.size(); ++i)
 				{
 					bool ok;
 					QString led = leds.at(i);
-					if (led!="")
+					if (!led.isEmpty())
 					{
 						qDebug() << "led:" << led;
 						int num=0,x=0,y=0,w=0, h=0;
-						if (led.indexOf("-")>0)
+						if (led.indexOf('-')>0)
 						{
-								num= led.split("-")[0].toInt(&ok);
+								num= led.split('-')[0].toInt(&ok);
 								if (ok)
 								{
-									QStringList xywh = led.split("-")[1].split(",");
+									QStringList xywh = led.split('-')[1].split(',');
 									if (xywh.count()>0) x = xywh[0].toInt(&ok);
 									if (xywh.count()>1) y = xywh[1].toInt(&ok);
 									if (xywh.count()>2) w = xywh[2].toInt(&ok);
@@ -1228,7 +1228,7 @@ void ApiServer::clientProcessCommands()
 				result = CmdSetResult_Busy;
 			}
 		}
-		else			
+		else
 		{
 			qWarning() << Q_FUNC_INFO << CmdUnknown << cmdBuffer;
 		}
@@ -1300,7 +1300,7 @@ void ApiServer::stopListening()
 	for (i = m_clients.begin(); i != m_clients.end(); ++i)
 	{
 
-		QTcpSocket * client = dynamic_cast<QTcpSocket*>(i.key());
+		QTcpSocket * client = i.key();
 
 		QString sessionKey = m_clients[client].sessionKey;
 		if (lightpack->CheckLock(sessionKey)==1)
@@ -1330,7 +1330,7 @@ void ApiServer::writeData(QTcpSocket* client, const QString & data)
 
 QString ApiServer::formatHelp(const QString & cmd)
 {
-	return QString("\t\t \"%1\" \r\n").arg(cmd.trimmed());
+	return QStringLiteral("\t\t \"%1\" \r\n").arg(cmd.trimmed());
 }
 
 QString ApiServer::formatHelp(const QString & cmd, const QString & description)
@@ -1339,7 +1339,7 @@ QString ApiServer::formatHelp(const QString & cmd, const QString & description)
 				QString(80,'.') + "\r\n"
 				"%1 \r\n"				// Command
 				"\t %2 \r\n"			// Description
-				).arg(cmd).arg(description);
+				).arg(cmd, description);
 }
 
 QString ApiServer::formatHelp(const QString & cmd, const QString & description, const QString & results)
@@ -1359,36 +1359,36 @@ QString ApiServer::formatHelp(const QString & cmd, const QString & description, 
 				"%1"
 				"\t Results: \r\n"	// Return values
 				"%2"
-				).arg(examples).arg(results);
+				).arg(examples, results);
 }
 
 void ApiServer::initHelpMessage()
 {
-	m_helpMessage += "\r\n";
-	m_helpMessage += "Prismatik " VERSION_STR ", API " API_VERSION "\r\n";
-	m_helpMessage += "Prismatik API is a fork of the original API\r\n";
-	m_helpMessage += "It is backwards compatible to Lightpack API 1.4\r\n";
-	m_helpMessage += "\r\n";
+	m_helpMessage += QStringLiteral("\r\n");
+	m_helpMessage += QStringLiteral("Prismatik " VERSION_STR ", API " API_VERSION "\r\n");
+	m_helpMessage += QStringLiteral("Prismatik API is a fork of the original API\r\n");
+	m_helpMessage += QStringLiteral("It is backwards compatible to Lightpack API 1.4\r\n");
+	m_helpMessage += QStringLiteral("\r\n");
 
 	m_helpMessage += formatHelp(
 				CmdApiKey,
-				"Command for enter an authorization key (see key in GUI)",
-				formatHelp(CmdApiKey + QString("{1ccf5dca-119d-45a0-a683-7d90a00c418f}")) +
-				formatHelp(CmdApiKey + QString("IDDQD")),
+				QStringLiteral("Command for enter an authorization key (see key in GUI)"),
+				formatHelp(CmdApiKey + QStringLiteral("{1ccf5dca-119d-45a0-a683-7d90a00c418f}")) +
+				formatHelp(CmdApiKey + QStringLiteral("IDDQD")),
 				formatHelp(CmdApiKeyResult_Ok) +
 				formatHelp(CmdApiKeyResult_Fail)
 				);
 
 	m_helpMessage += formatHelp(
 				CmdLock,
-				"Opens access to set-commands, If success - suspends capture and blocking access for other clients to set-commands.",
+				QStringLiteral("Opens access to set-commands, If success - suspends capture and blocking access for other clients to set-commands."),
 				formatHelp(CmdResultLock_Success) +
 				formatHelp(CmdResultLock_Busy)
 				);
 
 	m_helpMessage += formatHelp(
 				CmdUnlock,
-				"Closes access to set-commands. Restores device settings from the current profile, and continues the normal execution of the application.",
+				QStringLiteral("Closes access to set-commands. Restores device settings from the current profile, and continues the normal execution of the application."),
 				formatHelp(CmdResultUnlock_Success) +
 				formatHelp(CmdResultUnlock_NotLocked)
 				);
@@ -1396,7 +1396,7 @@ void ApiServer::initHelpMessage()
 	// Get-commands
 	m_helpMessage += formatHelp(
 				CmdGetStatus,
-				"Get status of the backlight",
+				QStringLiteral("Get status of the backlight"),
 				formatHelp(CmdResultStatus_On) +
 				formatHelp(CmdResultStatus_Off) +
 				formatHelp(CmdResultStatus_DeviceError) +
@@ -1404,48 +1404,48 @@ void ApiServer::initHelpMessage()
 				);
 	m_helpMessage += formatHelp(
 				CmdGetStatusAPI,
-				"Get status of the lightpack API",
+				QStringLiteral("Get status of the lightpack API"),
 				formatHelp(CmdResultStatusAPI_Busy) +
 				formatHelp(CmdResultStatusAPI_Idle)
 				);
 	m_helpMessage += formatHelp(
 				CmdGetProfile,
-				"Get the name of the current profile",
-				formatHelp(CmdResultProfile + QString("SampleProfileName"))
+				QStringLiteral("Get the name of the current profile"),
+				formatHelp(CmdResultProfile + QStringLiteral("SampleProfileName"))
 				);
 	m_helpMessage += formatHelp(
 				CmdGetProfiles,
-				"Get names of the all available profiles",
-				formatHelp(CmdResultProfiles + QString("Lightpack;New profile 1;New profile 2;"))
+				QStringLiteral("Get names of the all available profiles"),
+				formatHelp(CmdResultProfiles + QStringLiteral("Lightpack;New profile 1;New profile 2;"))
 				);
 	m_helpMessage += formatHelp(
 				CmdGetCountLeds,
-				"Get count leds of the current profile",
-				formatHelp(CmdResultCountLeds + QString("10"))
+				QStringLiteral("Get count leds of the current profile"),
+				formatHelp(CmdResultCountLeds + QStringLiteral("10"))
 				);
 	m_helpMessage += formatHelp(
 				CmdGetLeds,
-				"Get curent rect areas. Format: \"N-X,Y,W,H;\", where N - number of area, X,Y - position, H,W-size.",
-				formatHelp(CmdResultLeds + QString("1-0,0,100,100;2-0,200,100,100;"))
+				QStringLiteral("Get curent rect areas. Format: \"N-X,Y,W,H;\", where N - number of area, X,Y - position, H,W-size."),
+				formatHelp(CmdResultLeds + QStringLiteral("1-0,0,100,100;2-0,200,100,100;"))
 				);
 	m_helpMessage += formatHelp(
 				CmdGetColors,
-				"Get curent color leds. Format: \"N-R,G,B;\", where N - number of led, R, G, B - red, green and blue color components.",
-				formatHelp(CmdResultGetColors + QString("1-0,120,200;2-0,234,23;"))
+				QStringLiteral("Get curent color leds. Format: \"N-R,G,B;\", where N - number of led, R, G, B - red, green and blue color components."),
+				formatHelp(CmdResultGetColors + QStringLiteral("1-0,120,200;2-0,234,23;"))
 				);
 	m_helpMessage += formatHelp(
 				CmdGetFPS,
-				"Get FPS grabing",
-				formatHelp(CmdResultFPS + QString("25.57"))
+				QStringLiteral("Get FPS grabing"),
+				formatHelp(CmdResultFPS + QStringLiteral("25.57"))
 				);
 	m_helpMessage += formatHelp(
 				CmdGetScreenSize,
-				"Get size screen",
-				formatHelp(CmdResultScreenSize + QString("0,0,1024,768"))
+				QStringLiteral("Get size screen"),
+				formatHelp(CmdResultScreenSize + QStringLiteral("0,0,1024,768"))
 				);
 	m_helpMessage += formatHelp(
 				CmdGetBacklight,
-				"Get mode of the current profile",
+				QStringLiteral("Get mode of the current profile"),
 				formatHelp(CmdResultBacklight_Ambilight) +
 				formatHelp(CmdResultBacklight_Moodlamp)
 #ifdef SOUNDVIZ_SUPPORT
@@ -1454,34 +1454,34 @@ void ApiServer::initHelpMessage()
 				);
 	m_helpMessage += formatHelp(
 				CmdGetGamma,
-				"Get the current gamma correction value",
-				formatHelp(CmdResultGamma + QString("2.004"))
+				QStringLiteral("Get the current gamma correction value"),
+				formatHelp(CmdResultGamma + QStringLiteral("2.004"))
 				);
 	m_helpMessage += formatHelp(
 				CmdGetBrightness,
-				"Get the current brightness value",
-				formatHelp(CmdResultBrightness + QString("100"))
+				QStringLiteral("Get the current brightness value"),
+				formatHelp(CmdResultBrightness + QStringLiteral("100"))
 				);
 	m_helpMessage += formatHelp(
 				CmdGetSmooth,
-				"Get the current smooth value",
-				formatHelp(CmdResultSmooth + QString("1"))
+				QStringLiteral("Get the current smooth value"),
+				formatHelp(CmdResultSmooth + QStringLiteral("1"))
 				);
 #ifdef SOUNDVIZ_SUPPORT
 	m_helpMessage += formatHelp(
 		CmdGetSoundVizColors,
-		"Get min and max color for sound visualization. Format: \"R,G,B;R,G,B\". Since API 2.1",
-		formatHelp(CmdResultSoundVizColors + QString("0,0,0;255,255,255"))
+		QStringLiteral("Get min and max color for sound visualization. Format: \"R,G,B;R,G,B\". Since API 2.1"),
+		formatHelp(CmdResultSoundVizColors + QStringLiteral("0,0,0;255,255,255"))
 		);
 	m_helpMessage += formatHelp(
 		CmdGetSoundVizLiquid,
-		"Get wether or not sound visualization is in liquid color mode. Since API 2.1",
-		formatHelp(CmdResultSoundVizLiquid + QString("1"))
+		QStringLiteral("Get wether or not sound visualization is in liquid color mode. Since API 2.1"),
+		formatHelp(CmdResultSoundVizLiquid + QStringLiteral("1"))
 		);
 #endif
 	m_helpMessage += formatHelp(
 		CmdGetPersistOnUnlock,
-		"Get wether or not the last set colors should persist when unlocking",
+		QStringLiteral("Get wether or not the last set colors should persist when unlocking"),
 		formatHelp(CmdGetPersistOnUnlock_On)
 		);
 
@@ -1495,73 +1495,70 @@ void ApiServer::initHelpMessage()
 
 	m_helpMessage += formatHelp(
 				CmdSetColor,
-				"Set colors on several LEDs. Format: \"N-R,G,B;\", where N - number of led, R, G, B - red, green and blue color components. Works only on locking time (see lock).",
-				formatHelp(CmdSetColor + QString("1-255,255,30;")) +
-				formatHelp(CmdSetColor + QString("1-255,255,30;2-12,12,12;3-1,2,3;")),
+				QStringLiteral("Set colors on several LEDs. Format: \"N-R,G,B;\", where N - number of led, R, G, B - red, green and blue color components. Works only on locking time (see lock)."),
+				formatHelp(CmdSetColor + QStringLiteral("1-255,255,30;")) +
+				formatHelp(CmdSetColor + QStringLiteral("1-255,255,30;2-12,12,12;3-1,2,3;")),
 				helpCmdSetResults);
 
 	m_helpMessage += formatHelp(
 				CmdSetLeds,
-				"Set areas on several LEDs. Format: \"N-X,Y,W,H;\", where N - number of led, X,Y - position, H,W-size. Works only on locking time (see lock).",
-				formatHelp(CmdSetLeds + QString("1-0,0,100,100;")) +
-				formatHelp(CmdSetLeds + QString("1-0,0,100,100;2-0,100,100,100;3-100,0,100,100;")),
+				QStringLiteral("Set areas on several LEDs. Format: \"N-X,Y,W,H;\", where N - number of led, X,Y - position, H,W-size. Works only on locking time (see lock)."),
+				formatHelp(CmdSetLeds + QStringLiteral("1-0,0,100,100;")) +
+				formatHelp(CmdSetLeds + QStringLiteral("1-0,0,100,100;2-0,100,100,100;3-100,0,100,100;")),
 				helpCmdSetResults);
 
 	m_helpMessage += formatHelp(
 				CmdSetGamma,
-				QString("Set device gamma correction value [%1 - %2]. Works only on locking time (see lock).")
-				.arg(SettingsScope::Profile::Device::GammaMin)
-				.arg(SettingsScope::Profile::Device::GammaMax),
-				formatHelp(CmdSetGamma + QString("2.5")),
+				QStringLiteral("Set device gamma correction value [%1 - %2]. Works only on locking time (see lock).")
+				.arg(SettingsScope::Profile::Device::GammaMin, SettingsScope::Profile::Device::GammaMax),
+				formatHelp(CmdSetGamma + QStringLiteral("2.5")),
 				helpCmdSetResults);
 
 	m_helpMessage += formatHelp(
 				CmdSetBrightness,
-				QString("Set device brightness value [%1 - %2]. Works only on locking time (see lock).")
-				.arg(SettingsScope::Profile::Device::BrightnessMin)
-				.arg(SettingsScope::Profile::Device::BrightnessMax),
-				formatHelp(CmdSetBrightness + QString("0")) +
-				formatHelp(CmdSetBrightness + QString("93")),
+				QStringLiteral("Set device brightness value [%1 - %2]. Works only on locking time (see lock).")
+				.arg(SettingsScope::Profile::Device::BrightnessMin, SettingsScope::Profile::Device::BrightnessMax),
+				formatHelp(CmdSetBrightness + QStringLiteral("0")) +
+				formatHelp(CmdSetBrightness + QStringLiteral("93")),
 				helpCmdSetResults);
 
 	m_helpMessage += formatHelp(
 				CmdSetSmooth,
-				QString("Set device smooth value [%1 - %2]. Works only on locking time (see lock).")
-				.arg(SettingsScope::Profile::Device::SmoothMin)
-				.arg(SettingsScope::Profile::Device::SmoothMax),
-				formatHelp(CmdSetSmooth + QString("10")) +
-				formatHelp(CmdSetSmooth + QString("128")),
+				QStringLiteral("Set device smooth value [%1 - %2]. Works only on locking time (see lock).")
+				.arg(SettingsScope::Profile::Device::SmoothMin, SettingsScope::Profile::Device::SmoothMax),
+				formatHelp(CmdSetSmooth + QStringLiteral("10")) +
+				formatHelp(CmdSetSmooth + QStringLiteral("128")),
 				helpCmdSetResults);
 
 	m_helpMessage += formatHelp(
 				CmdSetProfile,
-				QString("Set current profile. Works only on locking time (see lock)."),
-				formatHelp(CmdSetProfile + QString("Lightpack")) +
-				formatHelp(CmdSetProfile + QString("16x9")),
+				QStringLiteral("Set current profile. Works only on locking time (see lock)."),
+				formatHelp(CmdSetProfile + QStringLiteral("Lightpack")) +
+				formatHelp(CmdSetProfile + QStringLiteral("16x9")),
 				helpCmdSetResults);
 
 	m_helpMessage += formatHelp(
 				CmdNewProfile,
-				QString("Create new profile. Works only on locking time (see lock)."),
-				formatHelp(CmdNewProfile + QString("16x9")) +
+				QStringLiteral("Create new profile. Works only on locking time (see lock)."),
+				formatHelp(CmdNewProfile + QStringLiteral("16x9")) +
 				helpCmdSetResults);
 
 	m_helpMessage += formatHelp(
 				CmdDeleteProfile,
-				QString("Delete profile. Works only on locking time (see lock)."),
-				formatHelp(CmdDeleteProfile + QString("16x9")) +
+				QStringLiteral("Delete profile. Works only on locking time (see lock)."),
+				formatHelp(CmdDeleteProfile + QStringLiteral("16x9")) +
 				helpCmdSetResults);
 
 	m_helpMessage += formatHelp(
 				CmdSetStatus,
-				QString("Set backlight status. Works only on locking time (see lock)."),
+				QStringLiteral("Set backlight status. Works only on locking time (see lock)."),
 				formatHelp(CmdSetStatus + QString(CmdSetStatus_On)) +
 				formatHelp(CmdSetStatus + QString(CmdSetStatus_Off)),
 				helpCmdSetResults);
 
 	m_helpMessage += formatHelp(
 				CmdSetBacklight,
-				QString("Set backlight mode. Works only on locking time (see lock)."),
+				QStringLiteral("Set backlight mode. Works only on locking time (see lock)."),
 				formatHelp(CmdSetBacklight + QString(CmdSetBacklight_Ambilight)) +
 				formatHelp(CmdSetBacklight + QString(CmdSetBacklight_Moodlamp))
 #ifdef SOUNDVIZ_SUPPORT
@@ -1573,33 +1570,33 @@ void ApiServer::initHelpMessage()
 #ifdef SOUNDVIZ_SUPPORT
 	m_helpMessage += formatHelp(
 		CmdSetSoundVizColors,
-		"Set min and max color for sound visualization. Format: \"R,G,B;R,G,B\". Since API 2.1",
-		formatHelp(CmdSetSoundVizColors + QString("0,0,0;255,255,255")),
+		QStringLiteral("Set min and max color for sound visualization. Format: \"R,G,B;R,G,B\". Since API 2.1"),
+		formatHelp(CmdSetSoundVizColors + QStringLiteral("0,0,0;255,255,255")),
 		helpCmdSetResults);
 	m_helpMessage += formatHelp(
 		CmdSetSoundVizLiquid,
-		"Set wether or not sound visualization is in liquid color mode. Since API 2.1",
-		formatHelp(CmdSetSoundVizLiquid + QString("0")),
+		QStringLiteral("Set wether or not sound visualization is in liquid color mode. Since API 2.1"),
+		formatHelp(CmdSetSoundVizLiquid + QStringLiteral("0")),
 		helpCmdSetResults);
 #endif
 	m_helpMessage += formatHelp(
 		CmdSetPersistOnUnlock,
-		"Set wether or not the last set colors should persist when unlocking. Since API 2.2",
+		QStringLiteral("Set wether or not the last set colors should persist when unlocking. Since API 2.2"),
 		formatHelp(CmdSetPersistOnUnlock + QString(CmdSetPersistOnUnlock_On)),
 		helpCmdSetResults);
 
 
-	m_helpMessage += formatHelp(CmdHelpShort, "Short version of this help");
+	m_helpMessage += formatHelp(CmdHelpShort, QStringLiteral("Short version of this help"));
 
-	m_helpMessage += formatHelp(CmdExit, "Closes connection");
+	m_helpMessage += formatHelp(CmdExit, QStringLiteral("Closes connection"));
 
-	m_helpMessage += "\r\n";
+	m_helpMessage += QStringLiteral("\r\n");
 }
 
 void ApiServer::initShortHelpMessage()
 {
-	m_shortHelpMessage += "\r\n";
-	m_shortHelpMessage += "List of available commands:\r\n";
+	m_shortHelpMessage += QStringLiteral("\r\n");
+	m_shortHelpMessage += QStringLiteral("List of available commands:\r\n");
 
 	QList<QString> cmds;
 	cmds << CmdApiKey << CmdLock << CmdUnlock
@@ -1622,7 +1619,7 @@ void ApiServer::initShortHelpMessage()
 			<< CmdSetPersistOnUnlock
 			<< CmdExit << CmdHelp << CmdHelpShort;
 
-	QString line = "	";
+	QString line = QStringLiteral("	");
 
 	for (int i = 0; i < cmds.count(); i++)
 	{
@@ -1630,17 +1627,17 @@ void ApiServer::initShortHelpMessage()
 		{
 			line += cmds[i].remove(':');
 		} else {
-			m_shortHelpMessage += line + "\r\n";
-			line = "	" + cmds[i].remove(':');
+			m_shortHelpMessage += line + QStringLiteral("\r\n");
+			line = QStringLiteral("	") + cmds[i].remove(':');
 		}
 
 		if (i != cmds.count() - 1)
-				line += ", ";
+				line += QStringLiteral(", ");
 	}
 
-	m_shortHelpMessage += line + "\r\n";
+	m_shortHelpMessage += line + QStringLiteral("\r\n");
 
-	m_shortHelpMessage += "\r\n";
-	m_shortHelpMessage += "Detailed version is available by \"help\" command. \r\n";
-	m_shortHelpMessage += "\r\n";
+	m_shortHelpMessage += QStringLiteral("\r\n");
+	m_shortHelpMessage += QStringLiteral("Detailed version is available by \"help\" command. \r\n");
+	m_shortHelpMessage += QStringLiteral("\r\n");
 }

--- a/Software/src/ApiServer.cpp
+++ b/Software/src/ApiServer.cpp
@@ -33,7 +33,7 @@
 #include "Settings.hpp"
 #include "TimeEvaluations.hpp"
 #include "version.h"
-#include <QtWidgets/QApplication>
+#include <QApplication>
 
 using namespace SettingsScope;
 

--- a/Software/src/ApiServer.cpp
+++ b/Software/src/ApiServer.cpp
@@ -407,14 +407,14 @@ void ApiServer::clientProcessCommands()
 			result = ApiServer::CmdResultProfiles;
 
 			for (int i = 0; i < profiles.count(); i++)
-				result += profiles[i] + QStringLiteral(";");
+				result += QStringLiteral("%1;").arg(profiles[i]);
 			result += QStringLiteral("\r\n");
 		}
 		else if (cmdBuffer == CmdGetProfile)
 		{
 			API_DEBUG_OUT << CmdGetProfile;
 
-			result = CmdResultProfile + lightpack->GetProfile() + QStringLiteral("\r\n");
+			result = QStringLiteral("%1%2\r\n").arg(CmdResultProfile, lightpack->GetProfile());
 		}
 		else if (cmdBuffer == CmdGetDevices)
 		{
@@ -424,15 +424,13 @@ void ApiServer::clientProcessCommands()
 
 			result = ApiServer::CmdResultDevices;
 			for (int i = 0; i < devices.count(); i++)
-				result += devices[i] + QStringLiteral(";");
+				result += QStringLiteral("%1;").arg(devices[i]);
 			result += QStringLiteral("\r\n");
 		}
 		else if (cmdBuffer == CmdGetDevice)
 		{
 			API_DEBUG_OUT << CmdGetDevice;
-			result = ApiServer::CmdResultDevice;
-			result += Settings::getConnectedDeviceName();
-			result += QStringLiteral("\r\n");
+			result = QStringLiteral("%1%2\r\n").arg(ApiServer::CmdResultDevice, Settings::getConnectedDeviceName());
 		}
 		else if (cmdBuffer == CmdGetMaxLeds)
 		{

--- a/Software/src/ApiServer.hpp
+++ b/Software/src/ApiServer.hpp
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <QDesktopWidget>
 #include <QStringList>
 #include <QTcpServer>
 #include <QTcpSocket>

--- a/Software/src/ApiServer.hpp
+++ b/Software/src/ApiServer.hpp
@@ -62,142 +62,142 @@ public:
 	void firstStart();
 
 public:
-	static const char * ApiVersion;
-	static const char * CmdUnknown;
-	static const char * CmdDeprecated;
-	static const char * CmdExit;
-	static const char * CmdHelp;
-	static const char * CmdHelpShort;
+	static const char * const ApiVersion;
+	static const char * const CmdUnknown;
+	static const char * const CmdDeprecated;
+	static const char * const CmdExit;
+	static const char * const CmdHelp;
+	static const char * const CmdHelpShort;
 
-	static const char * CmdApiKey;
-	static const char * CmdApiKeyResult_Ok;
-	static const char * CmdApiKeyResult_Fail;
-	static const char * CmdApiCheck_AuthRequired;
+	static const char * const CmdApiKey;
+	static const char * const CmdApiKeyResult_Ok;
+	static const char * const CmdApiKeyResult_Fail;
+	static const char * const CmdApiCheck_AuthRequired;
 
-	static const char * CmdGetStatus;
-	static const char * CmdResultStatus_On;
-	static const char * CmdResultStatus_Off;
-	static const char * CmdResultStatus_DeviceError;
-	static const char * CmdResultStatus_Unknown;
+	static const char * const CmdGetStatus;
+	static const char * const CmdResultStatus_On;
+	static const char * const CmdResultStatus_Off;
+	static const char * const CmdResultStatus_DeviceError;
+	static const char * const CmdResultStatus_Unknown;
 
-	static const char * CmdGetStatusAPI;
-	static const char * CmdResultStatusAPI_Busy;
-	static const char * CmdResultStatusAPI_Idle;
+	static const char * const CmdGetStatusAPI;
+	static const char * const CmdResultStatusAPI_Busy;
+	static const char * const CmdResultStatusAPI_Idle;
 
-	static const char * CmdGetProfiles;
-	static const char * CmdResultProfiles;
+	static const char * const CmdGetProfiles;
+	static const char * const CmdResultProfiles;
 
-	static const char * CmdGetProfile;
-	static const char * CmdResultProfile;
+	static const char * const CmdGetProfile;
+	static const char * const CmdResultProfile;
 
-	static const char * CmdGetDevices;
-	static const char * CmdResultDevices;
+	static const char * const CmdGetDevices;
+	static const char * const CmdResultDevices;
 
-	static const char * CmdGetDevice;
-	static const char * CmdResultDevice;
+	static const char * const CmdGetDevice;
+	static const char * const CmdResultDevice;
 
-	static const char * CmdGetMaxLeds;
-	static const char * CmdResultMaxLeds;
+	static const char * const CmdGetMaxLeds;
+	static const char * const CmdResultMaxLeds;
 
-	static const char * CmdGetCountLeds;
-	static const char * CmdResultCountLeds;
+	static const char * const CmdGetCountLeds;
+	static const char * const CmdResultCountLeds;
 
-	static const char * CmdGetLeds;
-	static const char * CmdResultLeds;
+	static const char * const CmdGetLeds;
+	static const char * const CmdResultLeds;
 
-	static const char * CmdGetColors;
-	static const char * CmdResultGetColors;
+	static const char * const CmdGetColors;
+	static const char * const CmdResultGetColors;
 
-	static const char * CmdGetFPS;
-	static const char * CmdResultFPS;
+	static const char * const CmdGetFPS;
+	static const char * const CmdResultFPS;
 
-	static const char * CmdGetScreenSize;
-	static const char * CmdResultScreenSize;
+	static const char * const CmdGetScreenSize;
+	static const char * const CmdResultScreenSize;
 
-	static const char * CmdGetCountMonitor;
-	static const char * CmdResultCountMonitor;
-	static const char * CmdGetSizeMonitor;
-	static const char * CmdResultSizeMonitor;
+	static const char * const CmdGetCountMonitor;
+	static const char * const CmdResultCountMonitor;
+	static const char * const CmdGetSizeMonitor;
+	static const char * const CmdResultSizeMonitor;
 
-	static const char * CmdGetBacklight;
-	static const char * CmdResultBacklight_Ambilight;
-	static const char * CmdResultBacklight_Moodlamp;
+	static const char * const CmdGetBacklight;
+	static const char * const CmdResultBacklight_Ambilight;
+	static const char * const CmdResultBacklight_Moodlamp;
 #ifdef SOUNDVIZ_SUPPORT
-	static const char * CmdResultBacklight_SoundViz;
+	static const char * const CmdResultBacklight_SoundViz;
 #endif
 
-	static const char * CmdGetGamma;
-	static const char * CmdResultGamma;
+	static const char * const CmdGetGamma;
+	static const char * const CmdResultGamma;
 
-	static const char * CmdGetBrightness;
-	static const char * CmdResultBrightness;
+	static const char * const CmdGetBrightness;
+	static const char * const CmdResultBrightness;
 
-	static const char * CmdGetSmooth;
-	static const char * CmdResultSmooth;
+	static const char * const CmdGetSmooth;
+	static const char * const CmdResultSmooth;
 
 #ifdef SOUNDVIZ_SUPPORT
-	static const char * CmdGetSoundVizColors;
-	static const char * CmdResultSoundVizColors;
+	static const char * const CmdGetSoundVizColors;
+	static const char * const CmdResultSoundVizColors;
 
-	static const char * CmdGetSoundVizLiquid;
-	static const char * CmdResultSoundVizLiquid;
+	static const char * const CmdGetSoundVizLiquid;
+	static const char * const CmdResultSoundVizLiquid;
 #endif
 
-	static const char * CmdGetPersistOnUnlock;
-	static const char * CmdGetPersistOnUnlock_On;
-	static const char * CmdGetPersistOnUnlock_Off;
+	static const char * const CmdGetPersistOnUnlock;
+	static const char * const CmdGetPersistOnUnlock_On;
+	static const char * const CmdGetPersistOnUnlock_Off;
 
-	static const char * CmdGuid;
+	static const char * const CmdGuid;
 
-	static const char * CmdLockStatus;
+	static const char * const CmdLockStatus;
 
-	static const char * CmdLock;
-	static const char * CmdResultLock_Success;
-	static const char * CmdResultLock_Busy;
+	static const char * const CmdLock;
+	static const char * const CmdResultLock_Success;
+	static const char * const CmdResultLock_Busy;
 
-	static const char * CmdUnlock;
-	static const char * CmdResultUnlock_Success;
-	static const char * CmdResultUnlock_NotLocked;
+	static const char * const CmdUnlock;
+	static const char * const CmdResultUnlock_Success;
+	static const char * const CmdResultUnlock_NotLocked;
 
 	// Set-commands works only after success lock
-	static const char * CmdSetResult_Ok;
-	static const char * CmdSetResult_Error;
-	static const char * CmdSetResult_Busy;
-	static const char * CmdSetResult_NotLocked;
+	static const char * const CmdSetResult_Ok;
+	static const char * const CmdSetResult_Error;
+	static const char * const CmdSetResult_Busy;
+	static const char * const CmdSetResult_NotLocked;
 
-	static const char * CmdSetColor;
-	static const char * CmdSetGamma;
-	static const char * CmdSetBrightness;
-	static const char * CmdSetSmooth;
-	static const char * CmdSetProfile;
+	static const char * const CmdSetColor;
+	static const char * const CmdSetGamma;
+	static const char * const CmdSetBrightness;
+	static const char * const CmdSetSmooth;
+	static const char * const CmdSetProfile;
 
 #ifdef SOUNDVIZ_SUPPORT
-	static const char * CmdSetSoundVizColors;
-	static const char * CmdSetSoundVizLiquid;
+	static const char * const CmdSetSoundVizColors;
+	static const char * const CmdSetSoundVizLiquid;
 #endif
 
-	static const char * CmdSetDevice;
+	static const char * const CmdSetDevice;
 
-	static const char * CmdSetCountLeds;
-	static const char * CmdSetLeds;
+	static const char * const CmdSetCountLeds;
+	static const char * const CmdSetLeds;
 
-	static const char * CmdNewProfile;
-	static const char * CmdDeleteProfile;
+	static const char * const CmdNewProfile;
+	static const char * const CmdDeleteProfile;
 
-	static const char * CmdSetStatus;
-	static const char * CmdSetStatus_On;
-	static const char * CmdSetStatus_Off;
+	static const char * const CmdSetStatus;
+	static const char * const CmdSetStatus_On;
+	static const char * const CmdSetStatus_Off;
 
-	static const char * CmdSetBacklight;
-	static const char * CmdSetBacklight_Ambilight;
-	static const char * CmdSetBacklight_Moodlamp;
+	static const char * const CmdSetBacklight;
+	static const char * const CmdSetBacklight_Ambilight;
+	static const char * const CmdSetBacklight_Moodlamp;
 #ifdef SOUNDVIZ_SUPPORT
-	static const char * CmdSetBacklight_SoundViz;
+	static const char * const CmdSetBacklight_SoundViz;
 #endif
 
-	static const char * CmdSetPersistOnUnlock;
-	static const char * CmdSetPersistOnUnlock_On;
-	static const char * CmdSetPersistOnUnlock_Off;
+	static const char * const CmdSetPersistOnUnlock;
+	static const char * const CmdSetPersistOnUnlock_On;
+	static const char * const CmdSetPersistOnUnlock_Off;
 
 	static const int SignalWaitTimeoutMs;
 

--- a/Software/src/ColorButton.cpp
+++ b/Software/src/ColorButton.cpp
@@ -8,7 +8,7 @@
 
 ColorButton::ColorButton(QWidget * parent) : QPushButton(parent)
 {
-	this->setText("");
+	this->setText(QLatin1String(""));
 	connect(this, SIGNAL(clicked()), this, SLOT(click()));
 }
 

--- a/Software/src/ColorButton.cpp
+++ b/Software/src/ColorButton.cpp
@@ -9,7 +9,7 @@
 ColorButton::ColorButton(QWidget * parent) : QPushButton(parent)
 {
 	this->setText(QLatin1String(""));
-	connect(this, SIGNAL(clicked()), this, SLOT(click()));
+	connect(this, &ColorButton::clicked, this, qOverload<>(&ColorButton::click));
 }
 
 ColorButton::~ColorButton()
@@ -51,7 +51,7 @@ void ColorButton::click()
 							| Qt::WindowCloseButtonHint);
 
 	QColor savedColor = getColor();
-	connect(dialog, SIGNAL(currentColorChanged(QColor)), this, SLOT(currentColorChanged(QColor)));
+	connect(dialog, &QColorDialog::currentColorChanged, this, &ColorButton::currentColorChanged);
 	dialog->setCurrentColor(getColor());
 	if (dialog->exec() != QDialog::Accepted)
 		setColor(savedColor);

--- a/Software/src/ColorButton.hpp
+++ b/Software/src/ColorButton.hpp
@@ -3,7 +3,7 @@
 #ifndef CB_H
 #define CB_H
 
-#include <QtWidgets/QPushButton>
+#include <QPushButton>
 
 class ColorButton : public QPushButton
 {

--- a/Software/src/GrabConfigWidget.cpp
+++ b/Software/src/GrabConfigWidget.cpp
@@ -27,6 +27,7 @@
 #include "ui_GrabConfigWidget.h"
 #include <QPainter>
 #include <QBitmap>
+#include <QDesktopWidget>
 #include <QScreen>
 #include <QPainterPath>
 #include "debug.h"

--- a/Software/src/GrabConfigWidget.cpp
+++ b/Software/src/GrabConfigWidget.cpp
@@ -27,7 +27,9 @@
 #include "ui_GrabConfigWidget.h"
 #include <QPainter>
 #include <QBitmap>
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
 #include <QDesktopWidget>
+#endif
 #include <QScreen>
 #include <QPainterPath>
 #include "debug.h"

--- a/Software/src/GrabConfigWidget.cpp
+++ b/Software/src/GrabConfigWidget.cpp
@@ -27,7 +27,6 @@
 #include "ui_GrabConfigWidget.h"
 #include <QPainter>
 #include <QBitmap>
-#include <QDesktopWidget>
 #include <QScreen>
 #include <QPainterPath>
 #include "debug.h"
@@ -190,7 +189,7 @@ void GrabConfigWidget::paintArrow(QPainter *p, ArrowSide side)
 								pathArrow.elementAt(2).x,
 								pathArrow.elementAt(2).y - 1);
 		break;
-	case RightSide:		
+	case RightSide:
 		mainRect.setRight(width() - Margin - 1);
 
 		pathArrow.moveTo(width() - Margin,	height() / 2 - Margin);

--- a/Software/src/GrabConfigWidget.hpp
+++ b/Software/src/GrabConfigWidget.hpp
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <QTimer>
 
 namespace Ui {

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -48,8 +48,9 @@
 
 using namespace SettingsScope;
 
-#define FPS_UPDATE_INTERVAL 500
-#define FAKE_GRAB_INTERVAL 900
+using namespace std::chrono_literals;
+constexpr const std::chrono::milliseconds FPS_UPDATE_INTERVAL = 500ms;
+constexpr const std::chrono::milliseconds FAKE_GRAB_INTERVAL = 900ms;
 
 #ifdef D3D10_GRAB_SUPPORT
 
@@ -85,6 +86,7 @@ GrabManager::GrabManager(QWidget *parent) : QObject(parent)
 	m_timerUpdateFPS->setTimerType(Qt::PreciseTimer);
 	connect(m_timerUpdateFPS, SIGNAL(timeout()), this, SLOT(timeoutUpdateFPS()));
 	m_timerUpdateFPS->setSingleShot(false);
+
 	m_timerUpdateFPS->setInterval(FPS_UPDATE_INTERVAL);
 
 	m_timerFakeGrab = new QTimer(this);
@@ -503,7 +505,7 @@ void GrabManager::timeoutFakeGrab()
 void GrabManager::timeoutUpdateFPS()
 {
 	DEBUG_HIGH_LEVEL << Q_FUNC_INFO;
-	emit ambilightTimeOfUpdatingColors((2.0 * FPS_UPDATE_INTERVAL) / (m_grabCountLastInterval + m_grabCountThisInterval));
+	emit ambilightTimeOfUpdatingColors((2.0 * FPS_UPDATE_INTERVAL.count()) / (m_grabCountLastInterval + m_grabCountThisInterval));
 
 	m_grabCountLastInterval = m_grabCountThisInterval;
 	m_grabCountThisInterval = 0;
@@ -529,7 +531,7 @@ void GrabManager::updateScreenGeometry()
 	foreach(QScreen* screen, screenList) {
 		m_lastScreenGeometry.append(screen->geometry());
 	}
-	
+
 	emit changeScreen();
 	if (m_grabber == NULL)
 	{

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -26,7 +26,6 @@
 
 #include <QtCore/qmath.h>
 #include <QtWidgets/QApplication>
-#include <QtWidgets/QDesktopWidget>
 
 #include "debug.h"
 #include "PrismatikMath.hpp"

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -24,8 +24,8 @@
  *
  */
 
-#include <QtCore/qmath.h>
-#include <QtWidgets/QApplication>
+#include <QtMath>
+#include <QApplication>
 
 #include "debug.h"
 #include "PrismatikMath.hpp"

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -650,7 +650,7 @@ void GrabManager::initGrabbers()
 #ifdef D3D10_GRAB_SUPPORT
 	if (Settings::isDx1011GrabberEnabled()) {
 		m_d3d10Grabber = static_cast<D3D10Grabber *>(initGrabber(new D3D10Grabber(NULL, m_grabberContext, &GetMainWindowHandle, Settings::isDx9GrabbingEnabled())));
-		connect(m_d3d10Grabber, &D3D10Grabber::grabberStateChangeRequested, this, GrabManager::onGrabberStateChangeRequested);
+		connect(m_d3d10Grabber, &D3D10Grabber::grabberStateChangeRequested, this, &GrabManager::onGrabberStateChangeRequested);
 		connect(getLightpackApp(), &LightpackApplication::postInitialization, m_d3d10Grabber, &D3D10Grabber::init);
 	} else {
 		m_d3d10Grabber = NULL;

--- a/Software/src/GrabManager.cpp
+++ b/Software/src/GrabManager.cpp
@@ -84,14 +84,14 @@ GrabManager::GrabManager(QWidget *parent) : QObject(parent)
 
 	m_timerUpdateFPS = new QTimer(this);
 	m_timerUpdateFPS->setTimerType(Qt::PreciseTimer);
-	connect(m_timerUpdateFPS, SIGNAL(timeout()), this, SLOT(timeoutUpdateFPS()));
+	connect(m_timerUpdateFPS, &QTimer::timeout, this, &GrabManager::timeoutUpdateFPS);
 	m_timerUpdateFPS->setSingleShot(false);
 
 	m_timerUpdateFPS->setInterval(FPS_UPDATE_INTERVAL);
 
 	m_timerFakeGrab = new QTimer(this);
 	m_timerFakeGrab->setTimerType(Qt::PreciseTimer);
-	connect(m_timerFakeGrab, SIGNAL(timeout()), this, SLOT(timeoutFakeGrab()));
+	connect(m_timerFakeGrab, &QTimer::timeout, this, &GrabManager::timeoutFakeGrab);
 	m_timerFakeGrab->setSingleShot(false);
 	m_timerFakeGrab->setInterval(FAKE_GRAB_INTERVAL);
 
@@ -102,8 +102,16 @@ GrabManager::GrabManager(QWidget *parent) : QObject(parent)
 	initColorLists(MaximumNumberOfLeds::Default);
 	initLedWidgets(MaximumNumberOfLeds::Default);
 
-	connect(QApplication::desktop(), SIGNAL(resized(int)), this, SLOT(scaleLedWidgets(int)));
-	connect(QApplication::desktop(), SIGNAL(screenCountChanged(int)), this, SLOT(onScreenCountChanged(int)));
+	int idx = 0;
+	for (const QScreen* screen : QGuiApplication::screens()) {
+		connect(screen, &QScreen::geometryChanged,
+			[=](const QRect& geometry) { this->scaleLedWidgets(idx, geometry); }
+		);
+		++idx;
+	}
+
+	connect(qGuiApp, &QGuiApplication::screenAdded, this, &GrabManager::onScreenCountChanged);
+	connect(qGuiApp, &QGuiApplication::screenRemoved, this, &GrabManager::onScreenCountChanged);
 
 	updateScreenGeometry();
 
@@ -541,16 +549,16 @@ void GrabManager::updateScreenGeometry()
 
 }
 
-void GrabManager::onScreenCountChanged(int)
+void GrabManager::onScreenCountChanged(QScreen* screen)
 {
+	Q_UNUSED(screen)
 	updateScreenGeometry();
 }
 
-void GrabManager::scaleLedWidgets(int screenIndexResized)
+void GrabManager::scaleLedWidgets(const int screenIndexResized, const QRect& screenGeometry)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << "screenIndexResized:" << screenIndexResized;
 
-	QRect screenGeometry = QGuiApplication::screens().value(screenIndexResized, QGuiApplication::primaryScreen())->geometry();
 	QRect lastScreenGeometry = m_lastScreenGeometry[screenIndexResized];
 
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << "screen " << screenIndexResized << " is resized to " << screenGeometry;
@@ -627,7 +635,7 @@ void GrabManager::initGrabbers()
 #ifdef DDUPL_GRAB_SUPPORT
 	DDuplGrabber* dDuplGrabber = new DDuplGrabber(NULL, m_grabberContext);
 	m_grabbers[Grab::GrabberTypeDDupl] = initGrabber(dDuplGrabber);
-	connect(this, SIGNAL(onSessionChange(int)), dDuplGrabber, SLOT(onSessionChange(int)));
+	connect(this, &GrabManager::onSessionChange, dDuplGrabber, &DDuplGrabber::onSessionChange);
 #endif
 
 #ifdef X11_GRAB_SUPPORT
@@ -643,8 +651,8 @@ void GrabManager::initGrabbers()
 #ifdef D3D10_GRAB_SUPPORT
 	if (Settings::isDx1011GrabberEnabled()) {
 		m_d3d10Grabber = static_cast<D3D10Grabber *>(initGrabber(new D3D10Grabber(NULL, m_grabberContext, &GetMainWindowHandle, Settings::isDx9GrabbingEnabled())));
-		connect(m_d3d10Grabber, SIGNAL(grabberStateChangeRequested(bool)), SLOT(onGrabberStateChangeRequested(bool)));
-		connect(getLightpackApp(), SIGNAL(postInitialization()), m_d3d10Grabber, SLOT(init()));
+		connect(m_d3d10Grabber, &D3D10Grabber::grabberStateChangeRequested, this, GrabManager::onGrabberStateChangeRequested);
+		connect(getLightpackApp(), &LightpackApplication::postInitialization, m_d3d10Grabber, &D3D10Grabber::init);
 	} else {
 		m_d3d10Grabber = NULL;
 	}
@@ -653,7 +661,7 @@ void GrabManager::initGrabbers()
 
 GrabberBase *GrabManager::initGrabber(GrabberBase * grabber) {
 	QMetaObject::invokeMethod(grabber, "setGrabInterval", Qt::QueuedConnection, Q_ARG(int, Settings::getGrabSlowdown()));
-	bool isConnected = connect(grabber, SIGNAL(frameGrabAttempted(GrabResult)), this, SLOT(onFrameGrabAttempted(GrabResult)), Qt::QueuedConnection);
+	bool isConnected = connect(grabber, &GrabberBase::frameGrabAttempted, this, &GrabManager::onFrameGrabAttempted, Qt::QueuedConnection);
 	Q_ASSERT_X(isConnected, "connecting grabber to grabManager", "failed");
 	Q_UNUSED(isConnected);
 
@@ -671,7 +679,7 @@ void GrabManager::reinitDx1011Grabber() {
 
 	if (Settings::isDx1011GrabberEnabled()) {
 		m_d3d10Grabber = static_cast<D3D10Grabber *>(initGrabber(new D3D10Grabber(NULL, m_grabberContext, &GetMainWindowHandle, Settings::isDx9GrabbingEnabled())));
-		connect(m_d3d10Grabber, SIGNAL(grabberStateChangeRequested(bool)), SLOT(onGrabberStateChangeRequested(bool)));
+		connect(m_d3d10Grabber, &D3D10Grabber::grabberStateChangeRequested, this, &GrabManager::onGrabberStateChangeRequested);
 		m_d3d10Grabber->init();
 	}
 
@@ -751,12 +759,12 @@ void GrabManager::initLedWidgets(int numberOfLeds)
 
 		GrabWidget * ledWidget = new GrabWidget(m_ledWidgets.size(), widgetFlags, &m_ledWidgets, m_parentWidget);
 
-		connect(ledWidget, SIGNAL(resizeOrMoveStarted(int)), this, SLOT(pauseWhileResizeOrMoving()));
-		connect(ledWidget, SIGNAL(resizeOrMoveCompleted(int)), this, SLOT(resumeAfterResizeOrMoving()));
+		connect(ledWidget, &GrabWidget::resizeOrMoveStarted, this, &GrabManager::pauseWhileResizeOrMoving);
+		connect(ledWidget, &GrabWidget::resizeOrMoveCompleted, this, &GrabManager::resumeAfterResizeOrMoving);
 
 // TODO: Check out this line!
 //			First LED widget using to determine grabbing-monitor in WinAPI version of Grab
-//		connect(ledWidget, SIGNAL(resizeOrMoveCompleted(int)), this, SLOT(firstWidgetPositionChanged()));
+//		connect(ledWidget, SIGNAL(resizeOrMoveCompleted(int)), this, &GrabManager::firstWidgetPositionChanged);
 
 		m_ledWidgets << ledWidget;
 
@@ -773,8 +781,8 @@ void GrabManager::initLedWidgets(int numberOfLeds)
 		{
 			GrabWidget * ledWidget = new GrabWidget(m_ledWidgets.size(), widgetFlags, &m_ledWidgets, m_parentWidget);
 
-			connect(ledWidget, SIGNAL(resizeOrMoveStarted(int)), this, SLOT(pauseWhileResizeOrMoving()));
-			connect(ledWidget, SIGNAL(resizeOrMoveCompleted(int)), this, SLOT(resumeAfterResizeOrMoving()));
+			connect(ledWidget, &GrabWidget::resizeOrMoveStarted, this, &GrabManager::pauseWhileResizeOrMoving);
+			connect(ledWidget, &GrabWidget::resizeOrMoveCompleted, this, &GrabManager::resumeAfterResizeOrMoving);
 
 			m_ledWidgets << ledWidget;
 		}

--- a/Software/src/GrabManager.hpp
+++ b/Software/src/GrabManager.hpp
@@ -87,12 +87,12 @@ private slots:
 	void timeoutUpdateFPS();
 	void pauseWhileResizeOrMoving();
 	void resumeAfterResizeOrMoving();
-	void scaleLedWidgets(int screenIndexResized);
 	void onFrameGrabAttempted(GrabResult result);
 	void updateScreenGeometry();
-	void onScreenCountChanged(int);
+	void onScreenCountChanged(QScreen* screen);
 
 private:
+	void scaleLedWidgets(const int screenIndexResized, const QRect& geometry);
 	GrabberBase *queryGrabber(Grab::GrabberType grabber);
 	void initGrabbers();
 	GrabberBase *initGrabber(GrabberBase *grabber);

--- a/Software/src/GrabWidget.cpp
+++ b/Software/src/GrabWidget.cpp
@@ -26,7 +26,7 @@
 
 
 #include <QtGui>
-#include <QtWidgets/QDesktopWidget>
+#include <QDesktopWidget>
 #include <QTextItem>
 #include "GrabWidget.hpp"
 #include "ui_GrabWidget.h"

--- a/Software/src/GrabWidget.cpp
+++ b/Software/src/GrabWidget.cpp
@@ -26,7 +26,9 @@
 
 
 #include <QtGui>
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
 #include <QDesktopWidget>
+#endif
 #include <QTextItem>
 #include "GrabWidget.hpp"
 #include "ui_GrabWidget.h"
@@ -383,8 +385,11 @@ void GrabWidget::mouseMoveEvent(QMouseEvent *pe)
 {
 	DEBUG_HIGH_LEVEL << Q_FUNC_INFO << "pe->pos() =" << pe->pos();
 
+	#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+	QRect screen = QGuiApplication::screenAt(this->geometry().center())->geometry();
+	#else
 	QRect screen = QApplication::desktop()->screenGeometry(this);
-
+	#endif
 
 	if (cmd == NOP ){
 		checkAndSetCursors(pe);

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -90,31 +90,31 @@ void LedDeviceAdalight::setColors(const QList<QRgb> & colors)
 	{
 		StructRgb color = m_colorsBuffer[i];
 
-		if (m_colorSequence == "RBG")
+		if (m_colorSequence == QStringLiteral("RBG"))
 		{
 			m_writeBuffer.append(color.r);
 			m_writeBuffer.append(color.b);
 			m_writeBuffer.append(color.g);
 		}
-		else if (m_colorSequence == "BRG")
+		else if (m_colorSequence == QStringLiteral("BRG"))
 		{
 			m_writeBuffer.append(color.b);
 			m_writeBuffer.append(color.r);
 			m_writeBuffer.append(color.g);
 		}
-		else if (m_colorSequence == "BGR")
+		else if (m_colorSequence == QStringLiteral("BGR"))
 		{
 			m_writeBuffer.append(color.b);
 			m_writeBuffer.append(color.g);
 			m_writeBuffer.append(color.r);
 		}
-		else if (m_colorSequence == "GRB")
+		else if (m_colorSequence == QStringLiteral("GRB"))
 		{
 			m_writeBuffer.append(color.g);
 			m_writeBuffer.append(color.r);
 			m_writeBuffer.append(color.b);
 		}
-		else if (m_colorSequence == "GBR")
+		else if (m_colorSequence == QStringLiteral("GBR"))
 		{
 			m_writeBuffer.append(color.g);
 			m_writeBuffer.append(color.b);
@@ -169,7 +169,7 @@ void LedDeviceAdalight::setSmoothSlowdown(int /*value*/)
 	emit commandCompleted(true);
 }
 
-void LedDeviceAdalight::setColorSequence(QString value)
+void LedDeviceAdalight::setColorSequence(const QString& value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value;
 
@@ -179,7 +179,7 @@ void LedDeviceAdalight::setColorSequence(QString value)
 
 void LedDeviceAdalight::requestFirmwareVersion()
 {
-	emit firmwareVersion("unknown (adalight device)");
+	emit firmwareVersion(QStringLiteral("unknown (adalight device)"));
 	emit commandCompleted(true);
 }
 

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -58,6 +58,11 @@ LedDeviceAdalight::~LedDeviceAdalight()
 	delete m_lastWillTimer;
 }
 
+int LedDeviceAdalight::maxLedsCount()
+{
+	return MaximumNumberOfLeds::Adalight;
+}
+
 void LedDeviceAdalight::close()
 {
 	if (m_AdalightDevice == NULL)

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -46,7 +46,7 @@ LedDeviceAdalight::LedDeviceAdalight(const QString &portName, const int baudRate
 	m_AdalightDevice = NULL;
 	m_lastWillTimer = new QTimer(this);
 	m_lastWillTimer->setTimerType(Qt::PreciseTimer);
-	connect(m_lastWillTimer, SIGNAL(timeout()), this, SLOT(writeLastWill()));
+	connect(m_lastWillTimer, &QTimer::timeout, this, qOverload<>(&LedDeviceAdalight::writeLastWill));
 	// TODO: think about init m_savedColors in all ILedDevices
 
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << "initialized";
@@ -253,6 +253,11 @@ void LedDeviceAdalight::open()
 	}
 
 	emit openDeviceSuccess(ok);
+}
+
+void LedDeviceAdalight::writeLastWill()
+{
+	writeLastWill(false);
 }
 
 void LedDeviceAdalight::writeLastWill(const bool force)

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -279,7 +279,8 @@ bool LedDeviceAdalight::writeBuffer(const QByteArray & buff)
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << "Serial bytesToWrite:" << m_AdalightDevice->bytesToWrite() << ", skipping current frame";
 		// If no more writes will be done ("Send data only of colors changed")
 		// re-schedule last skipped frame in case it's important (for ex a black frame to turn off)
-		m_lastWillTimer->start(100);
+		using namespace std::chrono_literals;
+		m_lastWillTimer->start(100ms);
 		return true;
 	}
 	m_lastWillTimer->stop();

--- a/Software/src/LedDeviceAdalight.hpp
+++ b/Software/src/LedDeviceAdalight.hpp
@@ -36,9 +36,9 @@ class LedDeviceAdalight : public AbstractLedDevice
 public:
 	LedDeviceAdalight(const QString &portName, const int baudRate, QObject * parent = 0);
 	virtual ~LedDeviceAdalight();
+	QString name() const { return QStringLiteral("adalight"); }
 
 public slots:
-	const QString name() const { return "adalight"; }
 	void open();
 	void close();
 	void setColors(const QList<QRgb> & /*colors*/);
@@ -46,7 +46,7 @@ public slots:
 	void setRefreshDelay(int /*value*/);
 	void setColorDepth(int /*value*/);
 	void setSmoothSlowdown(int /*value*/);
-	void setColorSequence(QString value);
+	void setColorSequence(const QString& value);
 	void requestFirmwareVersion();
 	void updateDeviceSettings();
 	int maxLedsCount() { return 511; }

--- a/Software/src/LedDeviceAdalight.hpp
+++ b/Software/src/LedDeviceAdalight.hpp
@@ -51,7 +51,8 @@ public slots:
 	void setColorSequence(const QString& value);
 	void requestFirmwareVersion();
 	void updateDeviceSettings();
-	void writeLastWill(const bool force = false);
+	void writeLastWill();
+	void writeLastWill(const bool force);
 
 private:
 	bool writeBuffer(const QByteArray & buff);

--- a/Software/src/LedDeviceAdalight.hpp
+++ b/Software/src/LedDeviceAdalight.hpp
@@ -37,6 +37,8 @@ public:
 	LedDeviceAdalight(const QString &portName, const int baudRate, QObject * parent = 0);
 	virtual ~LedDeviceAdalight();
 	QString name() const { return QStringLiteral("adalight"); }
+	int maxLedsCount();
+	virtual int defaultLedsCount() { return 25; }
 
 public slots:
 	void open();
@@ -49,8 +51,6 @@ public slots:
 	void setColorSequence(const QString& value);
 	void requestFirmwareVersion();
 	void updateDeviceSettings();
-	int maxLedsCount() { return 511; }
-	virtual int defaultLedsCount() { return 25; }
 	void writeLastWill(const bool force = false);
 
 private:

--- a/Software/src/LedDeviceAlienFx.cpp
+++ b/Software/src/LedDeviceAlienFx.cpp
@@ -179,4 +179,9 @@ void LedDeviceAlienFx::open()
 	emit openDeviceSuccess(true);
 }
 
+int LedDeviceAlienFx::maxLedsCount()
+{
+	return MaximumNumberOfLeds::AlienFx;
+}
+
 #endif /* Q_OS_WIN */

--- a/Software/src/LedDeviceAlienFx.cpp
+++ b/Software/src/LedDeviceAlienFx.cpp
@@ -161,7 +161,7 @@ void LedDeviceAlienFx::setSmoothSlowdown(int /*value*/)
 	emit commandCompleted(true);
 }
 
-void LedDeviceAlienFx::setColorSequence(QString /*value*/)
+void LedDeviceAlienFx::setColorSequence(const QString& /*value*/)
 {
 	emit commandCompleted(true);
 }
@@ -169,7 +169,7 @@ void LedDeviceAlienFx::setColorSequence(QString /*value*/)
 
 void LedDeviceAlienFx::requestFirmwareVersion()
 {
-	emit firmwareVersion("unknown (alienfx)");
+	emit firmwareVersion(QStringLiteral("unknown (alienfx)"));
 	emit commandCompleted(true);
 }
 

--- a/Software/src/LedDeviceAlienFx.hpp
+++ b/Software/src/LedDeviceAlienFx.hpp
@@ -39,6 +39,8 @@ public:
 	LedDeviceAlienFx(QObject *parent = 0);
 	virtual ~LedDeviceAlienFx();
 	QString name() const { return QStringLiteral("lightfx"); }
+	int maxLedsCount()
+	int defaultLedsCount() { return 1; }
 
 public slots:
 	void open();
@@ -50,8 +52,6 @@ public slots:
 	void setSmoothSlowdown(int /*value*/);
 	void setColorSequence(const QString& /*value*/);
 	void requestFirmwareVersion();
-	int maxLedsCount() { return 1; }
-	int defaultLedsCount() { return 1; }
 
 
 private:

--- a/Software/src/LedDeviceAlienFx.hpp
+++ b/Software/src/LedDeviceAlienFx.hpp
@@ -39,7 +39,7 @@ public:
 	LedDeviceAlienFx(QObject *parent = 0);
 	virtual ~LedDeviceAlienFx();
 	QString name() const { return QStringLiteral("lightfx"); }
-	int maxLedsCount()
+	int maxLedsCount();
 	int defaultLedsCount() { return 1; }
 
 public slots:

--- a/Software/src/LedDeviceAlienFx.hpp
+++ b/Software/src/LedDeviceAlienFx.hpp
@@ -38,9 +38,9 @@ class LedDeviceAlienFx : public AbstractLedDevice
 public:
 	LedDeviceAlienFx(QObject *parent = 0);
 	virtual ~LedDeviceAlienFx();
+	QString name() const { return QStringLiteral("lightfx"); }
 
 public slots:
-	const QString name() const { return "lightfx"; }
 	void open();
 	void close(){};
 	void setColors(const QList<QRgb> & colors);
@@ -48,7 +48,7 @@ public slots:
 	void setRefreshDelay(int /*value*/);
 	void setColorDepth(int /*value*/);
 	void setSmoothSlowdown(int /*value*/);
-	void setColorSequence(QString /*value*/);
+	void setColorSequence(const QString& /*value*/);
 	void requestFirmwareVersion();
 	int maxLedsCount() { return 1; }
 	int defaultLedsCount() { return 1; }

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -99,31 +99,31 @@ void LedDeviceArdulight::setColors(const QList<QRgb> & colors)
 	{
 		StructRgb color = m_colorsBuffer[i];
 
-		if (m_colorSequence == "RBG")
+		if (m_colorSequence == QStringLiteral("RBG"))
 		{
 			m_writeBuffer.append(color.r);
 			m_writeBuffer.append(color.b);
 			m_writeBuffer.append(color.g);
 		}
-		else if (m_colorSequence == "BRG")
+		else if (m_colorSequence == QStringLiteral("BRG"))
 		{
 			m_writeBuffer.append(color.b);
 			m_writeBuffer.append(color.r);
 			m_writeBuffer.append(color.g);
 		}
-		else if (m_colorSequence == "BGR")
+		else if (m_colorSequence == QStringLiteral("BGR"))
 		{
 			m_writeBuffer.append(color.b);
 			m_writeBuffer.append(color.g);
 			m_writeBuffer.append(color.r);
 		}
-		else if (m_colorSequence == "GRB")
+		else if (m_colorSequence == QStringLiteral("GRB"))
 		{
 			m_writeBuffer.append(color.g);
 			m_writeBuffer.append(color.r);
 			m_writeBuffer.append(color.b);
 		}
-		else if (m_colorSequence == "GBR")
+		else if (m_colorSequence == QStringLiteral("GBR"))
 		{
 			m_writeBuffer.append(color.g);
 			m_writeBuffer.append(color.b);
@@ -179,7 +179,7 @@ void LedDeviceArdulight::setSmoothSlowdown(int /*value*/)
 	emit commandCompleted(true);
 }
 
-void LedDeviceArdulight::setColorSequence(QString value)
+void LedDeviceArdulight::setColorSequence(const QString& value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value;
 
@@ -189,7 +189,7 @@ void LedDeviceArdulight::setColorSequence(QString value)
 
 void LedDeviceArdulight::requestFirmwareVersion()
 {
-	emit firmwareVersion("unknown (ardulight device)");
+	emit firmwareVersion(QStringLiteral("unknown (ardulight device)"));
 	emit commandCompleted(true);
 }
 

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -50,7 +50,7 @@ LedDeviceArdulight::LedDeviceArdulight(const QString &portName, const int baudRa
 
 	m_lastWillTimer = new QTimer(this);
 	m_lastWillTimer->setTimerType(Qt::PreciseTimer);
-	connect(m_lastWillTimer, SIGNAL(timeout()), this, SLOT(writeLastWill()));
+	connect(m_lastWillTimer, &QTimer::timeout, this, qOverload<>(&LedDeviceArdulight::writeLastWill));
 
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << "initialized";
 }
@@ -260,6 +260,11 @@ void LedDeviceArdulight::open()
 	}
 
 	emit openDeviceSuccess(ok);
+}
+
+void LedDeviceArdulight::writeLastWill()
+{
+	writeLastWill(false);
 }
 
 void LedDeviceArdulight::writeLastWill(const bool force)

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -317,3 +317,7 @@ void LedDeviceArdulight::resizeColorsBuffer(int buffSize)
 	}
 }
 
+int LedDeviceArdulight::maxLedsCount()
+{
+	return MaximumNumberOfLeds::Ardulight;
+}

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -286,7 +286,8 @@ bool LedDeviceArdulight::writeBuffer(const QByteArray & buff)
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << "Serial bytesToWrite:" << m_ArdulightDevice->bytesToWrite() << ", skipping current frame";
 		// If no more writes will be done ("Send data only of colors changed")
 		// re-schedule last skipped frame in case it's important (for ex a black frame to turn off)
-		m_lastWillTimer->start(100);
+		using namespace std::chrono_literals;
+		m_lastWillTimer->start(100ms);
 		return true;
 	}
 	m_lastWillTimer->stop();

--- a/Software/src/LedDeviceArdulight.hpp
+++ b/Software/src/LedDeviceArdulight.hpp
@@ -36,9 +36,9 @@ class LedDeviceArdulight : public AbstractLedDevice
 public:
 	LedDeviceArdulight(const QString &portName, const int baudRate, QObject * parent = 0);
 	virtual ~LedDeviceArdulight();
+	QString name() const { return QStringLiteral("ardulight"); }
 
 public slots:
-	const QString name() const { return "ardulight"; }
 	void open();
 	void close();
 	void setColors(const QList<QRgb> & /*colors*/);
@@ -46,7 +46,7 @@ public slots:
 	void setRefreshDelay(int /*value*/);
 	void setColorDepth(int /*value*/);
 	void setSmoothSlowdown(int /*value*/);
-	void setColorSequence(QString value);
+	void setColorSequence(const QString& value);
 	void requestFirmwareVersion();
 	void updateDeviceSettings();
 	int maxLedsCount(){ return 255; }

--- a/Software/src/LedDeviceArdulight.hpp
+++ b/Software/src/LedDeviceArdulight.hpp
@@ -51,7 +51,8 @@ public slots:
 	void setColorSequence(const QString& value);
 	void requestFirmwareVersion();
 	void updateDeviceSettings();
-	void writeLastWill(const bool force = false);
+	void writeLastWill();
+	void writeLastWill(const bool force);
 
 private:
 	bool writeBuffer(const QByteArray & buff);

--- a/Software/src/LedDeviceArdulight.hpp
+++ b/Software/src/LedDeviceArdulight.hpp
@@ -37,6 +37,8 @@ public:
 	LedDeviceArdulight(const QString &portName, const int baudRate, QObject * parent = 0);
 	virtual ~LedDeviceArdulight();
 	QString name() const { return QStringLiteral("ardulight"); }
+	int maxLedsCount();
+	virtual int defaultLedsCount() { return 25; }
 
 public slots:
 	void open();
@@ -49,8 +51,6 @@ public slots:
 	void setColorSequence(const QString& value);
 	void requestFirmwareVersion();
 	void updateDeviceSettings();
-	int maxLedsCount(){ return 255; }
-	virtual int defaultLedsCount() { return 25; }
 	void writeLastWill(const bool force = false);
 
 private:

--- a/Software/src/LedDeviceDnrgb.cpp
+++ b/Software/src/LedDeviceDnrgb.cpp
@@ -31,9 +31,9 @@ LedDeviceDnrgb::LedDeviceDnrgb(const QString& address, const QString& port, cons
 {
 }
 
-const QString LedDeviceDnrgb::name() const
+QString LedDeviceDnrgb::name() const
 {
-	return "dnrgb";
+	return QStringLiteral("dnrgb");
 }
 
 int LedDeviceDnrgb::maxLedsCount()
@@ -152,7 +152,7 @@ void LedDeviceDnrgb::switchOffLeds()
 
 void LedDeviceDnrgb::requestFirmwareVersion()
 {
-	emit firmwareVersion("1.0 (dnrgb device)");
+	emit firmwareVersion(QStringLiteral("1.0 (dnrgb device)"));
 	emit commandCompleted(true);
 }
 

--- a/Software/src/LedDeviceDnrgb.hpp
+++ b/Software/src/LedDeviceDnrgb.hpp
@@ -32,19 +32,19 @@ class LedDeviceDnrgb : public AbstractLedDeviceUdp
 {
 	Q_OBJECT
 public:
-    LedDeviceDnrgb(const QString& address, const QString& port, const int timeout, QObject * parent = 0);
+	LedDeviceDnrgb(const QString& address, const QString& port, const int timeout, QObject * parent = 0);
+	QString name() const;
 
 public slots:
-    const QString name() const;
 	void setColors(const QList<QRgb> & colors);
 	void switchOffLeds();
-    void requestFirmwareVersion();
-    int maxLedsCount();
+	void requestFirmwareVersion();
+	int maxLedsCount();
 
 protected:
-    void resizeColorsBuffer(int buffSize);
-    void reinitBufferHeader();
+	void resizeColorsBuffer(int buffSize);
+	void reinitBufferHeader();
 
 private:
-    constexpr static const int LedsPerPacket = 489;
+	constexpr static const int LedsPerPacket = 489;
 };

--- a/Software/src/LedDeviceDnrgb.hpp
+++ b/Software/src/LedDeviceDnrgb.hpp
@@ -42,6 +42,6 @@ public slots:
 protected:
 	virtual void reinitBufferHeader();
 
-private:
 	constexpr static const int LedsPerPacket = 489;
+	QList<QRgb> m_processedColorsSaved;
 };

--- a/Software/src/LedDeviceDnrgb.hpp
+++ b/Software/src/LedDeviceDnrgb.hpp
@@ -32,18 +32,15 @@ class LedDeviceDnrgb : public AbstractLedDeviceUdp
 {
 	Q_OBJECT
 public:
-	LedDeviceDnrgb(const QString& address, const QString& port, const int timeout, QObject * parent = 0);
+	LedDeviceDnrgb(const QString& address, const QString& port, const uint8_t timeout, QObject * parent = 0);
 	QString name() const;
+	int maxLedsCount();
 
 public slots:
 	void setColors(const QList<QRgb> & colors);
-	void switchOffLeds();
-	void requestFirmwareVersion();
-	int maxLedsCount();
 
 protected:
-	void resizeColorsBuffer(int buffSize);
-	void reinitBufferHeader();
+	virtual void reinitBufferHeader();
 
 private:
 	constexpr static const int LedsPerPacket = 489;

--- a/Software/src/LedDeviceDrgb.cpp
+++ b/Software/src/LedDeviceDrgb.cpp
@@ -53,9 +53,8 @@ void LedDeviceDrgb::setColors(const QList<QRgb> & colors)
 	m_writeBuffer.clear();
 	m_writeBuffer.reserve(m_writeBuffer.count() + m_colorsBuffer.count() * sizeof(char));
 	m_writeBuffer.append(m_writeBufferHeader);
-	// m_writeBuffer.resize(m_writeBuffer.count() + m_colorsBuffer.count() * sizeof(char));
 
-	for (const StructRgb color : m_colorsBuffer)
+	for (const StructRgb& color : m_colorsBuffer)
 	{
 		m_writeBuffer.append(color.r);
 		m_writeBuffer.append(color.g);

--- a/Software/src/LedDeviceDrgb.cpp
+++ b/Software/src/LedDeviceDrgb.cpp
@@ -31,9 +31,9 @@ LedDeviceDrgb::LedDeviceDrgb(const QString& address, const QString& port, const 
 {
 }
 
-const QString LedDeviceDrgb::name() const
-{ 
-	return "drgb"; 
+QString LedDeviceDrgb::name() const
+{
+	return QStringLiteral("drgb");
 }
 
 int LedDeviceDrgb::maxLedsCount()
@@ -61,7 +61,7 @@ void LedDeviceDrgb::setColors(const QList<QRgb> & colors)
 		m_writeBuffer.append(color.g);
 		m_writeBuffer.append(color.b);
 	}
-	
+
 	bool ok = writeBuffer(m_writeBuffer);
 	emit commandCompleted(ok);
 }
@@ -90,7 +90,7 @@ void LedDeviceDrgb::switchOffLeds()
 
 void LedDeviceDrgb::requestFirmwareVersion()
 {
-	emit firmwareVersion("1.0 (drgb device)");
+	emit firmwareVersion(QStringLiteral("1.0 (drgb device)"));
 	emit commandCompleted(true);
 }
 

--- a/Software/src/LedDeviceDrgb.hpp
+++ b/Software/src/LedDeviceDrgb.hpp
@@ -32,16 +32,13 @@ class LedDeviceDrgb : public AbstractLedDeviceUdp
 {
 	Q_OBJECT
 public:
-	LedDeviceDrgb(const QString& address, const QString& port, const int timeout, QObject * parent = 0);
+	LedDeviceDrgb(const QString& address, const QString& port, const uint8_t timeout, QObject * parent = 0);
 	QString name() const;
+	int maxLedsCount();
 
 public slots:
 	void setColors(const QList<QRgb> & colors);
-	void switchOffLeds();
-	void requestFirmwareVersion();
-	int maxLedsCount();
 
 protected:
-	void resizeColorsBuffer(int buffSize);
-	void reinitBufferHeader();
+	virtual void reinitBufferHeader();
 };

--- a/Software/src/LedDeviceDrgb.hpp
+++ b/Software/src/LedDeviceDrgb.hpp
@@ -32,16 +32,16 @@ class LedDeviceDrgb : public AbstractLedDeviceUdp
 {
 	Q_OBJECT
 public:
-    LedDeviceDrgb(const QString& address, const QString& port, const int timeout, QObject * parent = 0);
+	LedDeviceDrgb(const QString& address, const QString& port, const int timeout, QObject * parent = 0);
+	QString name() const;
 
 public slots:
-    const QString name() const;
 	void setColors(const QList<QRgb> & colors);
 	void switchOffLeds();
-    void requestFirmwareVersion();
-    int maxLedsCount();
+	void requestFirmwareVersion();
+	int maxLedsCount();
 
 protected:
-    void resizeColorsBuffer(int buffSize);
-    void reinitBufferHeader();
+	void resizeColorsBuffer(int buffSize);
+	void reinitBufferHeader();
 };

--- a/Software/src/LedDeviceLightpack.cpp
+++ b/Software/src/LedDeviceLightpack.cpp
@@ -78,7 +78,7 @@ void LedDeviceLightpack::setColors(const QList<QRgb> & colors)
 		return;
 	}
 
-	if (static_cast<size_t>(colors.count()) > maxLedsCount()) {
+	if (colors.count() > maxLedsCount()) {
 		qWarning() << Q_FUNC_INFO << "data size is greater than max leds count";
 		// skip command with wrong data size
 		return;
@@ -149,7 +149,7 @@ void LedDeviceLightpack::switchOffLeds()
 
 	if (m_colorsSaved.empty())
 	{
-		for (size_t i = 0; i < maxLedsCount(); ++i)
+		for (int i = 0; i < maxLedsCount(); ++i)
 			m_colorsSaved << 0;
 	} else {
 		for (int i = 0; i < m_colorsSaved.count(); i++)
@@ -227,7 +227,7 @@ void LedDeviceLightpack::setSmoothSlowdown(int value)
 	emit commandCompleted(ok);
 }
 
-void LedDeviceLightpack::setColorSequence(QString /*value*/)
+void LedDeviceLightpack::setColorSequence(const QString& /*value*/)
 {
 	emit commandCompleted(true);
 }
@@ -247,7 +247,7 @@ void LedDeviceLightpack::requestFirmwareVersion()
 		int fw_major = m_readBuffer[INDEX_FW_VER_MAJOR];
 		int fw_minor = m_readBuffer[INDEX_FW_VER_MINOR];
 		fw_unofficial = m_readBuffer[INDEX_FW_VER_UNOFFICIAL];
-		fwVersion = QString::number(fw_major) + "." + QString::number(fw_minor) + (fw_unofficial > 0 ? "+" + QString::number(fw_unofficial) : "");
+		fwVersion = QString::number(fw_major) + QStringLiteral(".") + QString::number(fw_minor) + (fw_unofficial > 0 ? QStringLiteral("+") + QString::number(fw_unofficial) : QLatin1String(""));
 	} else {
 		fwVersion = tr("read device fail");
 	}
@@ -281,7 +281,7 @@ void LedDeviceLightpack::open()
 		return;
 	}
 
-	DEBUG_LOW_LEVEL << Q_FUNC_INFO << QString("hid_open(0x%1, 0x%2)")
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO << QStringLiteral("hid_open(0x%1, 0x%2)")
 						.arg(USB_VENDOR_ID, 4, 16, QChar('0'))
 						.arg(USB_PRODUCT_ID, 4, 16, QChar('0'));
 
@@ -454,7 +454,7 @@ void LedDeviceLightpack::resizeColorsBuffer(int buffSize)
 
 	m_colorsBuffer.clear();
 
-	size_t checkedBufferSize = buffSize;
+	int checkedBufferSize = buffSize;
 	if (checkedBufferSize > maxLedsCount())
 	{
 		qCritical() << Q_FUNC_INFO << "buffSize > MaximumLedsCount" << checkedBufferSize << ">" << maxLedsCount();

--- a/Software/src/LedDeviceLightpack.cpp
+++ b/Software/src/LedDeviceLightpack.cpp
@@ -50,9 +50,9 @@ LedDeviceLightpack::LedDeviceLightpack(QObject *parent) :
 
 	m_timerPingDevice = new QTimer(this);
 
-	connect(m_timerPingDevice, SIGNAL(timeout()), this, SLOT(timerPingDeviceTimeout()));
-	connect(this, SIGNAL(ioDeviceSuccess(bool)), this, SLOT(restartPingDevice(bool)));
-	connect(this, SIGNAL(openDeviceSuccess(bool)), this, SLOT(restartPingDevice(bool)));
+	connect(m_timerPingDevice, &QTimer::timeout, this, &LedDeviceLightpack::timerPingDeviceTimeout);
+	connect(this, &LedDeviceLightpack::ioDeviceSuccess, this, &LedDeviceLightpack::restartPingDevice);
+	connect(this, &LedDeviceLightpack::openDeviceSuccess, this, &LedDeviceLightpack::restartPingDevice);
 
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << "initialized";
 }
@@ -478,10 +478,8 @@ void LedDeviceLightpack::closeDevices()
 	m_devices.clear();
 }
 
-void LedDeviceLightpack::restartPingDevice(bool isSuccess)
+void LedDeviceLightpack::restartPingDevice()
 {
-	Q_UNUSED(isSuccess);
-
 	if (Settings::isBacklightEnabled() && Settings::isPingDeviceEverySecond())
 	{
 		// Start ping device with PingDeviceInterval ms after last data transfer complete

--- a/Software/src/LedDeviceLightpack.hpp
+++ b/Software/src/LedDeviceLightpack.hpp
@@ -76,7 +76,7 @@ private:
 	void closeDevices();
 
 private slots:
-	void restartPingDevice(bool isSuccess);
+	void restartPingDevice();
 	void timerPingDeviceTimeout();
 
 private:

--- a/Software/src/LedDeviceLightpack.hpp
+++ b/Software/src/LedDeviceLightpack.hpp
@@ -49,6 +49,9 @@ public:
 	LedDeviceLightpack(QObject *parent = 0);
 	virtual ~LedDeviceLightpack();
 	QString name() const { return QStringLiteral("lightpack"); }
+	virtual int defaultLedsCount() { return maxLedsCount(); }
+	int lightpacksFound() { return m_devices.size(); }
+	virtual int maxLedsCount();
 
 public slots:
 	virtual void open();
@@ -62,9 +65,6 @@ public slots:
 	virtual void setColorSequence(const QString& /*value*/);
 	virtual void requestFirmwareVersion();
 	virtual void updateDeviceSettings();
-	virtual int maxLedsCount();
-	virtual int defaultLedsCount() { return maxLedsCount(); }
-	int lightpacksFound() { return m_devices.size(); }
 
 private:
 	bool readDataFromDevice();

--- a/Software/src/LedDeviceLightpack.hpp
+++ b/Software/src/LedDeviceLightpack.hpp
@@ -48,9 +48,9 @@ class LedDeviceLightpack : public AbstractLedDevice
 public:
 	LedDeviceLightpack(QObject *parent = 0);
 	virtual ~LedDeviceLightpack();
+	QString name() const { return QStringLiteral("lightpack"); }
 
 public slots:
-	virtual const QString name() const { return "lightpack"; }
 	virtual void open();
 	virtual void close();
 	virtual void setColors(const QList<QRgb> & colors);
@@ -59,14 +59,14 @@ public slots:
 	virtual void setRefreshDelay(int value);
 	virtual void setColorDepth(int value);
 	virtual void setSmoothSlowdown(int value);
-	virtual void setColorSequence(QString /*value*/);
+	virtual void setColorSequence(const QString& /*value*/);
 	virtual void requestFirmwareVersion();
 	virtual void updateDeviceSettings();
 	virtual int maxLedsCount();
 	virtual int defaultLedsCount() { return maxLedsCount(); }
 	int lightpacksFound() { return m_devices.size(); }
 
-private: 
+private:
 	bool readDataFromDevice();
 	bool writeBufferToDevice(int command, hid_device *phid_device);
 	bool tryToReopenDevice();

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -85,14 +85,14 @@ LedDeviceManager::~LedDeviceManager()
 void LedDeviceManager::init()
 {
 	if (!m_cmdTimeoutTimer) {
-		m_cmdTimeoutTimer = new QTimer();
+		m_cmdTimeoutTimer = new QTimer(this);
 
 		m_cmdTimeoutTimer->setInterval(100);
 		connect(m_cmdTimeoutTimer, SIGNAL(timeout()), this, SLOT(ledDeviceCommandTimedOut()));
 	}
 
 	if (!m_recreateTimer) {
-		m_recreateTimer = new QTimer();
+		m_recreateTimer = new QTimer(this);
 		m_recreateTimer->setSingleShot(true);
 		connect(m_recreateTimer, SIGNAL(timeout()), this, SLOT(recreateLedDevice()));
 	}
@@ -552,12 +552,12 @@ void LedDeviceManager::connectSignalSlotsLedDevice()
 	connect(this, SIGNAL(ledDeviceSetRefreshDelay(int)),				m_ledDevice, SLOT(setRefreshDelay(int)),						Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceSetColorDepth(int)),					m_ledDevice, SLOT(setColorDepth(int)),							Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceSetSmoothSlowdown(int)),				m_ledDevice, SLOT(setSmoothSlowdown(int)),						Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetGamma(double, bool)),				m_ledDevice, SLOT(setGamma(double, bool)),						Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetBrightness(int, bool)),			m_ledDevice, SLOT(setBrightness(int, bool)),					Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetBrightnessCap(int, bool)),			m_ledDevice, SLOT(setBrightnessCap(int, bool)),					Qt::QueuedConnection);
+	connect(this, SIGNAL(ledDeviceSetGamma(double,bool)),				m_ledDevice, SLOT(setGamma(double,bool)),						Qt::QueuedConnection);
+	connect(this, SIGNAL(ledDeviceSetBrightness(int,bool)),			m_ledDevice, SLOT(setBrightness(int,bool)),					Qt::QueuedConnection);
+	connect(this, SIGNAL(ledDeviceSetBrightnessCap(int,bool)),			m_ledDevice, SLOT(setBrightnessCap(int,bool)),					Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceSetColorSequence(QString)),			m_ledDevice, SLOT(setColorSequence(QString)),					Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetLuminosityThreshold(int, bool)),	m_ledDevice, SLOT(setLuminosityThreshold(int, bool)),			Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetMinimumLuminosityEnabled(bool, bool)),	m_ledDevice,SLOT(setMinimumLuminosityThresholdEnabled(bool, bool)),	Qt::QueuedConnection);
+	connect(this, SIGNAL(ledDeviceSetLuminosityThreshold(int,bool)),	m_ledDevice, SLOT(setLuminosityThreshold(int,bool)),			Qt::QueuedConnection);
+	connect(this, SIGNAL(ledDeviceSetMinimumLuminosityEnabled(bool,bool)),	m_ledDevice,SLOT(setMinimumLuminosityThresholdEnabled(bool,bool)),	Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceSetDitheringEnabled(bool)),			m_ledDevice, SLOT(setDitheringEnabled(bool)),					Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceRequestFirmwareVersion()),			m_ledDevice, SLOT(requestFirmwareVersion()),					Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceUpdateWBAdjustments()),				m_ledDevice, SLOT(updateWBAdjustments()),						Qt::QueuedConnection);
@@ -587,12 +587,12 @@ void LedDeviceManager::disconnectSignalSlotsLedDevice()
 	disconnect(this, SIGNAL(ledDeviceSetRefreshDelay(int)),					m_ledDevice, SLOT(setRefreshDelay(int)));
 	disconnect(this, SIGNAL(ledDeviceSetColorDepth(int)),					m_ledDevice, SLOT(setColorDepth(int)));
 	disconnect(this, SIGNAL(ledDeviceSetSmoothSlowdown(int)),				m_ledDevice, SLOT(setSmoothSlowdown(int)));
-	disconnect(this, SIGNAL(ledDeviceSetGamma(double, bool)),				m_ledDevice, SLOT(setGamma(double, bool)));
-	disconnect(this, SIGNAL(ledDeviceSetBrightness(int, bool)),				m_ledDevice, SLOT(setBrightness(int, bool)));
-	disconnect(this, SIGNAL(ledDeviceSetBrightnessCap(int, bool)),			m_ledDevice, SLOT(setBrightnessCap(int, bool)));
+	disconnect(this, SIGNAL(ledDeviceSetGamma(double,bool)),				m_ledDevice, SLOT(setGamma(double,bool)));
+	disconnect(this, SIGNAL(ledDeviceSetBrightness(int,bool)),				m_ledDevice, SLOT(setBrightness(int,bool)));
+	disconnect(this, SIGNAL(ledDeviceSetBrightnessCap(int,bool)),			m_ledDevice, SLOT(setBrightnessCap(int,bool)));
 	disconnect(this, SIGNAL(ledDeviceSetColorSequence(QString)),			m_ledDevice, SLOT(setColorSequence(QString)));
-	disconnect(this, SIGNAL(ledDeviceSetLuminosityThreshold(int, bool)),	m_ledDevice, SLOT(setLuminosityThreshold(int, bool)));
-	disconnect(this, SIGNAL(ledDeviceSetMinimumLuminosityEnabled(bool, bool)),	m_ledDevice, SLOT(setMinimumLuminosityThresholdEnabled(bool, bool)));
+	disconnect(this, SIGNAL(ledDeviceSetLuminosityThreshold(int,bool)),	m_ledDevice, SLOT(setLuminosityThreshold(int,bool)));
+	disconnect(this, SIGNAL(ledDeviceSetMinimumLuminosityEnabled(bool,bool)),	m_ledDevice, SLOT(setMinimumLuminosityThresholdEnabled(bool,bool)));
 	disconnect(this, SIGNAL(ledDeviceRequestFirmwareVersion()),				m_ledDevice, SLOT(requestFirmwareVersion()));
 	disconnect(this, SIGNAL(ledDeviceUpdateWBAdjustments()),				m_ledDevice, SLOT(updateWBAdjustments()));
 	disconnect(this, SIGNAL(ledDeviceUpdateDeviceSettings()),				m_ledDevice, SLOT(updateDeviceSettings()));

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -310,7 +310,7 @@ void LedDeviceManager::setDitheringEnabled(bool isEnabled) {
 	}
 }
 
-void LedDeviceManager::setColorSequence(QString value)
+void LedDeviceManager::setColorSequence(const QString& value)
 {
 	DEBUG_MID_LEVEL << Q_FUNC_INFO << value << "Is last command completed:" << m_isLastCommandCompleted;
 

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -303,7 +303,7 @@ void LedDeviceManager::setDitheringEnabled(bool isEnabled) {
 	if (m_isLastCommandCompleted) {
 		m_cmdTimeoutTimer->start();
 		m_isLastCommandCompleted = false;
-		emit ledDeviceSetDitheringEnabled(isEnabled);
+		emit ledDeviceSetDitheringEnabled(isEnabled, m_backlightStatus != Backlight::StatusOff);
 	}
 	else {
 		m_savedDitheringEnabled = isEnabled;
@@ -559,7 +559,7 @@ void LedDeviceManager::connectSignalSlotsLedDevice()
 	connect(this, SIGNAL(ledDeviceSetColorSequence(QString)),			m_ledDevice, SLOT(setColorSequence(QString)),					Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceSetLuminosityThreshold(int,bool)),	m_ledDevice, SLOT(setLuminosityThreshold(int,bool)),			Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceSetMinimumLuminosityEnabled(bool,bool)),	m_ledDevice,SLOT(setMinimumLuminosityThresholdEnabled(bool,bool)),	Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetDitheringEnabled(bool)),			m_ledDevice, SLOT(setDitheringEnabled(bool)),					Qt::QueuedConnection);
+	connect(this, SIGNAL(ledDeviceSetDitheringEnabled(bool,bool)),			m_ledDevice, SLOT(setDitheringEnabled(bool,bool)),					Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceRequestFirmwareVersion()),			m_ledDevice, SLOT(requestFirmwareVersion()),					Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceUpdateWBAdjustments()),				m_ledDevice, SLOT(updateWBAdjustments()),						Qt::QueuedConnection);
 	connect(this, SIGNAL(ledDeviceUpdateDeviceSettings()),				m_ledDevice, SLOT(updateDeviceSettings()),						Qt::QueuedConnection);
@@ -685,7 +685,7 @@ void LedDeviceManager::cmdQueueProcessNext()
 
 		case LedDeviceCommands::SetDitheringEnabled:
 			m_cmdTimeoutTimer->start();
-			emit ledDeviceSetDitheringEnabled(m_savedDitheringEnabled);
+			emit ledDeviceSetDitheringEnabled(m_savedDitheringEnabled, m_backlightStatus != Backlight::StatusOff);
 			break;
 
 		case LedDeviceCommands::RequestFirmwareVersion:

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -575,32 +575,6 @@ void LedDeviceManager::disconnectSignalSlotsLedDevice()
 	}
 	m_ledDevice->disconnect(this, nullptr, nullptr, nullptr);
 	disconnect(m_ledDevice, nullptr, nullptr, nullptr);
-/*
-    disconnect(m_ledDevice, &AbstractLedDevice::commandCompleted,		this, &LedDeviceManager::ledDeviceCommandCompleted);
-	disconnect(m_ledDevice, &AbstractLedDevice::ioDeviceSuccess,		this, &LedDeviceManager::ledDeviceIoDeviceSuccess);
-	disconnect(m_ledDevice, &AbstractLedDevice::openDeviceSuccess,	this, &LedDeviceManager::ledDeviceOpenDeviceSuccess);
-
-	disconnect(m_ledDevice, &AbstractLedDevice::firmwareVersion,		this, &LedDeviceManager::firmwareVersion);
-	disconnect(m_ledDevice, &AbstractLedDevice::firmwareVersionUnofficial, this, &LedDeviceManager::firmwareVersionUnofficial);
-	disconnect(m_ledDevice, &AbstractLedDevice::colorsUpdated,		this, &LedDeviceManager::setColors_VirtualDeviceCallback);
-
-	disconnect(this, &LedDeviceManager::ledDeviceOpen,								m_ledDevice, &AbstractLedDevice::open);
-	disconnect(this, &LedDeviceManager::ledDeviceSetColors,				m_ledDevice, &AbstractLedDevice::setColors);
-	disconnect(this, &LedDeviceManager::ledDeviceOffLeds,							m_ledDevice, &AbstractLedDevice::switchOffLeds);
-	disconnect(this, &LedDeviceManager::ledDeviceSetUsbPowerLedDisabled,			m_ledDevice, &AbstractLedDevice::setUsbPowerLedDisabled);
-	disconnect(this, &LedDeviceManager::ledDeviceSetRefreshDelay,					m_ledDevice, &AbstractLedDevice::setRefreshDelay);
-	disconnect(this, &LedDeviceManager::ledDeviceSetColorDepth,					m_ledDevice, &AbstractLedDevice::setColorDepth);
-	disconnect(this, &LedDeviceManager::ledDeviceSetSmoothSlowdown,				m_ledDevice, &AbstractLedDevice::setSmoothSlowdown);
-	disconnect(this, &LedDeviceManager::ledDeviceSetGamma,				m_ledDevice, &AbstractLedDevice::setGamma);
-	disconnect(this, &LedDeviceManager::ledDeviceSetBrightness,				m_ledDevice, &AbstractLedDevice::setBrightness);
-	disconnect(this, &LedDeviceManager::ledDeviceSetBrightnessCap,			m_ledDevice, &AbstractLedDevice::setBrightnessCap);
-	disconnect(this, &LedDeviceManager::ledDeviceSetColorSequence,			m_ledDevice, &AbstractLedDevice::setColorSequence);
-	disconnect(this, &LedDeviceManager::ledDeviceSetLuminosityThreshold,	m_ledDevice, &AbstractLedDevice::setLuminosityThreshold);
-	disconnect(this, &LedDeviceManager::ledDeviceSetMinimumLuminosityEnabled,	m_ledDevice, &AbstractLedDevice::setMinimumLuminosityThresholdEnabled);
-	disconnect(this, &LedDeviceManager::ledDeviceRequestFirmwareVersion,				m_ledDevice, &AbstractLedDevice::requestFirmwareVersion);
-	disconnect(this, &LedDeviceManager::ledDeviceUpdateWBAdjustments,				m_ledDevice, qOverload<>(&AbstractLedDevice::updateWBAdjustments));
-	disconnect(this, &LedDeviceManager::ledDeviceUpdateDeviceSettings,				m_ledDevice, &AbstractLedDevice::updateDeviceSettings);
-*/
 }
 
 void LedDeviceManager::cmdQueueAppend(LedDeviceCommands::Cmd cmd)

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -87,8 +87,8 @@ void LedDeviceManager::init()
 {
 	if (!m_cmdTimeoutTimer) {
 		m_cmdTimeoutTimer = new QTimer(this);
-
-		m_cmdTimeoutTimer->setInterval(100);
+		using namespace std::chrono_literals;
+		m_cmdTimeoutTimer->setInterval(100ms);
 		connect(m_cmdTimeoutTimer, &QTimer::timeout, this, &LedDeviceManager::ledDeviceCommandTimedOut);
 	}
 
@@ -413,14 +413,15 @@ void LedDeviceManager::ledDeviceIoDeviceSuccess(bool isSuccess)
 void LedDeviceManager::triggerRecreateLedDevice()
 {
 	if (!m_recreateTimer->isActive()) {
+		using namespace std::chrono_literals;
 		if (m_failedCreationAttempts == 0) {
-			m_recreateTimer->setInterval(200);
+			m_recreateTimer->setInterval(200ms);
 		} else if (m_failedCreationAttempts == 1) {
-			m_recreateTimer->setInterval(500);
+			m_recreateTimer->setInterval(500ms);
 		} else if (m_failedCreationAttempts < 10) {
-			m_recreateTimer->setInterval(1000);
+			m_recreateTimer->setInterval(1s);
 		} else {
-			m_recreateTimer->setInterval(5000);
+			m_recreateTimer->setInterval(5s);
 		}
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Will try to recreate device in" << m_recreateTimer->interval() << "msec";
 		m_recreateTimer->start();
@@ -574,7 +575,7 @@ void LedDeviceManager::disconnectSignalSlotsLedDevice()
 	}
 	m_ledDevice->disconnect(this, nullptr, nullptr, nullptr);
 	disconnect(m_ledDevice, nullptr, nullptr, nullptr);
-/*	
+/*
     disconnect(m_ledDevice, &AbstractLedDevice::commandCompleted,		this, &LedDeviceManager::ledDeviceCommandCompleted);
 	disconnect(m_ledDevice, &AbstractLedDevice::ioDeviceSuccess,		this, &LedDeviceManager::ledDeviceIoDeviceSuccess);
 	disconnect(m_ledDevice, &AbstractLedDevice::openDeviceSuccess,	this, &LedDeviceManager::ledDeviceOpenDeviceSuccess);

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -64,6 +64,7 @@ LedDeviceManager::LedDeviceManager(QObject *parent)
 
 	m_savedBrightnessCap = SettingsScope::Profile::Device::BrightnessCapDefault;
 
+	m_ledDevices.reserve(SupportedDevices::DeviceTypesCount);
 	for (int i = 0; i < SupportedDevices::DeviceTypesCount; i++)
 		m_ledDevices.append(NULL);
 }

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -89,13 +89,13 @@ void LedDeviceManager::init()
 		m_cmdTimeoutTimer = new QTimer(this);
 
 		m_cmdTimeoutTimer->setInterval(100);
-		connect(m_cmdTimeoutTimer, SIGNAL(timeout()), this, SLOT(ledDeviceCommandTimedOut()));
+		connect(m_cmdTimeoutTimer, &QTimer::timeout, this, &LedDeviceManager::ledDeviceCommandTimedOut);
 	}
 
 	if (!m_recreateTimer) {
 		m_recreateTimer = new QTimer(this);
 		m_recreateTimer->setSingleShot(true);
-		connect(m_recreateTimer, SIGNAL(timeout()), this, SLOT(recreateLedDevice()));
+		connect(m_recreateTimer, &QTimer::timeout, this, &LedDeviceManager::recreateLedDevice);
 	}
 
 	initLedDevice();
@@ -538,31 +538,31 @@ void LedDeviceManager::connectSignalSlotsLedDevice()
 		return;
 	}
 
-	connect(m_ledDevice, SIGNAL(commandCompleted(bool)),			this, SLOT(ledDeviceCommandCompleted(bool)),				Qt::QueuedConnection);
-	connect(m_ledDevice, SIGNAL(ioDeviceSuccess(bool)),				this, SLOT(ledDeviceIoDeviceSuccess(bool)),					Qt::QueuedConnection);
-	connect(m_ledDevice, SIGNAL(openDeviceSuccess(bool)),			this, SLOT(ledDeviceOpenDeviceSuccess(bool)),				Qt::QueuedConnection);
+	connect(m_ledDevice, &AbstractLedDevice::commandCompleted,			this, &LedDeviceManager::ledDeviceCommandCompleted,				Qt::QueuedConnection);
+	connect(m_ledDevice, &AbstractLedDevice::ioDeviceSuccess,				this, &LedDeviceManager::ledDeviceIoDeviceSuccess,					Qt::QueuedConnection);
+	connect(m_ledDevice, &AbstractLedDevice::openDeviceSuccess,			this, &LedDeviceManager::ledDeviceOpenDeviceSuccess,				Qt::QueuedConnection);
 
-	connect(m_ledDevice, SIGNAL(firmwareVersion(QString)),			this, SIGNAL(firmwareVersion(QString)),						Qt::QueuedConnection);
-	connect(m_ledDevice, SIGNAL(firmwareVersionUnofficial(int)),	this, SIGNAL(firmwareVersionUnofficial(int)),				Qt::QueuedConnection);
-	connect(m_ledDevice, SIGNAL(colorsUpdated(QList<QRgb>)),		this, SIGNAL(setColors_VirtualDeviceCallback(QList<QRgb>)),	Qt::QueuedConnection);
+	connect(m_ledDevice, &AbstractLedDevice::firmwareVersion,			this, &LedDeviceManager::firmwareVersion,						Qt::QueuedConnection);
+	connect(m_ledDevice, &AbstractLedDevice::firmwareVersionUnofficial,	this, &LedDeviceManager::firmwareVersionUnofficial,				Qt::QueuedConnection);
+	connect(m_ledDevice, &AbstractLedDevice::colorsUpdated,		this, &LedDeviceManager::setColors_VirtualDeviceCallback,	Qt::QueuedConnection);
 
-	connect(this, SIGNAL(ledDeviceOpen()),								m_ledDevice, SLOT(open()),										Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetColors(QList<QRgb>)),				m_ledDevice, SLOT(setColors(QList<QRgb>)),						Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceOffLeds()),							m_ledDevice, SLOT(switchOffLeds()),								Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetUsbPowerLedDisabled(bool)),		m_ledDevice, SLOT(setUsbPowerLedDisabled(bool)),				Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetRefreshDelay(int)),				m_ledDevice, SLOT(setRefreshDelay(int)),						Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetColorDepth(int)),					m_ledDevice, SLOT(setColorDepth(int)),							Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetSmoothSlowdown(int)),				m_ledDevice, SLOT(setSmoothSlowdown(int)),						Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetGamma(double,bool)),				m_ledDevice, SLOT(setGamma(double,bool)),						Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetBrightness(int,bool)),			m_ledDevice, SLOT(setBrightness(int,bool)),					Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetBrightnessCap(int,bool)),			m_ledDevice, SLOT(setBrightnessCap(int,bool)),					Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetColorSequence(QString)),			m_ledDevice, SLOT(setColorSequence(QString)),					Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetLuminosityThreshold(int,bool)),	m_ledDevice, SLOT(setLuminosityThreshold(int,bool)),			Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetMinimumLuminosityEnabled(bool,bool)),	m_ledDevice,SLOT(setMinimumLuminosityThresholdEnabled(bool,bool)),	Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceSetDitheringEnabled(bool,bool)),			m_ledDevice, SLOT(setDitheringEnabled(bool,bool)),					Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceRequestFirmwareVersion()),			m_ledDevice, SLOT(requestFirmwareVersion()),					Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceUpdateWBAdjustments()),				m_ledDevice, SLOT(updateWBAdjustments()),						Qt::QueuedConnection);
-	connect(this, SIGNAL(ledDeviceUpdateDeviceSettings()),				m_ledDevice, SLOT(updateDeviceSettings()),						Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceOpen,								m_ledDevice, &AbstractLedDevice::open,										Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetColors,				m_ledDevice, &AbstractLedDevice::setColors,						Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceOffLeds,							m_ledDevice, &AbstractLedDevice::switchOffLeds,								Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetUsbPowerLedDisabled,		m_ledDevice, &AbstractLedDevice::setUsbPowerLedDisabled,				Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetRefreshDelay,				m_ledDevice, &AbstractLedDevice::setRefreshDelay,						Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetColorDepth,					m_ledDevice, &AbstractLedDevice::setColorDepth,							Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetSmoothSlowdown,				m_ledDevice, &AbstractLedDevice::setSmoothSlowdown,						Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetGamma,				m_ledDevice, &AbstractLedDevice::setGamma,						Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetBrightness,			m_ledDevice, &AbstractLedDevice::setBrightness,					Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetBrightnessCap,			m_ledDevice, &AbstractLedDevice::setBrightnessCap,					Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetColorSequence,			m_ledDevice, &AbstractLedDevice::setColorSequence,					Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetLuminosityThreshold,	m_ledDevice, &AbstractLedDevice::setLuminosityThreshold,			Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetMinimumLuminosityEnabled,	m_ledDevice, &AbstractLedDevice::setMinimumLuminosityThresholdEnabled,	Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceSetDitheringEnabled,			m_ledDevice, &AbstractLedDevice::setDitheringEnabled,					Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceRequestFirmwareVersion,			m_ledDevice, &AbstractLedDevice::requestFirmwareVersion,					Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceUpdateWBAdjustments,				m_ledDevice, qOverload<>(&AbstractLedDevice::updateWBAdjustments),						Qt::QueuedConnection);
+	connect(this, &LedDeviceManager::ledDeviceUpdateDeviceSettings,				m_ledDevice, &AbstractLedDevice::updateDeviceSettings,						Qt::QueuedConnection);
 }
 
 void LedDeviceManager::disconnectSignalSlotsLedDevice()
@@ -572,31 +572,34 @@ void LedDeviceManager::disconnectSignalSlotsLedDevice()
 		qWarning() << Q_FUNC_INFO << "m_ledDevice == NULL";
 		return;
 	}
+	m_ledDevice->disconnect(this, nullptr, nullptr, nullptr);
+	disconnect(m_ledDevice, nullptr, nullptr, nullptr);
+/*	
+    disconnect(m_ledDevice, &AbstractLedDevice::commandCompleted,		this, &LedDeviceManager::ledDeviceCommandCompleted);
+	disconnect(m_ledDevice, &AbstractLedDevice::ioDeviceSuccess,		this, &LedDeviceManager::ledDeviceIoDeviceSuccess);
+	disconnect(m_ledDevice, &AbstractLedDevice::openDeviceSuccess,	this, &LedDeviceManager::ledDeviceOpenDeviceSuccess);
 
-	disconnect(m_ledDevice, SIGNAL(commandCompleted(bool)),		this, SLOT(ledDeviceCommandCompleted(bool)));
-	disconnect(m_ledDevice, SIGNAL(ioDeviceSuccess(bool)),		this, SLOT(ledDeviceIoDeviceSuccess(bool)));
-	disconnect(m_ledDevice, SIGNAL(openDeviceSuccess(bool)),	this, SLOT(ledDeviceOpenDeviceSuccess(bool)));
+	disconnect(m_ledDevice, &AbstractLedDevice::firmwareVersion,		this, &LedDeviceManager::firmwareVersion);
+	disconnect(m_ledDevice, &AbstractLedDevice::firmwareVersionUnofficial, this, &LedDeviceManager::firmwareVersionUnofficial);
+	disconnect(m_ledDevice, &AbstractLedDevice::colorsUpdated,		this, &LedDeviceManager::setColors_VirtualDeviceCallback);
 
-	disconnect(m_ledDevice, SIGNAL(firmwareVersion(QString)),		this, SIGNAL(firmwareVersion(QString)));
-	disconnect(m_ledDevice, SIGNAL(firmwareVersionUnofficial(int)), this, SIGNAL(firmwareVersionUnofficial(int)));
-	disconnect(m_ledDevice, SIGNAL(colorsUpdated(QList<QRgb>)),		this, SIGNAL(setColors_VirtualDeviceCallback(QList<QRgb>)));
-
-	disconnect(this, SIGNAL(ledDeviceOpen()),								m_ledDevice, SLOT(open()));
-	disconnect(this, SIGNAL(ledDeviceSetColors(QList<QRgb>)),				m_ledDevice, SLOT(setColors(QList<QRgb>)));
-	disconnect(this, SIGNAL(ledDeviceOffLeds()),							m_ledDevice, SLOT(switchOffLeds()));
-	disconnect(this, SIGNAL(ledDeviceSetUsbPowerLedDisabled(bool)),			m_ledDevice, SLOT(setUsbPowerLedDisabled(bool)));
-	disconnect(this, SIGNAL(ledDeviceSetRefreshDelay(int)),					m_ledDevice, SLOT(setRefreshDelay(int)));
-	disconnect(this, SIGNAL(ledDeviceSetColorDepth(int)),					m_ledDevice, SLOT(setColorDepth(int)));
-	disconnect(this, SIGNAL(ledDeviceSetSmoothSlowdown(int)),				m_ledDevice, SLOT(setSmoothSlowdown(int)));
-	disconnect(this, SIGNAL(ledDeviceSetGamma(double,bool)),				m_ledDevice, SLOT(setGamma(double,bool)));
-	disconnect(this, SIGNAL(ledDeviceSetBrightness(int,bool)),				m_ledDevice, SLOT(setBrightness(int,bool)));
-	disconnect(this, SIGNAL(ledDeviceSetBrightnessCap(int,bool)),			m_ledDevice, SLOT(setBrightnessCap(int,bool)));
-	disconnect(this, SIGNAL(ledDeviceSetColorSequence(QString)),			m_ledDevice, SLOT(setColorSequence(QString)));
-	disconnect(this, SIGNAL(ledDeviceSetLuminosityThreshold(int,bool)),	m_ledDevice, SLOT(setLuminosityThreshold(int,bool)));
-	disconnect(this, SIGNAL(ledDeviceSetMinimumLuminosityEnabled(bool,bool)),	m_ledDevice, SLOT(setMinimumLuminosityThresholdEnabled(bool,bool)));
-	disconnect(this, SIGNAL(ledDeviceRequestFirmwareVersion()),				m_ledDevice, SLOT(requestFirmwareVersion()));
-	disconnect(this, SIGNAL(ledDeviceUpdateWBAdjustments()),				m_ledDevice, SLOT(updateWBAdjustments()));
-	disconnect(this, SIGNAL(ledDeviceUpdateDeviceSettings()),				m_ledDevice, SLOT(updateDeviceSettings()));
+	disconnect(this, &LedDeviceManager::ledDeviceOpen,								m_ledDevice, &AbstractLedDevice::open);
+	disconnect(this, &LedDeviceManager::ledDeviceSetColors,				m_ledDevice, &AbstractLedDevice::setColors);
+	disconnect(this, &LedDeviceManager::ledDeviceOffLeds,							m_ledDevice, &AbstractLedDevice::switchOffLeds);
+	disconnect(this, &LedDeviceManager::ledDeviceSetUsbPowerLedDisabled,			m_ledDevice, &AbstractLedDevice::setUsbPowerLedDisabled);
+	disconnect(this, &LedDeviceManager::ledDeviceSetRefreshDelay,					m_ledDevice, &AbstractLedDevice::setRefreshDelay);
+	disconnect(this, &LedDeviceManager::ledDeviceSetColorDepth,					m_ledDevice, &AbstractLedDevice::setColorDepth);
+	disconnect(this, &LedDeviceManager::ledDeviceSetSmoothSlowdown,				m_ledDevice, &AbstractLedDevice::setSmoothSlowdown);
+	disconnect(this, &LedDeviceManager::ledDeviceSetGamma,				m_ledDevice, &AbstractLedDevice::setGamma);
+	disconnect(this, &LedDeviceManager::ledDeviceSetBrightness,				m_ledDevice, &AbstractLedDevice::setBrightness);
+	disconnect(this, &LedDeviceManager::ledDeviceSetBrightnessCap,			m_ledDevice, &AbstractLedDevice::setBrightnessCap);
+	disconnect(this, &LedDeviceManager::ledDeviceSetColorSequence,			m_ledDevice, &AbstractLedDevice::setColorSequence);
+	disconnect(this, &LedDeviceManager::ledDeviceSetLuminosityThreshold,	m_ledDevice, &AbstractLedDevice::setLuminosityThreshold);
+	disconnect(this, &LedDeviceManager::ledDeviceSetMinimumLuminosityEnabled,	m_ledDevice, &AbstractLedDevice::setMinimumLuminosityThresholdEnabled);
+	disconnect(this, &LedDeviceManager::ledDeviceRequestFirmwareVersion,				m_ledDevice, &AbstractLedDevice::requestFirmwareVersion);
+	disconnect(this, &LedDeviceManager::ledDeviceUpdateWBAdjustments,				m_ledDevice, qOverload<>(&AbstractLedDevice::updateWBAdjustments));
+	disconnect(this, &LedDeviceManager::ledDeviceUpdateDeviceSettings,				m_ledDevice, &AbstractLedDevice::updateDeviceSettings);
+*/
 }
 
 void LedDeviceManager::cmdQueueAppend(LedDeviceCommands::Cmd cmd)

--- a/Software/src/LedDeviceManager.hpp
+++ b/Software/src/LedDeviceManager.hpp
@@ -88,7 +88,7 @@ public slots:
 	void setLuminosityThreshold(int value);
 	void setMinimumLuminosityEnabled(bool value);
 	void setDitheringEnabled(bool isEnabled);
-	void setColorSequence(QString value);
+	void setColorSequence(const QString& value);
 	void requestFirmwareVersion();
 	void updateWBAdjustments();
 	void updateDeviceSettings();
@@ -99,7 +99,7 @@ private slots:
 	void ledDeviceOpenDeviceSuccess(bool isSuccess);
 	void ledDeviceIoDeviceSuccess(bool isSuccess);
 
-private:	
+private:
 	void initLedDevice();
 	AbstractLedDevice * createLedDevice(SupportedDevices::DeviceType deviceType);
 	void connectSignalSlotsLedDevice();

--- a/Software/src/LedDeviceManager.hpp
+++ b/Software/src/LedDeviceManager.hpp
@@ -63,7 +63,7 @@ signals:
 	void ledDeviceSetBrightnessCap(int value, bool);
 	void ledDeviceSetLuminosityThreshold(int value, bool);
 	void ledDeviceSetMinimumLuminosityEnabled(bool, bool);
-	void ledDeviceSetDitheringEnabled(bool isEnabled);
+	void ledDeviceSetDitheringEnabled(bool isEnabled, bool);
 	void ledDeviceSetColorSequence(QString value);
 	void ledDeviceRequestFirmwareVersion();
 	void ledDeviceUpdateWBAdjustments();

--- a/Software/src/LedDeviceVirtual.cpp
+++ b/Software/src/LedDeviceVirtual.cpp
@@ -90,30 +90,32 @@ void LedDeviceVirtual::setSmoothSlowdown(int /*value*/)
 	emit commandCompleted(true);
 }
 
-void LedDeviceVirtual::setColorSequence(QString /*value*/)
+void LedDeviceVirtual::setColorSequence(const QString& /*value*/)
 {
 	emit commandCompleted(true);
 }
 
-void LedDeviceVirtual::setGamma(double value)
+void LedDeviceVirtual::setGamma(double value, const bool update = true)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value;
 
 	m_gamma = value;
-	setColors(m_colorsSaved);
+	if (update)
+		setColors(m_colorsSaved);
 }
 
-void LedDeviceVirtual::setBrightness(int percent)
+void LedDeviceVirtual::setBrightness(int percent, const bool update = true)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << percent;
 
 	m_brightness = percent;
-	setColors(m_colorsSaved);
+	if (update)
+		setColors(m_colorsSaved);
 }
 
 void LedDeviceVirtual::requestFirmwareVersion()
 {
-	emit firmwareVersion("1.0 (virtual device)");
+	emit firmwareVersion(QStringLiteral("1.0 (virtual device)"));
 	emit commandCompleted(true);
 }
 

--- a/Software/src/LedDeviceVirtual.cpp
+++ b/Software/src/LedDeviceVirtual.cpp
@@ -52,7 +52,7 @@ void LedDeviceVirtual::setColors(const QList<QRgb> & colors)
 		applyColorModifications(colors, m_colorsBuffer);
 		applyDithering(m_colorsBuffer, 8);
 
-		for (const StructRgb color : m_colorsBuffer)
+		for (const StructRgb& color : m_colorsBuffer)
 			callbackColors.append(qRgb(color.r, color.g, color.b));
 
 		emit colorsUpdated(callbackColors);

--- a/Software/src/LedDeviceVirtual.hpp
+++ b/Software/src/LedDeviceVirtual.hpp
@@ -35,9 +35,9 @@ class LedDeviceVirtual : public AbstractLedDevice
 public:
 	LedDeviceVirtual(QObject * parent = 0);
 	virtual ~LedDeviceVirtual() {}
+	QString name() const { return QStringLiteral("virtual"); }
 
 public slots:
-	const QString name() const { return "virtual"; }
 	void open();
 	void close(){}
 	void setColors(const QList<QRgb> & colors);
@@ -45,9 +45,9 @@ public slots:
 	void setRefreshDelay(int /*value*/);
 	void setColorDepth(int /*value*/);
 	void setSmoothSlowdown(int /*value*/);
-	void setColorSequence(QString /*value*/);
-	void setGamma(double value);
-	void setBrightness(int value);
+	void setColorSequence(const QString& /*value*/);
+	void setGamma(double value, bool update);
+	void setBrightness(int value, bool update);
 	void requestFirmwareVersion();
 	int maxLedsCount() { return 511; }
 	int defaultLedsCount() { return 10; }

--- a/Software/src/LedDeviceVirtual.hpp
+++ b/Software/src/LedDeviceVirtual.hpp
@@ -27,7 +27,6 @@
 #pragma once
 
 #include "AbstractLedDevice.hpp"
-#include "colorspace_types.h"
 
 class LedDeviceVirtual : public AbstractLedDevice
 {
@@ -36,6 +35,8 @@ public:
 	LedDeviceVirtual(QObject * parent = 0);
 	virtual ~LedDeviceVirtual() {}
 	QString name() const { return QStringLiteral("virtual"); }
+	int maxLedsCount();
+	int defaultLedsCount() { return 10; }
 
 public slots:
 	void open();
@@ -46,14 +47,8 @@ public slots:
 	void setColorDepth(int /*value*/);
 	void setSmoothSlowdown(int /*value*/);
 	void setColorSequence(const QString& /*value*/);
-	void setGamma(double value, bool update);
-	void setBrightness(int value, bool update);
 	void requestFirmwareVersion();
-	int maxLedsCount() { return 511; }
-	int defaultLedsCount() { return 10; }
-
 
 private:
 	void resizeColorsBuffer(int buffSize);
-
 };

--- a/Software/src/LedDeviceWarls.cpp
+++ b/Software/src/LedDeviceWarls.cpp
@@ -48,24 +48,29 @@ void LedDeviceWarls::setColors(const QList<QRgb> & colors)
 	applyColorModifications(colors, m_colorsBuffer);
 	applyDithering(m_colorsBuffer, 8);
 
-	const int totalColorsSaved = m_colorsSaved.count();
+	const int totalColorsSaved = m_processedColorsSaved.count();
 	m_writeBuffer.clear();
 	m_writeBuffer.append(m_writeBufferHeader);
+	QList<QRgb> newColors;
+	newColors.reserve(colors.count());
 
 	for (int i = 0; i < m_colorsBuffer.count(); i++)
 	{
-		if (i >= totalColorsSaved || colors[i] != m_colorsSaved[i])
+		const StructRgb color = m_colorsBuffer[i];
+		const QRgb newColor = qRgb(color.r, color.g, color.b);
+		if (i >= totalColorsSaved || newColor != m_processedColorsSaved[i])
 		{
-			const StructRgb color = m_colorsBuffer[i];
 
 			m_writeBuffer.append(i);
 			m_writeBuffer.append(color.r);
 			m_writeBuffer.append(color.g);
 			m_writeBuffer.append(color.b);
 		}
+		newColors << newColor;
 	}
 
 	m_colorsSaved = colors;
+	m_processedColorsSaved = newColors;
 
 	// This may send the header only
 	const bool ok = writeBuffer(m_writeBuffer);

--- a/Software/src/LedDeviceWarls.cpp
+++ b/Software/src/LedDeviceWarls.cpp
@@ -31,9 +31,9 @@ LedDeviceWarls::LedDeviceWarls(const QString& address, const QString& port, cons
 {
 }
 
-const QString LedDeviceWarls::name() const
-{ 
-	return "warls"; 
+QString LedDeviceWarls::name() const
+{
+	return QStringLiteral("warls");
 }
 
 int LedDeviceWarls::maxLedsCount()
@@ -96,7 +96,7 @@ void LedDeviceWarls::switchOffLeds()
 
 void LedDeviceWarls::requestFirmwareVersion()
 {
-	emit firmwareVersion("1.0 (warls device)");
+	emit firmwareVersion(QStringLiteral("1.0 (warls device)"));
 	emit commandCompleted(true);
 }
 

--- a/Software/src/LedDeviceWarls.cpp
+++ b/Software/src/LedDeviceWarls.cpp
@@ -27,7 +27,7 @@
 #include "LedDeviceWarls.hpp"
 #include "enums.hpp"
 
-LedDeviceWarls::LedDeviceWarls(const QString& address, const QString& port, const int timeout, QObject * parent) : AbstractLedDeviceUdp(address, port, timeout, parent)
+LedDeviceWarls::LedDeviceWarls(const QString& address, const QString& port, const uint8_t timeout, QObject * parent) : AbstractLedDeviceUdp(address, port, timeout, parent)
 {
 }
 
@@ -48,14 +48,15 @@ void LedDeviceWarls::setColors(const QList<QRgb> & colors)
 	applyColorModifications(colors, m_colorsBuffer);
 	applyDithering(m_colorsBuffer, 8);
 
+	const int totalColorsSaved = m_colorsSaved.count();
 	m_writeBuffer.clear();
 	m_writeBuffer.append(m_writeBufferHeader);
 
 	for (int i = 0; i < m_colorsBuffer.count(); i++)
 	{
-		if (colors[i] != m_colorsSaved[i])
+		if (i >= totalColorsSaved || colors[i] != m_colorsSaved[i])
 		{
-			StructRgb color = m_colorsBuffer[i];
+			const StructRgb color = m_colorsBuffer[i];
 
 			m_writeBuffer.append(i);
 			m_writeBuffer.append(color.r);
@@ -67,61 +68,8 @@ void LedDeviceWarls::setColors(const QList<QRgb> & colors)
 	m_colorsSaved = colors;
 
 	// This may send the header only
-	bool ok = writeBuffer(m_writeBuffer);
+	const bool ok = writeBuffer(m_writeBuffer);
 	emit commandCompleted(ok);
-}
-
-void LedDeviceWarls::switchOffLeds()
-{
-	int count = m_colorsSaved.count();
-	m_colorsSaved.clear();
-
-	for (int i = 0; i < count; i++) {
-		m_colorsSaved << 0;
-	}
-
-	m_writeBuffer.clear();
-	m_writeBuffer.append(m_writeBufferHeader);
-
-	for (int i = 0; i < count; i++) {
-		m_writeBuffer.append((char)i)
-			.append((char)0)
-			.append((char)0)
-			.append((char)0);
-	}
-
-	bool ok = writeBuffer(m_writeBuffer);
-	emit commandCompleted(ok);
-}
-
-void LedDeviceWarls::requestFirmwareVersion()
-{
-	emit firmwareVersion(QStringLiteral("1.0 (warls device)"));
-	emit commandCompleted(true);
-}
-
-void LedDeviceWarls::resizeColorsBuffer(int buffSize)
-{
-	if (m_colorsBuffer.count() == buffSize)
-		return;
-
-	m_colorsBuffer.clear();
-	m_colorsSaved.clear();
-
-	if (buffSize > MaximumNumberOfLeds::Warls)
-	{
-		qCritical() << Q_FUNC_INFO << "buffSize > MaximumNumberOfLeds::Warls" << buffSize << ">" << MaximumNumberOfLeds::Warls;
-
-		buffSize = MaximumNumberOfLeds::Warls;
-	}
-
-	for (int i = 0; i < buffSize; i++)
-	{
-		m_colorsBuffer << StructRgb();
-		m_colorsSaved << 0;
-	}
-
-	reinitBufferHeader();
 }
 
 void LedDeviceWarls::reinitBufferHeader()

--- a/Software/src/LedDeviceWarls.hpp
+++ b/Software/src/LedDeviceWarls.hpp
@@ -41,4 +41,6 @@ public slots:
 
 protected:
 	virtual void reinitBufferHeader();
+
+	QList<QRgb> m_processedColorsSaved;
 };

--- a/Software/src/LedDeviceWarls.hpp
+++ b/Software/src/LedDeviceWarls.hpp
@@ -32,16 +32,13 @@ class LedDeviceWarls : public AbstractLedDeviceUdp
 {
 	Q_OBJECT
 public:
-	LedDeviceWarls(const QString& address, const QString& port, const int timeout, QObject * parent = 0);
+	LedDeviceWarls(const QString& address, const QString& port, const uint8_t timeout, QObject * parent = 0);
 	QString name() const;
+	int maxLedsCount();
 
 public slots:
 	void setColors(const QList<QRgb> & colors);
-	void switchOffLeds();
-	void requestFirmwareVersion();
-	int maxLedsCount();
 
 protected:
-	void resizeColorsBuffer(int buffSize);
-	void reinitBufferHeader();
+	virtual void reinitBufferHeader();
 };

--- a/Software/src/LedDeviceWarls.hpp
+++ b/Software/src/LedDeviceWarls.hpp
@@ -32,16 +32,16 @@ class LedDeviceWarls : public AbstractLedDeviceUdp
 {
 	Q_OBJECT
 public:
-    LedDeviceWarls(const QString& address, const QString& port, const int timeout, QObject * parent = 0);
+	LedDeviceWarls(const QString& address, const QString& port, const int timeout, QObject * parent = 0);
+	QString name() const;
 
 public slots:
-    const QString name() const;
 	void setColors(const QList<QRgb> & colors);
 	void switchOffLeds();
-    void requestFirmwareVersion();
-    int maxLedsCount();
+	void requestFirmwareVersion();
+	int maxLedsCount();
 
 protected:
-    void resizeColorsBuffer(int buffSize);
-    void reinitBufferHeader();
+	void resizeColorsBuffer(int buffSize);
+	void reinitBufferHeader();
 };

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -807,7 +807,6 @@ void LightpackApplication::commitData(QSessionManager &sessionManager)
 	{
 		// Disable signals with new colors
 		disconnect(m_settingsWindow, SIGNAL(updateLedsColors(QList<QRgb>)), m_ledDeviceManager, SLOT(setColors(QList<QRgb>)));
-		disconnect(m_apiServer, SIGNAL(updateLedsColors(QList<QRgb>)), m_ledDeviceManager, SLOT(setColors(QList<QRgb>)));
 
 		// Process all currently pending signals
 		QApplication::processEvents(QEventLoop::AllEvents, 1000);

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -102,9 +102,9 @@ LightpackApplication::~LightpackApplication()
 
 void LightpackApplication::initializeAll(const QString & appDirPath)
 {
-	setApplicationName("Prismatik");
-	setOrganizationName("Woodenshark LLC");
-	setApplicationVersion(VERSION_STR);
+	setApplicationName(QStringLiteral("Prismatik"));
+	setOrganizationName(QStringLiteral("Woodenshark LLC"));
+	setApplicationVersion(QStringLiteral(VERSION_STR));
 	setQuitOnLastWindowClosed(false);
 
 	m_applicationDirPath = appDirPath;
@@ -238,7 +238,7 @@ void LightpackApplication::setBacklightChanged(Lightpack::Mode mode)
 	startBacklight();
 }
 
-void LightpackApplication::setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus status, QList<QString> modules)
+void LightpackApplication::setDeviceLockViaAPI(const DeviceLocked::DeviceLockStatus status, const QList<QString>& modules)
 {
 	Q_UNUSED(modules);
 	m_deviceLockStatus = status;
@@ -347,7 +347,7 @@ void LightpackApplication::onSessionChange(int change)
 				// Process all currently pending signals (which may include updating the color signals)
 				QApplication::processEvents(QEventLoop::AllEvents, 500);
 
-				getLightpackApp()->settingsWnd()->switchOffLeds();
+				emit getLightpackApp()->settingsWnd()->switchOffLeds();
 				QApplication::processEvents(QEventLoop::AllEvents, 500);
 			}
 			break;
@@ -357,7 +357,7 @@ void LightpackApplication::onSessionChange(int change)
 
 			if (!SettingsScope::Settings::isKeepLightsOnAfterLock())
 			{
-				getLightpackApp()->settingsWnd()->switchOffLeds();
+				emit getLightpackApp()->settingsWnd()->switchOffLeds();
 				m_isLightsTurnedOffBySessionChange = true;
 			}
 			m_isSessionLocked = true;
@@ -365,7 +365,7 @@ void LightpackApplication::onSessionChange(int change)
 		case SystemSession::Status::Unlocking:
 			if (m_isSessionLocked && !SettingsScope::Settings::isKeepLightsOnAfterLock() && m_isLightsWereOnBeforeLock)
 			{
-				getLightpackApp()->settingsWnd()->switchOnLeds();
+				emit getLightpackApp()->settingsWnd()->switchOnLeds();
 				m_isLightsTurnedOffBySessionChange = false;
 			}
 			m_isSessionLocked = false;
@@ -376,7 +376,7 @@ void LightpackApplication::onSessionChange(int change)
 
 			if (!SettingsScope::Settings::isKeepLightsOnAfterSuspend())
 			{
-				getLightpackApp()->settingsWnd()->switchOffLeds();
+				emit getLightpackApp()->settingsWnd()->switchOffLeds();
 				m_isLightsTurnedOffBySessionChange = true;
 			}
 			m_isSuspending = true;
@@ -384,7 +384,7 @@ void LightpackApplication::onSessionChange(int change)
 		case SystemSession::Status::Resuming:
 			if (m_isSuspending && !SettingsScope::Settings::isKeepLightsOnAfterSuspend() && m_isLightsWereOnBeforeSuspend)
 			{
-				getLightpackApp()->settingsWnd()->switchOnLeds();
+				emit getLightpackApp()->settingsWnd()->switchOnLeds();
 				m_isLightsTurnedOffBySessionChange = false;
 			}
 			m_isSuspending = false;
@@ -396,7 +396,7 @@ void LightpackApplication::onSessionChange(int change)
 
 			if (!SettingsScope::Settings::isKeepLightsOnAfterScreenOff())
 			{
-				getLightpackApp()->settingsWnd()->switchOffLeds();
+				emit getLightpackApp()->settingsWnd()->switchOffLeds();
 				m_isLightsTurnedOffBySessionChange = true;
 			}
 			m_isDisplayOff = true;
@@ -404,7 +404,7 @@ void LightpackApplication::onSessionChange(int change)
 		case SystemSession::Status::DisplayOn:
 			if (m_isDisplayOff && !SettingsScope::Settings::isKeepLightsOnAfterScreenOff() && m_isLightsWereOnBeforeDisplaySleep)
 			{
-				getLightpackApp()->settingsWnd()->switchOnLeds();
+				emit getLightpackApp()->settingsWnd()->switchOnLeds();
 				m_isLightsTurnedOffBySessionChange = false;
 			}
 			m_isDisplayOff = false;
@@ -431,11 +431,11 @@ void LightpackApplication::processCommandLineArguments()
 	if (parser.isSetVersion())
 	{
 		const QString versionString =
-			"Version: " VERSION_STR "\n"
+			QStringLiteral("Version: " VERSION_STR "\n"
 #ifdef GIT_REVISION
 			"Revision: " GIT_REVISION "\n"
 #endif
-			"Build with Qt version " QT_VERSION_STR "\n";
+			"Build with Qt version " QT_VERSION_STR "\n");
 		outputMessage(versionString);
 		::exit(0);
 	}
@@ -447,7 +447,7 @@ void LightpackApplication::processCommandLineArguments()
 	} else if (parser.isSetWizard()) {
 		if (isRunning()) {
 			DEBUG_LOW_LEVEL << "Application still running, telling it to quit";
-			sendMessage("quitForWizard");
+			sendMessage(QStringLiteral("quitForWizard"));
 			while (isRunning()) {
 				QThread::sleep(200);
 			}
@@ -462,20 +462,20 @@ void LightpackApplication::processCommandLineArguments()
 			LedDeviceLightpack lightpackDevice;
 			lightpackDevice.switchOffLeds();
 		} else {
-			sendMessage("off");
+			sendMessage(QStringLiteral("off"));
 		}
 		::exit(0);
 	}
 	else if (parser.isSetBacklightOn())
 	{
 		if (isRunning())
-			sendMessage("on");
+			sendMessage(QStringLiteral("on"));
 		::exit(0);
 	}
 
 	if (parser.isSetProfile()) {
 		if (isRunning())
-			sendMessage("set-profile " + parser.profileName());
+			sendMessage(QStringLiteral("set-profile ") + parser.profileName());
 		::exit(0);
 	}
 
@@ -489,10 +489,10 @@ void LightpackApplication::processCommandLineArguments()
 		qDebug() << "Debug level" << g_debugLevel;
 }
 
-void LightpackApplication::outputMessage(QString message) const
+void LightpackApplication::outputMessage(const QString& message) const
 {
 #ifdef Q_OS_WIN
-	QMessageBox::information(NULL, "Prismatik", message, QMessageBox::Ok);
+	QMessageBox::information(NULL, QStringLiteral("Prismatik"), message, QMessageBox::Ok);
 #else
 	fprintf(stderr, "%s\n", message.toStdString().c_str());
 #endif
@@ -558,7 +558,7 @@ bool LightpackApplication::checkSystemTrayAvailability() const
 
 	if (QSystemTrayIcon::isSystemTrayAvailable() == false)
 	{
-		QMessageBox::critical(0, "Prismatik", "I couldn't detect any system tray on this system.");
+		QMessageBox::critical(0, QStringLiteral("Prismatik"), QStringLiteral("I couldn't detect any system tray on this system."));
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Systray couldn't be detected, running in trayless mode";
 		return false;
 	}
@@ -690,7 +690,7 @@ void LightpackApplication::startPluginManager()
 		connect(m_pluginManager,SIGNAL(updatePlugin(QList<Plugin*>)),m_pluginInterface,SLOT(updatePlugin(QList<Plugin*>)), Qt::QueuedConnection);
 	}
 
-	m_pluginManager->LoadPlugins(QString(Settings::getApplicationDirPath() + "Plugins"));
+	m_pluginManager->LoadPlugins(QString(Settings::getApplicationDirPath() + QStringLiteral("Plugins")));
 	m_pluginManager->StartPlugins();
 
 }

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -137,11 +137,11 @@ void LightpackApplication::initializeAll(const QString & appDirPath)
 		else
 			m_settingsWindow->setVisible(true);
 		m_settingsWindow->connectSignalsSlots();
-		connect(this, SIGNAL(postInitialization()), m_settingsWindow, SLOT(onPostInit()));
+		connect(this, &LightpackApplication::postInitialization, m_settingsWindow, &SettingsWindow::onPostInit);
 //		m_settingsWindow->profileSwitch(Settings::getCurrentProfileName());
 		// Process messages from another instances in SettingsWindow
-		connect(this, SIGNAL(messageReceived(QString)), m_settingsWindow, SLOT(processMessage(QString)));
-		connect(this, SIGNAL(focusChanged(QWidget*,QWidget*)), this, SLOT(onFocusChanged(QWidget*,QWidget*)));
+		connect(this, &LightpackApplication::messageReceived, m_settingsWindow, &SettingsWindow::processMessage);
+		connect(this, &LightpackApplication::focusChanged, this, &LightpackApplication::onFocusChanged);
 	}
 	// Register QMetaType for Qt::QueuedConnection
 	qRegisterMetaType< QList<QRgb> >("QList<QRgb>");
@@ -168,7 +168,7 @@ void LightpackApplication::initializeAll(const QString & appDirPath)
 
 	if (!m_noGui && m_settingsWindow)
 	{
-		connect(m_settingsWindow, SIGNAL(backlightStatusChanged(Backlight::Status)), this, SLOT(setStatusChanged(Backlight::Status)));
+		connect(m_settingsWindow, &SettingsWindow::backlightStatusChanged, this, &LightpackApplication::setStatusChanged);
 		m_settingsWindow->startBacklight();
 	}
 
@@ -182,11 +182,11 @@ void LightpackApplication::initializeAll(const QString & appDirPath)
     if (eventFilter)
     {
         QSharedPointer<SystemSession::EventFilter> sessionChangeDetector(eventFilter);
-        connect(sessionChangeDetector.data(), SIGNAL(sessionChangeDetected(int)), this, SLOT(onSessionChange(int)));
-        connect(sessionChangeDetector.data(), SIGNAL(sessionChangeDetected(int)), m_grabManager, SIGNAL(onSessionChange(int)));
+        connect(sessionChangeDetector.data(), &SystemSession::EventFilter::sessionChangeDetected, this, &LightpackApplication::onSessionChange);
+        connect(sessionChangeDetector.data(), &SystemSession::EventFilter::sessionChangeDetected, m_grabManager, &GrabManager::onSessionChange);
         m_EventFilters.push_back(sessionChangeDetector);
     }
-	for (EventFilters::const_iterator it = m_EventFilters.begin(); it != m_EventFilters.end(); ++it)
+	for (EventFilters::const_iterator it = m_EventFilters.cbegin(); it != m_EventFilters.cend(); ++it)
 		this->installNativeEventFilter(it->data());
 
 	emit postInitialization();
@@ -195,7 +195,7 @@ void LightpackApplication::initializeAll(const QString & appDirPath)
 void LightpackApplication::runWizardLoop(bool isInitFromSettings)
 {
 	Wizard *w = new Wizard(isInitFromSettings);
-	connect(w, SIGNAL(finished(int)), this, SLOT(quitFromWizard(int)));
+	connect(w, &Wizard::finished, this, &LightpackApplication::quitFromWizard);
 	w->setWindowFlags(Qt::WindowStaysOnTopHint);
 	w->show();
 	this->exec();
@@ -573,30 +573,30 @@ void LightpackApplication::startApiServer()
 	m_apiServer->setInterface(m_pluginInterface);
 	m_apiServerThread = new QThread();
 
-	connect(this, SIGNAL(clearColorBuffers()), m_apiServer, SIGNAL(clearColorBuffers()));
+	connect(this, &LightpackApplication::clearColorBuffers, m_apiServer, &ApiServer::clearColorBuffers);
 
-	connect(settings(), SIGNAL(apiServerSettingsChanged()),		m_apiServer, SLOT(apiServerSettingsChanged()));
-	connect(settings(), SIGNAL(apiKeyChanged(QString)), m_apiServer, SLOT(updateApiKey(QString)));
+	connect(settings(), &Settings::apiServerSettingsChanged,		m_apiServer, &ApiServer::apiServerSettingsChanged);
+	connect(settings(), &Settings::apiKeyChanged, m_apiServer, &ApiServer::updateApiKey);
 
-	connect(settings(), SIGNAL(lightpackNumberOfLedsChanged(int)),	m_apiServer, SIGNAL(updateApiDeviceNumberOfLeds(int)));
-	connect(settings(), SIGNAL(adalightNumberOfLedsChanged(int)),	m_apiServer, SIGNAL(updateApiDeviceNumberOfLeds(int)));
-	connect(settings(), SIGNAL(ardulightNumberOfLedsChanged(int)),	m_apiServer, SIGNAL(updateApiDeviceNumberOfLeds(int)));
-	connect(settings(), SIGNAL(virtualNumberOfLedsChanged(int)),	m_apiServer, SIGNAL(updateApiDeviceNumberOfLeds(int)));
+	connect(settings(), &Settings::lightpackNumberOfLedsChanged,	m_apiServer, &ApiServer::updateApiDeviceNumberOfLeds);
+	connect(settings(), &Settings::adalightNumberOfLedsChanged,	m_apiServer, &ApiServer::updateApiDeviceNumberOfLeds);
+	connect(settings(), &Settings::ardulightNumberOfLedsChanged,	m_apiServer, &ApiServer::updateApiDeviceNumberOfLeds);
+	connect(settings(), &Settings::virtualNumberOfLedsChanged,	m_apiServer, &ApiServer::updateApiDeviceNumberOfLeds);
 
 	if (!m_noGui)
 	{
-		connect(m_apiServer, SIGNAL(errorOnStartListening(QString)), m_settingsWindow, SLOT(onApiServer_ErrorOnStartListening(QString)));
+		connect(m_apiServer, &ApiServer::errorOnStartListening, m_settingsWindow, &SettingsWindow::onApiServer_ErrorOnStartListening);
 	}
 
-	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetColors(QList<QRgb>)),	m_pluginInterface, SLOT(updateColorsCache(QList<QRgb>)),	Qt::QueuedConnection);
-	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetSmoothSlowdown(int)),			m_pluginInterface, SLOT(updateSmoothCache(int)),					Qt::QueuedConnection);
-	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetGamma(double,bool)),			m_pluginInterface, SLOT(updateGammaCache(double)),					Qt::QueuedConnection);
-	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetBrightness(int,bool)),			m_pluginInterface, SLOT(updateBrightnessCache(int)),				Qt::QueuedConnection);
+	connect(m_ledDeviceManager, &LedDeviceManager::ledDeviceSetColors,	m_pluginInterface, &LightpackPluginInterface::updateColorsCache,	Qt::QueuedConnection);
+	connect(m_ledDeviceManager, &LedDeviceManager::ledDeviceSetSmoothSlowdown,			m_pluginInterface, &LightpackPluginInterface::updateSmoothCache,					Qt::QueuedConnection);
+	connect(m_ledDeviceManager, &LedDeviceManager::ledDeviceSetGamma,			m_pluginInterface, &LightpackPluginInterface::updateGammaCache,					Qt::QueuedConnection);
+	connect(m_ledDeviceManager, &LedDeviceManager::ledDeviceSetBrightness,			m_pluginInterface, &LightpackPluginInterface::updateBrightnessCache,				Qt::QueuedConnection);
 
 #ifdef SOUNDVIZ_SUPPORT
-	connect(settings(), SIGNAL(soundVisualizerMinColorChanged(QColor)), m_pluginInterface, SLOT(updateSoundVizMinColorCache(QColor)), Qt::QueuedConnection);
-	connect(settings(), SIGNAL(soundVisualizerMaxColorChanged(QColor)), m_pluginInterface, SLOT(updateSoundVizMaxColorCache(QColor)), Qt::QueuedConnection);
-	connect(settings(), SIGNAL(soundVisualizerLiquidModeChanged(bool)), m_pluginInterface, SLOT(updateSoundVizLiquidCache(bool)), Qt::QueuedConnection);
+	connect(settings(), &Settings::soundVisualizerMinColorChanged, m_pluginInterface, &LightpackPluginInterface::updateSoundVizMinColorCache, Qt::QueuedConnection);
+	connect(settings(), &Settings::soundVisualizerMaxColorChanged, m_pluginInterface, &LightpackPluginInterface::updateSoundVizMaxColorCache, Qt::QueuedConnection);
+	connect(settings(), &Settings::soundVisualizerLiquidModeChanged, m_pluginInterface, &LightpackPluginInterface::updateSoundVizLiquidCache, Qt::QueuedConnection);
 #endif
 
 	m_apiServer->firstStart();
@@ -611,61 +611,61 @@ void LightpackApplication::startLedDeviceManager()
 	m_ledDeviceManager = new LedDeviceManager();
 	m_ledDeviceManagerThread = new QThread();
 
-//	connect(settings(), SIGNAL(connectedDeviceChanged(const SupportedDevices::DeviceType)), this, SLOT(handleConnectedDeviceChange(const SupportedDevices::DeviceType)), Qt::DirectConnection);
-//	connect(settings(), SIGNAL(adalightSerialPortNameChanged(QString)),				m_ledDeviceManager, SLOT(recreateLedDevice()), Qt::DirectConnection);
-//	connect(settings(), SIGNAL(adalightSerialPortBaudRateChanged(QString)),			m_ledDeviceManager, SLOT(recreateLedDevice()), Qt::DirectConnection);
-//	connect(m_settingsWindow, SIGNAL(updateLedsColors(const QList<QRgb> &)),			m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+//	connect(settings(), &Settings::connectedDeviceChanged, this, &LightpackApplication::handleConnectedDeviceChange, Qt::DirectConnection);
+//	connect(settings(), &Settings::adalightSerialPortNameChanged,				m_ledDeviceManager, &LedDeviceManager::recreateLedDevice, Qt::DirectConnection);
+//	connect(settings(), &Settings::adalightSerialPortBaudRateChanged,			m_ledDeviceManager, &LedDeviceManager::recreateLedDevice, Qt::DirectConnection);
+//	connect(m_settingsWindow, &SettingsWindow::updateLedsColors,			m_ledDeviceManager, &LedDeviceManager::setColors, Qt::QueuedConnection);
 	m_pluginInterface = new LightpackPluginInterface(NULL);
 
-	connect(m_pluginInterface, SIGNAL(updateDeviceLockStatus(DeviceLocked::DeviceLockStatus,QList<QString>)), this, SLOT(setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus,QList<QString>)));
-	connect(m_pluginInterface, SIGNAL(updateLedsColors(QList<QRgb>)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
-	connect(m_pluginInterface, SIGNAL(updateGamma(double)),		m_ledDeviceManager, SLOT(setGamma(double)),		Qt::QueuedConnection);
-	connect(m_pluginInterface, SIGNAL(updateBrightness(int)),	m_ledDeviceManager, SLOT(setBrightness(int)),		Qt::QueuedConnection);
-	connect(m_pluginInterface, SIGNAL(updateSmooth(int)),		m_ledDeviceManager, SLOT(setSmoothSlowdown(int)), Qt::QueuedConnection);
-	connect(m_pluginInterface, SIGNAL(requestBacklightStatus()),			this,	SLOT(requestBacklightStatus()));
-	connect(m_pluginInterface, SIGNAL(updateBacklight(Lightpack::Mode)),	this,	SLOT(setBacklightChanged(Lightpack::Mode)));
-//	connect(m_pluginInterface, SIGNAL(changeDevice(QString)),		m_settingsWindow , SLOT(setDevice(QString)));
-//	connect(m_pluginInterface, SIGNAL(updateCountLeds(int)),		m_settingsWindow , SLOT(updateUiFromSettings()));
-//	connect(m_pluginInterface, SIGNAL(updateCountLeds(int)),		this , SLOT(numberOfLedsChanged(int)));
+	connect(m_pluginInterface, &LightpackPluginInterface::updateDeviceLockStatus, this, &LightpackApplication::setDeviceLockViaAPI);
+	connect(m_pluginInterface, &LightpackPluginInterface::updateLedsColors,	m_ledDeviceManager, &LedDeviceManager::setColors, Qt::QueuedConnection);
+	connect(m_pluginInterface, &LightpackPluginInterface::updateGamma,		m_ledDeviceManager, &LedDeviceManager::setGamma,		Qt::QueuedConnection);
+	connect(m_pluginInterface, &LightpackPluginInterface::updateBrightness,	m_ledDeviceManager, &LedDeviceManager::setBrightness,		Qt::QueuedConnection);
+	connect(m_pluginInterface, &LightpackPluginInterface::updateSmooth,		m_ledDeviceManager, &LedDeviceManager::setSmoothSlowdown, Qt::QueuedConnection);
+	connect(m_pluginInterface, &LightpackPluginInterface::requestBacklightStatus,			this, &LightpackApplication::requestBacklightStatus);
+	connect(m_pluginInterface, &LightpackPluginInterface::updateBacklight,	this, &LightpackApplication::setBacklightChanged);
+//	connect(m_pluginInterface, &LightpackPluginInterface::changeDevice,		m_settingsWindow , SLOT(setDevice(QString)));
+//	connect(m_pluginInterface, &LightpackPluginInterface::updateCountLeds,		m_settingsWindow , SLOT(updateUiFromSettings()));
+//	connect(m_pluginInterface, &LightpackPluginInterface::updateCountLeds,		this , SLOT(numberOfLedsChanged(int)));
 
 	if (!m_noGui)
 	{
-		connect(m_pluginInterface, SIGNAL(updateLedsColors(QList<QRgb>)),	m_settingsWindow, SLOT(updateVirtualLedsColors(QList<QRgb>)));
-		connect(m_pluginInterface, SIGNAL(updateDeviceLockStatus(DeviceLocked::DeviceLockStatus,QList<QString>)), m_settingsWindow, SLOT(setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus,QList<QString>)));
-		connect(m_pluginInterface, SIGNAL(updateProfile(QString)),						m_settingsWindow, SLOT(profileSwitch(QString)));
-		connect(m_pluginInterface, SIGNAL(updateStatus(Backlight::Status)),				m_settingsWindow, SLOT(setBacklightStatus(Backlight::Status)));
+		connect(m_pluginInterface, &LightpackPluginInterface::updateLedsColors,	m_settingsWindow, &SettingsWindow::updateVirtualLedsColors);
+		connect(m_pluginInterface, &LightpackPluginInterface::updateDeviceLockStatus, m_settingsWindow, &SettingsWindow::setDeviceLockViaAPI);
+		connect(m_pluginInterface, &LightpackPluginInterface::updateProfile,						m_settingsWindow, &SettingsWindow::profileSwitch);
+		connect(m_pluginInterface, &LightpackPluginInterface::updateStatus,				m_settingsWindow, &SettingsWindow::setBacklightStatus);
 	}
 	else
 	{
-		connect(m_pluginInterface, SIGNAL(updateProfile(QString)),						this, SLOT(profileSwitch(QString)));
-		connect(m_pluginInterface, SIGNAL(updateStatus(Backlight::Status)),				this, SLOT(setStatusChanged(Backlight::Status)));
+		connect(m_pluginInterface, &LightpackPluginInterface::updateProfile,						this, &LightpackApplication::profileSwitch);
+		connect(m_pluginInterface, &LightpackPluginInterface::updateStatus,				this, &LightpackApplication::setStatusChanged);
 	}
 
-	connect(settings(), SIGNAL(deviceColorDepthChanged(int)),			m_ledDeviceManager, SLOT(setColorDepth(int)),					Qt::QueuedConnection);
-	connect(settings(), SIGNAL(deviceSmoothChanged(int)),				m_ledDeviceManager, SLOT(setSmoothSlowdown(int)),				Qt::QueuedConnection);
-	connect(settings(), SIGNAL(deviceRefreshDelayChanged(int)),			m_ledDeviceManager, SLOT(setRefreshDelay(int)),					Qt::QueuedConnection);
-	connect(settings(), SIGNAL(deviceUsbPowerLedDisabledChanged(bool)), m_ledDeviceManager, SLOT(setUsbPowerLedDisabled(bool)),			Qt::QueuedConnection);
-	connect(settings(), SIGNAL(deviceGammaChanged(double)),				m_ledDeviceManager, SLOT(setGamma(double)),						Qt::QueuedConnection);
-	connect(settings(), SIGNAL(deviceDitheringEnabledChanged(bool)),	m_ledDeviceManager, SLOT(setDitheringEnabled(bool)),			Qt::QueuedConnection);
-	connect(settings(), SIGNAL(deviceBrightnessChanged(int)),			m_ledDeviceManager, SLOT(setBrightness(int)),					Qt::QueuedConnection);
-	connect(settings(), SIGNAL(deviceBrightnessCapChanged(int)),		m_ledDeviceManager, SLOT(setBrightnessCap(int)),				Qt::QueuedConnection);
-	connect(settings(), SIGNAL(luminosityThresholdChanged(int)),		m_ledDeviceManager, SLOT(setLuminosityThreshold(int)),			Qt::QueuedConnection);
-	connect(settings(), SIGNAL(minimumLuminosityEnabledChanged(bool)),	m_ledDeviceManager, SLOT(setMinimumLuminosityEnabled(bool)),	Qt::QueuedConnection);
-	connect(settings(), SIGNAL(ledCoefBlueChanged(int,double)),			m_ledDeviceManager, SLOT(updateWBAdjustments()),				Qt::QueuedConnection);
-	connect(settings(), SIGNAL(ledCoefRedChanged(int,double)),			m_ledDeviceManager, SLOT(updateWBAdjustments()),				Qt::QueuedConnection);
-	connect(settings(), SIGNAL(ledCoefGreenChanged(int,double)),		m_ledDeviceManager, SLOT(updateWBAdjustments()),				Qt::QueuedConnection);
+	connect(settings(), &Settings::deviceColorDepthChanged,			m_ledDeviceManager, &LedDeviceManager::setColorDepth,					Qt::QueuedConnection);
+	connect(settings(), &Settings::deviceSmoothChanged,				m_ledDeviceManager, &LedDeviceManager::setSmoothSlowdown,				Qt::QueuedConnection);
+	connect(settings(), &Settings::deviceRefreshDelayChanged,			m_ledDeviceManager, &LedDeviceManager::setRefreshDelay,					Qt::QueuedConnection);
+	connect(settings(), &Settings::deviceUsbPowerLedDisabledChanged, m_ledDeviceManager, &LedDeviceManager::setUsbPowerLedDisabled,			Qt::QueuedConnection);
+	connect(settings(), &Settings::deviceGammaChanged,				m_ledDeviceManager, &LedDeviceManager::setGamma,						Qt::QueuedConnection);
+	connect(settings(), &Settings::deviceDitheringEnabledChanged,	m_ledDeviceManager, &LedDeviceManager::setDitheringEnabled,			Qt::QueuedConnection);
+	connect(settings(), &Settings::deviceBrightnessChanged,			m_ledDeviceManager, &LedDeviceManager::setBrightness,					Qt::QueuedConnection);
+	connect(settings(), &Settings::deviceBrightnessCapChanged,		m_ledDeviceManager, &LedDeviceManager::setBrightnessCap,				Qt::QueuedConnection);
+	connect(settings(), &Settings::luminosityThresholdChanged,		m_ledDeviceManager, &LedDeviceManager::setLuminosityThreshold,			Qt::QueuedConnection);
+	connect(settings(), &Settings::minimumLuminosityEnabledChanged,	m_ledDeviceManager, &LedDeviceManager::setMinimumLuminosityEnabled,	Qt::QueuedConnection);
+	connect(settings(), &Settings::ledCoefBlueChanged,			m_ledDeviceManager, &LedDeviceManager::updateWBAdjustments,				Qt::QueuedConnection);
+	connect(settings(), &Settings::ledCoefRedChanged,			m_ledDeviceManager, &LedDeviceManager::updateWBAdjustments,				Qt::QueuedConnection);
+	connect(settings(), &Settings::ledCoefGreenChanged,		m_ledDeviceManager, &LedDeviceManager::updateWBAdjustments,				Qt::QueuedConnection);
 
 
 	if (!m_noGui)
 	{
-		connect(m_settingsWindow, SIGNAL(requestFirmwareVersion()),			m_ledDeviceManager, SLOT(requestFirmwareVersion()),							Qt::QueuedConnection);
-		connect(m_settingsWindow, SIGNAL(switchOffLeds()),					m_ledDeviceManager, SLOT(switchOffLeds()),									Qt::QueuedConnection);
-		connect(m_settingsWindow, SIGNAL(switchOnLeds()),					m_ledDeviceManager, SLOT(switchOnLeds()),									Qt::QueuedConnection);
-		connect(m_ledDeviceManager, SIGNAL(openDeviceSuccess(bool)),		m_settingsWindow,	SLOT(ledDeviceOpenSuccess(bool)),						Qt::QueuedConnection);
-		connect(m_ledDeviceManager, SIGNAL(ioDeviceSuccess(bool)),			m_settingsWindow,	SLOT(ledDeviceCallSuccess(bool)),						Qt::QueuedConnection);
-		connect(m_ledDeviceManager, SIGNAL(firmwareVersion(QString)),		m_settingsWindow,	SLOT(ledDeviceFirmwareVersionResult(QString)),			Qt::QueuedConnection);
-		connect(m_ledDeviceManager, SIGNAL(firmwareVersionUnofficial(int)), m_settingsWindow,	SLOT(ledDeviceFirmwareVersionUnofficialResult(int)),	Qt::QueuedConnection);
-		connect(m_ledDeviceManager, SIGNAL(setColors_VirtualDeviceCallback(QList<QRgb>)), m_settingsWindow, SLOT(updateVirtualLedsColors(QList<QRgb>)), Qt::QueuedConnection);
+		connect(m_settingsWindow, &SettingsWindow::requestFirmwareVersion,			m_ledDeviceManager, &LedDeviceManager::requestFirmwareVersion,							Qt::QueuedConnection);
+		connect(m_settingsWindow, &SettingsWindow::switchOffLeds,					m_ledDeviceManager, &LedDeviceManager::switchOffLeds,									Qt::QueuedConnection);
+		connect(m_settingsWindow, &SettingsWindow::switchOnLeds,					m_ledDeviceManager, &LedDeviceManager::switchOnLeds,									Qt::QueuedConnection);
+		connect(m_ledDeviceManager, &LedDeviceManager::openDeviceSuccess,		m_settingsWindow, &SettingsWindow::ledDeviceOpenSuccess,						Qt::QueuedConnection);
+		connect(m_ledDeviceManager, &LedDeviceManager::ioDeviceSuccess,			m_settingsWindow, &SettingsWindow::ledDeviceCallSuccess,						Qt::QueuedConnection);
+		connect(m_ledDeviceManager, &LedDeviceManager::firmwareVersion,		m_settingsWindow, &SettingsWindow::ledDeviceFirmwareVersionResult,			Qt::QueuedConnection);
+		connect(m_ledDeviceManager, &LedDeviceManager::firmwareVersionUnofficial, m_settingsWindow, &SettingsWindow::ledDeviceFirmwareVersionUnofficialResult,	Qt::QueuedConnection);
+		connect(m_ledDeviceManager, &LedDeviceManager::setColors_VirtualDeviceCallback, m_settingsWindow, &SettingsWindow::updateVirtualLedsColors, Qt::QueuedConnection);
 	}
 	m_ledDeviceManager->moveToThread(m_ledDeviceManagerThread);
 	m_ledDeviceManagerThread->start();
@@ -681,13 +681,13 @@ void LightpackApplication::startPluginManager()
 
 	m_pluginManager = new PluginsManager(NULL);
 
-	connect(this, SIGNAL(destroyed()),m_pluginManager, SLOT(StopPlugins()));
+	connect(this, &LightpackApplication::destroyed,m_pluginManager, &PluginsManager::StopPlugins);
 
 	if (!m_noGui)
 	{
-		connect(m_settingsWindow,SIGNAL(reloadPlugins()),m_pluginManager,SLOT(reloadPlugins()));
-		connect(m_pluginManager,SIGNAL(updatePlugin(QList<Plugin*>)),m_settingsWindow,SLOT(updatePlugin(QList<Plugin*>)), Qt::QueuedConnection);
-		connect(m_pluginManager,SIGNAL(updatePlugin(QList<Plugin*>)),m_pluginInterface,SLOT(updatePlugin(QList<Plugin*>)), Qt::QueuedConnection);
+		connect(m_settingsWindow, &SettingsWindow::reloadPlugins,m_pluginManager, &PluginsManager::reloadPlugins);
+		connect(m_pluginManager, &PluginsManager::updatePlugin,m_settingsWindow, &SettingsWindow::updatePlugin, Qt::QueuedConnection);
+		connect(m_pluginManager, &PluginsManager::updatePlugin,m_pluginInterface, &LightpackPluginInterface::updatePlugin, Qt::QueuedConnection);
 	}
 
 	m_pluginManager->LoadPlugins(QString(Settings::getApplicationDirPath() + QStringLiteral("Plugins")));
@@ -712,87 +712,87 @@ void LightpackApplication::initGrabManager()
 		qWarning() << Q_FUNC_INFO << "No compatible Sound Manager";
 #endif
 
-	connect(settings(), SIGNAL(grabberTypeChanged(Grab::GrabberType)),	m_grabManager,		SLOT(onGrabberTypeChanged(Grab::GrabberType)),	Qt::QueuedConnection);
-	connect(settings(), SIGNAL(grabSlowdownChanged(int)),						m_grabManager,		SLOT(onGrabSlowdownChanged(int)),						Qt::QueuedConnection);
-	connect(settings(), SIGNAL(grabAvgColorsEnabledChanged(bool)),				m_grabManager,		SLOT(onGrabAvgColorsEnabledChanged(bool)),				Qt::QueuedConnection);
-	connect(settings(), SIGNAL(grabOverBrightenChanged(int)),					m_grabManager,		SLOT(onGrabOverBrightenChanged(int)),					Qt::QueuedConnection);
-	connect(settings(), SIGNAL(grabApplyBlueLightReductionChanged(bool)),				m_grabManager,		SLOT(onGrabApplyBlueLightReductionChanged(bool)),				Qt::QueuedConnection);
-	connect(settings(), SIGNAL(grabApplyColorTemperatureChanged(bool)),         m_grabManager,      SLOT(onGrabApplyColorTemperatureChanged(bool)),           Qt::QueuedConnection);
-	connect(settings(), SIGNAL(grabColorTemperatureChanged(int)),               m_grabManager,      SLOT(onGrabColorTemperatureChanged(int)),                 Qt::QueuedConnection);
-	connect(settings(), SIGNAL(grabGammaChanged(double)),                       m_grabManager,      SLOT(onGrabGammaChanged(double)),                         Qt::QueuedConnection);
-	connect(settings(), SIGNAL(sendDataOnlyIfColorsChangesChanged(bool)),		m_grabManager,		SLOT(onSendDataOnlyIfColorsEnabledChanged(bool)),		Qt::QueuedConnection);
+	connect(settings(), &Settings::grabberTypeChanged,	m_grabManager, &GrabManager::onGrabberTypeChanged,	Qt::QueuedConnection);
+	connect(settings(), &Settings::grabSlowdownChanged,						m_grabManager, &GrabManager::onGrabSlowdownChanged,						Qt::QueuedConnection);
+	connect(settings(), &Settings::grabAvgColorsEnabledChanged,				m_grabManager, &GrabManager::onGrabAvgColorsEnabledChanged,				Qt::QueuedConnection);
+	connect(settings(), &Settings::grabOverBrightenChanged,					m_grabManager, &GrabManager::onGrabOverBrightenChanged,					Qt::QueuedConnection);
+	connect(settings(), &Settings::grabApplyBlueLightReductionChanged,				m_grabManager, &GrabManager::onGrabApplyBlueLightReductionChanged,				Qt::QueuedConnection);
+	connect(settings(), &Settings::grabApplyColorTemperatureChanged,         m_grabManager, &GrabManager::onGrabApplyColorTemperatureChanged,           Qt::QueuedConnection);
+	connect(settings(), &Settings::grabColorTemperatureChanged,               m_grabManager, &GrabManager::onGrabColorTemperatureChanged,                 Qt::QueuedConnection);
+	connect(settings(), &Settings::grabGammaChanged,                       m_grabManager, &GrabManager::onGrabGammaChanged,                         Qt::QueuedConnection);
+	connect(settings(), &Settings::sendDataOnlyIfColorsChangesChanged,		m_grabManager, &GrabManager::onSendDataOnlyIfColorsEnabledChanged,		Qt::QueuedConnection);
 #ifdef D3D10_GRAB_SUPPORT
-	connect(settings(), SIGNAL(dx1011GrabberEnabledChanged(bool)),				m_grabManager,		SLOT(onDx1011GrabberEnabledChanged(bool)),				Qt::QueuedConnection);
-	connect(settings(), SIGNAL(dx9GrabberEnabledChanged(bool)),					m_grabManager,		SLOT(onDx9GrabberEnabledChanged(bool)),					Qt::QueuedConnection);
+	connect(settings(), &Settings::dx1011GrabberEnabledChanged,				m_grabManager, &GrabManager::onDx1011GrabberEnabledChanged,				Qt::QueuedConnection);
+	connect(settings(), &Settings::dx9GrabberEnabledChanged,					m_grabManager, &GrabManager::onDx9GrabberEnabledChanged,					Qt::QueuedConnection);
 #endif
 
-	connect(settings(), SIGNAL(moodLampColorChanged(QColor)),					m_moodlampManager,	SLOT(setCurrentColor(QColor)));
-	connect(settings(), SIGNAL(moodLampSpeedChanged(int)),						m_moodlampManager,	SLOT(setLiquidModeSpeed(int)));
-	connect(settings(), SIGNAL(moodLampLiquidModeChanged(bool)),				m_moodlampManager,	SLOT(setLiquidMode(bool)));
-	connect(settings(), SIGNAL(moodLampLampChanged(int)),						m_moodlampManager,	SLOT(setCurrentLamp(int)));
-	connect(settings(), SIGNAL(sendDataOnlyIfColorsChangesChanged(bool)),		m_moodlampManager,	SLOT(setSendDataOnlyIfColorsChanged(bool)));
+	connect(settings(), &Settings::moodLampColorChanged,					m_moodlampManager, &MoodLampManager::setCurrentColor);
+	connect(settings(), &Settings::moodLampSpeedChanged,						m_moodlampManager, &MoodLampManager::setLiquidModeSpeed);
+	connect(settings(), &Settings::moodLampLiquidModeChanged,				m_moodlampManager, &MoodLampManager::setLiquidMode);
+	connect(settings(), &Settings::moodLampLampChanged,						m_moodlampManager, &MoodLampManager::setCurrentLamp);
+	connect(settings(), &Settings::sendDataOnlyIfColorsChangesChanged,		m_moodlampManager, &MoodLampManager::setSendDataOnlyIfColorsChanged);
 
 #ifdef SOUNDVIZ_SUPPORT
 	if (m_soundManager)
 	{
-		connect(settings(), SIGNAL(soundVisualizerDeviceChanged(int)),				m_soundManager,		SLOT(setDevice(int)));
-		connect(settings(), SIGNAL(soundVisualizerVisualizerChanged(int)),			m_soundManager,		SLOT(setVisualizer(int)));
-		connect(settings(), SIGNAL(soundVisualizerMaxColorChanged(QColor)),			m_soundManager,		SLOT(setMaxColor(QColor)));
-		connect(settings(), SIGNAL(soundVisualizerMinColorChanged(QColor)),			m_soundManager,		SLOT(setMinColor(QColor)));
-		connect(settings(), SIGNAL(soundVisualizerLiquidSpeedChanged(int)),			m_soundManager,		SLOT(setLiquidModeSpeed(int)));
-		connect(settings(), SIGNAL(soundVisualizerLiquidModeChanged(bool)),			m_soundManager,		SLOT(setLiquidMode(bool)));
-		connect(settings(), SIGNAL(sendDataOnlyIfColorsChangesChanged(bool)),		m_soundManager,		SLOT(setSendDataOnlyIfColorsChanged(bool)));
+		connect(settings(), &Settings::soundVisualizerDeviceChanged,				m_soundManager, &SoundManagerBase::setDevice);
+		connect(settings(), &Settings::soundVisualizerVisualizerChanged,			m_soundManager, &SoundManagerBase::setVisualizer);
+		connect(settings(), &Settings::soundVisualizerMaxColorChanged,			m_soundManager, &SoundManagerBase::setMaxColor);
+		connect(settings(), &Settings::soundVisualizerMinColorChanged,			m_soundManager, &SoundManagerBase::setMinColor);
+		connect(settings(), &Settings::soundVisualizerLiquidSpeedChanged,			m_soundManager, &SoundManagerBase::setLiquidModeSpeed);
+		connect(settings(), &Settings::soundVisualizerLiquidModeChanged,			m_soundManager, &SoundManagerBase::setLiquidMode);
+		connect(settings(), &Settings::sendDataOnlyIfColorsChangesChanged,		m_soundManager, &SoundManagerBase::setSendDataOnlyIfColorsChanged);
 
-		connect(m_pluginInterface, SIGNAL(updateSoundVizMinColor(QColor)),			m_soundManager,		SLOT(setMinColor(QColor)),								Qt::QueuedConnection);
-		connect(m_pluginInterface, SIGNAL(updateSoundVizMaxColor(QColor)),			m_soundManager,		SLOT(setMaxColor(QColor)),								Qt::QueuedConnection);
-		connect(m_pluginInterface, SIGNAL(updateSoundVizLiquid(bool)),				m_soundManager,		SLOT(setLiquidMode(bool)),								Qt::QueuedConnection);
+		connect(m_pluginInterface, &LightpackPluginInterface::updateSoundVizMinColor,			m_soundManager, &SoundManagerBase::setMinColor,								Qt::QueuedConnection);
+		connect(m_pluginInterface, &LightpackPluginInterface::updateSoundVizMaxColor,			m_soundManager, &SoundManagerBase::setMaxColor,								Qt::QueuedConnection);
+		connect(m_pluginInterface, &LightpackPluginInterface::updateSoundVizLiquid,				m_soundManager, &SoundManagerBase::setLiquidMode,								Qt::QueuedConnection);
 	}
 #endif
 
-	connect(settings(), SIGNAL(currentProfileInited(QString)),			m_grabManager,		SLOT(settingsProfileChanged(QString)),			Qt::QueuedConnection);
+	connect(settings(), &Settings::currentProfileInited,			m_grabManager, &GrabManager::settingsProfileChanged,			Qt::QueuedConnection);
 
-	connect(settings(), SIGNAL(currentProfileInited(QString)),			m_moodlampManager,	SLOT(settingsProfileChanged(QString)),			Qt::QueuedConnection);
+	connect(settings(), &Settings::currentProfileInited,			m_moodlampManager, &MoodLampManager::settingsProfileChanged,			Qt::QueuedConnection);
 #ifdef SOUNDVIZ_SUPPORT
 	if (m_soundManager)
-		connect(settings(), SIGNAL(currentProfileInited(QString)),			m_soundManager,		SLOT(settingsProfileChanged(QString)));
+		connect(settings(), &Settings::currentProfileInited,			m_soundManager, &SoundManagerBase::settingsProfileChanged);
 #endif
 
 	// Connections to signals which will be connected to ILedDevice
 	if (!m_noGui && m_settingsWindow)
 	{
-		connect(m_settingsWindow, SIGNAL(showLedWidgets(bool)), this, SLOT(showLedWidgets(bool)));
-		connect(m_settingsWindow, SIGNAL(setColoredLedWidget(bool)), this, SLOT(setColoredLedWidget(bool)));
+		connect(m_settingsWindow, &SettingsWindow::showLedWidgets, this, &LightpackApplication::showLedWidgets);
+		connect(m_settingsWindow, &SettingsWindow::setColoredLedWidget, this, &LightpackApplication::setColoredLedWidget);
 
 		// GrabManager to this
-		connect(m_grabManager, SIGNAL(ambilightTimeOfUpdatingColors(double)), m_settingsWindow, SLOT(refreshAmbilightEvaluated(double)));
+		connect(m_grabManager, &GrabManager::ambilightTimeOfUpdatingColors, m_settingsWindow, &SettingsWindow::refreshAmbilightEvaluated);
 
 #ifdef SOUNDVIZ_SUPPORT
 		if (m_soundManager) {
-			connect(m_settingsWindow, SIGNAL(requestSoundVizDevices()), m_soundManager, SLOT(requestDeviceList()));
-			connect(m_soundManager, SIGNAL(deviceList(QList<SoundManagerDeviceInfo>,int)), m_settingsWindow, SLOT(updateAvailableSoundVizDevices(QList<SoundManagerDeviceInfo>,int)));
+			connect(m_settingsWindow, &SettingsWindow::requestSoundVizDevices, m_soundManager, &SoundManagerBase::requestDeviceList);
+			connect(m_soundManager, &SoundManagerBase::deviceList, m_settingsWindow, &SettingsWindow::updateAvailableSoundVizDevices);
 
-			connect(m_settingsWindow, SIGNAL(requestSoundVizVisualizers()), m_soundManager, SLOT(requestVisualizerList()));
-			connect(m_soundManager, SIGNAL(visualizerList(QList<SoundManagerVisualizerInfo>,int)), m_settingsWindow, SLOT(updateAvailableSoundVizVisualizers(QList<SoundManagerVisualizerInfo>,int)));
+			connect(m_settingsWindow, &SettingsWindow::requestSoundVizVisualizers, m_soundManager, &SoundManagerBase::requestVisualizerList);
+			connect(m_soundManager, &SoundManagerBase::visualizerList, m_settingsWindow, &SettingsWindow::updateAvailableSoundVizVisualizers);
 		}
 #endif
 
-		connect(m_settingsWindow, SIGNAL(requestMoodLampLamps()), m_moodlampManager, SLOT(requestLampList()));
-		connect(m_moodlampManager, SIGNAL(lampList(QList<MoodLampLampInfo>,int)), m_settingsWindow, SLOT(updateAvailableMoodLampLamps(QList<MoodLampLampInfo>,int)));
+		connect(m_settingsWindow, &SettingsWindow::requestMoodLampLamps, m_moodlampManager, &MoodLampManager::requestLampList);
+		connect(m_moodlampManager, &MoodLampManager::lampList, m_settingsWindow, &SettingsWindow::updateAvailableMoodLampLamps);
 	}
 
-	connect(m_grabManager, SIGNAL(ambilightTimeOfUpdatingColors(double)), m_pluginInterface, SLOT(refreshAmbilightEvaluated(double)));
+	connect(m_grabManager, &GrabManager::ambilightTimeOfUpdatingColors, m_pluginInterface, &LightpackPluginInterface::refreshAmbilightEvaluated);
 
-	connect(m_grabManager,		SIGNAL(updateLedsColors(QList<QRgb>)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
-	connect(m_moodlampManager,	SIGNAL(updateLedsColors(QList<QRgb>)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+	connect(m_grabManager, &GrabManager::updateLedsColors,	m_ledDeviceManager, &LedDeviceManager::setColors, Qt::QueuedConnection);
+	connect(m_moodlampManager, &MoodLampManager::updateLedsColors,	m_ledDeviceManager, &LedDeviceManager::setColors, Qt::QueuedConnection);
 	if (!m_noGui && m_settingsWindow)
-		connect(m_moodlampManager,	SIGNAL(moodlampFrametime(double)),		m_settingsWindow, 	SLOT(refreshAmbilightEvaluated(double)), Qt::QueuedConnection);
-	connect(m_ledDeviceManager,	SIGNAL(openDeviceSuccess(bool)),				m_grabManager,		SLOT(ledDeviceOpenSuccess(bool)), Qt::QueuedConnection);
-	connect(m_ledDeviceManager,	SIGNAL(ioDeviceSuccess(bool)),					m_grabManager,		SLOT(ledDeviceCallSuccess(bool)), Qt::QueuedConnection);
+		connect(m_moodlampManager, &MoodLampManager::moodlampFrametime,		m_settingsWindow, &SettingsWindow::refreshAmbilightEvaluated, Qt::QueuedConnection);
+	connect(m_ledDeviceManager, &LedDeviceManager::openDeviceSuccess,				m_grabManager, &GrabManager::ledDeviceOpenSuccess, Qt::QueuedConnection);
+	connect(m_ledDeviceManager, &LedDeviceManager::ioDeviceSuccess,					m_grabManager, &GrabManager::ledDeviceCallSuccess, Qt::QueuedConnection);
 #ifdef SOUNDVIZ_SUPPORT
 	if (m_soundManager) {
-		connect(m_soundManager,		SIGNAL(updateLedsColors(QList<QRgb>)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+		connect(m_soundManager, &SoundManagerBase::updateLedsColors,	m_ledDeviceManager, &LedDeviceManager::setColors, Qt::QueuedConnection);
 		if (!m_noGui && m_settingsWindow)
-			connect(m_soundManager,		SIGNAL(visualizerFrametime(double)),	m_settingsWindow, SLOT(refreshAmbilightEvaluated(double)), Qt::QueuedConnection);
+			connect(m_soundManager, &SoundManagerBase::visualizerFrametime,	m_settingsWindow, &SettingsWindow::refreshAmbilightEvaluated, Qt::QueuedConnection);
 	}
 #endif
 }
@@ -806,7 +806,7 @@ void LightpackApplication::commitData(QSessionManager &sessionManager)
 	if (m_ledDeviceManager != NULL)
 	{
 		// Disable signals with new colors
-		disconnect(m_settingsWindow, SIGNAL(updateLedsColors(QList<QRgb>)), m_ledDeviceManager, SLOT(setColors(QList<QRgb>)));
+		disconnect(m_settingsWindow, &SettingsWindow::updateLedsColors, m_ledDeviceManager, &LedDeviceManager::setColors);
 
 		// Process all currently pending signals
 		QApplication::processEvents(QEventLoop::AllEvents, 1000);

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -576,7 +576,7 @@ void LightpackApplication::startApiServer()
 	connect(this, SIGNAL(clearColorBuffers()), m_apiServer, SIGNAL(clearColorBuffers()));
 
 	connect(settings(), SIGNAL(apiServerSettingsChanged()),		m_apiServer, SLOT(apiServerSettingsChanged()));
-	connect(settings(), SIGNAL(apiKeyChanged(const QString &)), m_apiServer, SLOT(updateApiKey(const QString &)));
+	connect(settings(), SIGNAL(apiKeyChanged(QString)), m_apiServer, SLOT(updateApiKey(QString)));
 
 	connect(settings(), SIGNAL(lightpackNumberOfLedsChanged(int)),	m_apiServer, SIGNAL(updateApiDeviceNumberOfLeds(int)));
 	connect(settings(), SIGNAL(adalightNumberOfLedsChanged(int)),	m_apiServer, SIGNAL(updateApiDeviceNumberOfLeds(int)));
@@ -588,10 +588,10 @@ void LightpackApplication::startApiServer()
 		connect(m_apiServer, SIGNAL(errorOnStartListening(QString)), m_settingsWindow, SLOT(onApiServer_ErrorOnStartListening(QString)));
 	}
 
-	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetColors(const QList<QRgb> &)),	m_pluginInterface, SLOT(updateColorsCache(const QList<QRgb> &)),	Qt::QueuedConnection);
+	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetColors(QList<QRgb>)),	m_pluginInterface, SLOT(updateColorsCache(QList<QRgb>)),	Qt::QueuedConnection);
 	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetSmoothSlowdown(int)),			m_pluginInterface, SLOT(updateSmoothCache(int)),					Qt::QueuedConnection);
-	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetGamma(double, bool)),			m_pluginInterface, SLOT(updateGammaCache(double)),					Qt::QueuedConnection);
-	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetBrightness(int, bool)),			m_pluginInterface, SLOT(updateBrightnessCache(int)),				Qt::QueuedConnection);
+	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetGamma(double,bool)),			m_pluginInterface, SLOT(updateGammaCache(double)),					Qt::QueuedConnection);
+	connect(m_ledDeviceManager, SIGNAL(ledDeviceSetBrightness(int,bool)),			m_pluginInterface, SLOT(updateBrightnessCache(int)),				Qt::QueuedConnection);
 
 #ifdef SOUNDVIZ_SUPPORT
 	connect(settings(), SIGNAL(soundVisualizerMinColorChanged(QColor)), m_pluginInterface, SLOT(updateSoundVizMinColorCache(QColor)), Qt::QueuedConnection);
@@ -617,8 +617,8 @@ void LightpackApplication::startLedDeviceManager()
 //	connect(m_settingsWindow, SIGNAL(updateLedsColors(const QList<QRgb> &)),			m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
 	m_pluginInterface = new LightpackPluginInterface(NULL);
 
-	connect(m_pluginInterface, SIGNAL(updateDeviceLockStatus(DeviceLocked::DeviceLockStatus, QList<QString>)), this, SLOT(setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus, QList<QString>)));
-	connect(m_pluginInterface, SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+	connect(m_pluginInterface, SIGNAL(updateDeviceLockStatus(DeviceLocked::DeviceLockStatus,QList<QString>)), this, SLOT(setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus,QList<QString>)));
+	connect(m_pluginInterface, SIGNAL(updateLedsColors(QList<QRgb>)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
 	connect(m_pluginInterface, SIGNAL(updateGamma(double)),		m_ledDeviceManager, SLOT(setGamma(double)),		Qt::QueuedConnection);
 	connect(m_pluginInterface, SIGNAL(updateBrightness(int)),	m_ledDeviceManager, SLOT(setBrightness(int)),		Qt::QueuedConnection);
 	connect(m_pluginInterface, SIGNAL(updateSmooth(int)),		m_ledDeviceManager, SLOT(setSmoothSlowdown(int)), Qt::QueuedConnection);
@@ -630,8 +630,8 @@ void LightpackApplication::startLedDeviceManager()
 
 	if (!m_noGui)
 	{
-		connect(m_pluginInterface, SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_settingsWindow, SLOT(updateVirtualLedsColors(QList<QRgb>)));
-		connect(m_pluginInterface, SIGNAL(updateDeviceLockStatus(DeviceLocked::DeviceLockStatus, QList<QString>)), m_settingsWindow, SLOT(setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus, QList<QString>)));
+		connect(m_pluginInterface, SIGNAL(updateLedsColors(QList<QRgb>)),	m_settingsWindow, SLOT(updateVirtualLedsColors(QList<QRgb>)));
+		connect(m_pluginInterface, SIGNAL(updateDeviceLockStatus(DeviceLocked::DeviceLockStatus,QList<QString>)), m_settingsWindow, SLOT(setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus,QList<QString>)));
 		connect(m_pluginInterface, SIGNAL(updateProfile(QString)),						m_settingsWindow, SLOT(profileSwitch(QString)));
 		connect(m_pluginInterface, SIGNAL(updateStatus(Backlight::Status)),				m_settingsWindow, SLOT(setBacklightStatus(Backlight::Status)));
 	}
@@ -712,7 +712,7 @@ void LightpackApplication::initGrabManager()
 		qWarning() << Q_FUNC_INFO << "No compatible Sound Manager";
 #endif
 
-	connect(settings(), SIGNAL(grabberTypeChanged(const Grab::GrabberType &)),	m_grabManager,		SLOT(onGrabberTypeChanged(const Grab::GrabberType &)),	Qt::QueuedConnection);
+	connect(settings(), SIGNAL(grabberTypeChanged(Grab::GrabberType)),	m_grabManager,		SLOT(onGrabberTypeChanged(Grab::GrabberType)),	Qt::QueuedConnection);
 	connect(settings(), SIGNAL(grabSlowdownChanged(int)),						m_grabManager,		SLOT(onGrabSlowdownChanged(int)),						Qt::QueuedConnection);
 	connect(settings(), SIGNAL(grabAvgColorsEnabledChanged(bool)),				m_grabManager,		SLOT(onGrabAvgColorsEnabledChanged(bool)),				Qt::QueuedConnection);
 	connect(settings(), SIGNAL(grabOverBrightenChanged(int)),					m_grabManager,		SLOT(onGrabOverBrightenChanged(int)),					Qt::QueuedConnection);
@@ -749,12 +749,12 @@ void LightpackApplication::initGrabManager()
 	}
 #endif
 
-	connect(settings(), SIGNAL(currentProfileInited(const QString &)),			m_grabManager,		SLOT(settingsProfileChanged(const QString &)),			Qt::QueuedConnection);
+	connect(settings(), SIGNAL(currentProfileInited(QString)),			m_grabManager,		SLOT(settingsProfileChanged(QString)),			Qt::QueuedConnection);
 
-	connect(settings(), SIGNAL(currentProfileInited(const QString &)),			m_moodlampManager,	SLOT(settingsProfileChanged(const QString &)),			Qt::QueuedConnection);
+	connect(settings(), SIGNAL(currentProfileInited(QString)),			m_moodlampManager,	SLOT(settingsProfileChanged(QString)),			Qt::QueuedConnection);
 #ifdef SOUNDVIZ_SUPPORT
 	if (m_soundManager)
-		connect(settings(), SIGNAL(currentProfileInited(const QString &)),			m_soundManager,		SLOT(settingsProfileChanged(const QString &)));
+		connect(settings(), SIGNAL(currentProfileInited(QString)),			m_soundManager,		SLOT(settingsProfileChanged(QString)));
 #endif
 
 	// Connections to signals which will be connected to ILedDevice
@@ -769,30 +769,30 @@ void LightpackApplication::initGrabManager()
 #ifdef SOUNDVIZ_SUPPORT
 		if (m_soundManager) {
 			connect(m_settingsWindow, SIGNAL(requestSoundVizDevices()), m_soundManager, SLOT(requestDeviceList()));
-			connect(m_soundManager, SIGNAL(deviceList(const QList<SoundManagerDeviceInfo> &, int)), m_settingsWindow, SLOT(updateAvailableSoundVizDevices(const QList<SoundManagerDeviceInfo> &, int)));
+			connect(m_soundManager, SIGNAL(deviceList(QList<SoundManagerDeviceInfo>,int)), m_settingsWindow, SLOT(updateAvailableSoundVizDevices(QList<SoundManagerDeviceInfo>,int)));
 
 			connect(m_settingsWindow, SIGNAL(requestSoundVizVisualizers()), m_soundManager, SLOT(requestVisualizerList()));
-			connect(m_soundManager, SIGNAL(visualizerList(const QList<SoundManagerVisualizerInfo> &, int)), m_settingsWindow, SLOT(updateAvailableSoundVizVisualizers(const QList<SoundManagerVisualizerInfo> &, int)));
+			connect(m_soundManager, SIGNAL(visualizerList(QList<SoundManagerVisualizerInfo>,int)), m_settingsWindow, SLOT(updateAvailableSoundVizVisualizers(QList<SoundManagerVisualizerInfo>,int)));
 		}
 #endif
 
 		connect(m_settingsWindow, SIGNAL(requestMoodLampLamps()), m_moodlampManager, SLOT(requestLampList()));
-		connect(m_moodlampManager, SIGNAL(lampList(const QList<MoodLampLampInfo> &, int)), m_settingsWindow, SLOT(updateAvailableMoodLampLamps(const QList<MoodLampLampInfo> &, int)));
+		connect(m_moodlampManager, SIGNAL(lampList(QList<MoodLampLampInfo>,int)), m_settingsWindow, SLOT(updateAvailableMoodLampLamps(QList<MoodLampLampInfo>,int)));
 	}
 
 	connect(m_grabManager, SIGNAL(ambilightTimeOfUpdatingColors(double)), m_pluginInterface, SLOT(refreshAmbilightEvaluated(double)));
 
-	connect(m_grabManager,		SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
-	connect(m_moodlampManager,	SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+	connect(m_grabManager,		SIGNAL(updateLedsColors(QList<QRgb>)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+	connect(m_moodlampManager,	SIGNAL(updateLedsColors(QList<QRgb>)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
 	if (!m_noGui && m_settingsWindow)
-		connect(m_moodlampManager,	SIGNAL(moodlampFrametime(const double)),		m_settingsWindow, 	SLOT(refreshAmbilightEvaluated(double)), Qt::QueuedConnection);
+		connect(m_moodlampManager,	SIGNAL(moodlampFrametime(double)),		m_settingsWindow, 	SLOT(refreshAmbilightEvaluated(double)), Qt::QueuedConnection);
 	connect(m_ledDeviceManager,	SIGNAL(openDeviceSuccess(bool)),				m_grabManager,		SLOT(ledDeviceOpenSuccess(bool)), Qt::QueuedConnection);
 	connect(m_ledDeviceManager,	SIGNAL(ioDeviceSuccess(bool)),					m_grabManager,		SLOT(ledDeviceCallSuccess(bool)), Qt::QueuedConnection);
 #ifdef SOUNDVIZ_SUPPORT
 	if (m_soundManager) {
-		connect(m_soundManager,		SIGNAL(updateLedsColors(const QList<QRgb> &)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
+		connect(m_soundManager,		SIGNAL(updateLedsColors(QList<QRgb>)),	m_ledDeviceManager, SLOT(setColors(QList<QRgb>)), Qt::QueuedConnection);
 		if (!m_noGui && m_settingsWindow)
-			connect(m_soundManager,		SIGNAL(visualizerFrametime(const double)),	m_settingsWindow, SLOT(refreshAmbilightEvaluated(double)), Qt::QueuedConnection);
+			connect(m_soundManager,		SIGNAL(visualizerFrametime(double)),	m_settingsWindow, SLOT(refreshAmbilightEvaluated(double)), Qt::QueuedConnection);
 	}
 #endif
 }

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -47,13 +47,6 @@
 using namespace std;
 using namespace SettingsScope;
 
-struct QtMetaObject : private QObject
-{
-public:
-	static const QMetaObject *get()
-	{ return &static_cast<QtMetaObject*>(0)->staticQtMetaObject; }
-};
-
 LightpackApplication::LightpackApplication(int &argc, char **argv)
 	: QtSingleApplication(argc, argv)
 {

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -27,8 +27,8 @@
 #include "LightpackApplication.hpp"
 #include "LedDeviceLightpack.hpp"
 #include "version.h"
-#include <QtWidgets/QMessageBox>
-#include <QtWidgets/QHBoxLayout>
+#include <QMessageBox>
+#include <QHBoxLayout>
 #include "ApiServer.hpp"
 #include "LightpackPluginInterface.hpp"
 #include "PluginsManager.hpp"

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -431,11 +431,11 @@ void LightpackApplication::processCommandLineArguments()
 	if (parser.isSetVersion())
 	{
 		const QString versionString =
-			QStringLiteral("Version: " VERSION_STR "\n"
+			QStringLiteral("Version: " VERSION_STR "\n") +
 #ifdef GIT_REVISION
-			"Revision: " GIT_REVISION "\n"
+			QStringLiteral("Revision: " GIT_REVISION "\n") +
 #endif
-			"Build with Qt version " QT_VERSION_STR "\n");
+			QStringLiteral("Build with Qt version " QT_VERSION_STR "\n");
 		outputMessage(versionString);
 		::exit(0);
 	}

--- a/Software/src/LightpackApplication.hpp
+++ b/Software/src/LightpackApplication.hpp
@@ -73,7 +73,7 @@ public slots:
 
 private slots:
 	void requestBacklightStatus();
-	void setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus status, QList<QString> modules);
+	void setDeviceLockViaAPI(const DeviceLocked::DeviceLockStatus status, const QList<QString>& modules);
 	void profileSwitch(const QString & configName);
 	void settingsChanged();
 //	void numberOfLedsChanged(int);
@@ -86,7 +86,7 @@ private slots:
 
 private:
 	void processCommandLineArguments();
-	void outputMessage(QString message) const;
+	void outputMessage(const QString& message) const;
 	void printVersionsSoftwareQtOS() const;
 	bool checkSystemTrayAvailability() const;
 	void startApiServer();

--- a/Software/src/LightpackCommandLineParser.cpp
+++ b/Software/src/LightpackCommandLineParser.cpp
@@ -1,20 +1,20 @@
 #include "LightpackCommandLineParser.hpp"
 
 LightpackCommandLineParser::LightpackCommandLineParser()
-	: m_noGUIOption("nogui", "no GUI (console mode)")
-	, m_wizardOption("wizard", "run settings wizard first")
-	, m_backlightOffOption("off", "send 'off leds' command to the device or running instance")
-	, m_backlightOnOption("on", "send 'on leds' command to running instance, if any")
-	, m_debugLevelOption("debug", "verbosity level of debug output (high, mid, low, zero)", "debug")
-	, m_debugLevelHighOption("debug-high", "sets application debug level to high.")
-	, m_debugLevelMidOption("debug-mid", "sets application debug level to mid.")
-	, m_debugLevelLowOption("debug-low", "sets application debug level to low.")
-	, m_debugLevelZeroOption("debug-zero", "sets application debug level to zero.")
+	: m_noGUIOption(QStringLiteral("nogui"), QStringLiteral("no GUI (console mode)"))
+	, m_wizardOption(QStringLiteral("wizard"), QStringLiteral("run settings wizard first"))
+	, m_backlightOffOption(QStringLiteral("off"), QStringLiteral("send 'off leds' command to the device or running instance"))
+	, m_backlightOnOption(QStringLiteral("on"), QStringLiteral("send 'on leds' command to running instance, if any"))
+	, m_debugLevelOption(QStringLiteral("debug"), QStringLiteral("verbosity level of debug output (high, mid, low, zero)"), QStringLiteral("debug"))
+	, m_debugLevelHighOption(QStringLiteral("debug-high"), QStringLiteral("sets application debug level to high."))
+	, m_debugLevelMidOption(QStringLiteral("debug-mid"), QStringLiteral("sets application debug level to mid."))
+	, m_debugLevelLowOption(QStringLiteral("debug-low"), QStringLiteral("sets application debug level to low."))
+	, m_debugLevelZeroOption(QStringLiteral("debug-zero"), QStringLiteral("sets application debug level to zero."))
 	, m_versionOption(m_parser.addVersionOption())
 	, m_helpOption(m_parser.addHelpOption())
-	, m_optionSetProfile("set-profile", "switch to another profile in already running instance", "profile")
+	, m_optionSetProfile(QStringLiteral("set-profile"), QStringLiteral("switch to another profile in already running instance"), QStringLiteral("profile"))
 {
-	m_parser.setApplicationDescription("Prismatik of Lightpack");
+	m_parser.setApplicationDescription(QStringLiteral("Prismatik of Lightpack"));
 	m_parser.addOption(m_noGUIOption);
 	m_parser.addOption(m_wizardOption);
 	m_parser.addOption(m_backlightOffOption);
@@ -88,20 +88,20 @@ QString LightpackCommandLineParser::helpText() const {
 
 QString LightpackCommandLineParser::errorText() const {
 	if (isSetBacklightOff() && isSetBacklightOn())
-		return "Bad options specified!";
+		return QStringLiteral("Bad options specified!");
 	return m_parser.errorText();
 }
 
 // static
 Debug::DebugLevels LightpackCommandLineParser::parseDebugLevel(const QString& levelValue)
 {
-	if (levelValue == "high")
+	if (levelValue == QStringLiteral("high"))
 		return Debug::HighLevel;
-	else if (levelValue == "mid")
+	else if (levelValue == QStringLiteral("mid"))
 		return Debug::MidLevel;
-	else if (levelValue == "low")
+	else if (levelValue == QStringLiteral("low"))
 		return Debug::LowLevel;
-	else if (levelValue == "zero")
+	else if (levelValue == QStringLiteral("zero"))
 		return Debug::ZeroLevel;
 
 	Q_ASSERT(false);

--- a/Software/src/LightpackPluginInterface.cpp
+++ b/Software/src/LightpackPluginInterface.cpp
@@ -22,7 +22,8 @@ LightpackPluginInterface::LightpackPluginInterface(QObject *parent) :
 
 	initColors(10);
 	m_timerLock = new QTimer(this);
-	m_timerLock->start(5000); // check in 5000 ms
+	using namespace std::chrono_literals;
+	m_timerLock->start(5s); // check in 5000 ms
 	connect(m_timerLock, &QTimer::timeout, this, &LightpackPluginInterface::timeoutLock);
 	_plugins.clear();
 }

--- a/Software/src/LightpackPluginInterface.cpp
+++ b/Software/src/LightpackPluginInterface.cpp
@@ -19,7 +19,7 @@ LightpackPluginInterface::LightpackPluginInterface(QObject *parent) :
 	m_brightness = SettingsScope::Profile::Device::BrightnessDefault;
 	m_smooth = SettingsScope::Profile::Device::SmoothDefault;
 	m_persistOnUnlock = false;
-	
+
 	initColors(10);
 	m_timerLock = new QTimer(this);
 	m_timerLock->start(5000); // check in 5000 ms
@@ -45,12 +45,12 @@ void LightpackPluginInterface::timeoutLock()
 	else
 	{
 		if (!lockSessionKeys.isEmpty())
-			if (lockSessionKeys[0].indexOf("API", 0) == -1)
+			if (lockSessionKeys[0].indexOf(QStringLiteral("API"), 0) == -1)
 				UnLock(lockSessionKeys[0]);
 	}
 }
 
-void LightpackPluginInterface::updatePlugin(QList<Plugin*> plugins)
+void LightpackPluginInterface::updatePlugin(const QList<Plugin*>& plugins)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	if (!lockSessionKeys.isEmpty())
@@ -61,7 +61,7 @@ void LightpackPluginInterface::updatePlugin(QList<Plugin*> plugins)
 
 }
 
-bool LightpackPluginInterface::VerifySessionKey(QString sessionKey)
+bool LightpackPluginInterface::VerifySessionKey(const QString& sessionKey)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << sessionKey;
 
@@ -72,7 +72,7 @@ bool LightpackPluginInterface::VerifySessionKey(QString sessionKey)
 	return false;
 }
 
-Plugin* LightpackPluginInterface::findName(QString name)
+Plugin* LightpackPluginInterface::findName(const QString& name)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << name;
 	foreach(Plugin* plugin, _plugins){
@@ -83,7 +83,7 @@ Plugin* LightpackPluginInterface::findName(QString name)
 	return NULL;
 }
 
-Plugin* LightpackPluginInterface::findSessionKey(QString sessionKey)
+Plugin* LightpackPluginInterface::findSessionKey(const QString& sessionKey)
 {
 	foreach(Plugin* plugin, _plugins){
 		if (plugin->Guid() == sessionKey)
@@ -133,7 +133,7 @@ void LightpackPluginInterface::resultBacklightStatus(Backlight::Status status)
 	}
 }
 
-void LightpackPluginInterface::changeProfile(QString profile)
+void LightpackPluginInterface::changeProfile(const QString& profile)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << profile;
 
@@ -204,20 +204,20 @@ void LightpackPluginInterface::updateSoundVizLiquidCache(bool value)
 
 QString LightpackPluginInterface::Version()
 {
-	return API_VERSION;
+	return QStringLiteral(API_VERSION);
 }
 
 // TODO identification plugin locked
-QString LightpackPluginInterface::GetSessionKey(QString module)
+QString LightpackPluginInterface::GetSessionKey(const QString& module)
 {
-	if (module=="API") return "Lock";
+	if (module==QStringLiteral("API")) return QStringLiteral("Lock");
 	Plugin* plugin = findName(module);
-	if (plugin == NULL) return "";
+	if (plugin == NULL) return QLatin1String("");
 		return plugin->Guid();
 
 }
 
-int LightpackPluginInterface::CheckLock(QString sessionKey)
+int LightpackPluginInterface::CheckLock(const QString& sessionKey)
 {
 	if (lockSessionKeys.isEmpty())
 		return 0;
@@ -228,11 +228,11 @@ int LightpackPluginInterface::CheckLock(QString sessionKey)
 
 
 //TODO: lock unlock
-bool LightpackPluginInterface::Lock(QString sessionKey)
+bool LightpackPluginInterface::Lock(const QString& sessionKey)
 {
-	if (sessionKey == "") return false;
+	if (sessionKey.isEmpty()) return false;
 		if (lockSessionKeys.contains(sessionKey)) return true;
-		if (sessionKey.indexOf("API", 0) != -1)
+		if (sessionKey.indexOf(QStringLiteral("API"), 0) != -1)
 			{
 				if (lockSessionKeys.count()>0)
 					return false;
@@ -244,9 +244,9 @@ bool LightpackPluginInterface::Lock(QString sessionKey)
 				Plugin* plugin = findSessionKey(sessionKey);
 				if (plugin == NULL) return false;
 
-					foreach (QString key,lockSessionKeys)
+					foreach (const QString& key,lockSessionKeys)
 					{
-						if (key.indexOf("API", 0) != -1) break;
+						if (key.indexOf(QStringLiteral("API"), 0) != -1) break;
 
 								Plugin* pluginLock = findSessionKey(key);
 								if (pluginLock == NULL) return false;
@@ -261,7 +261,7 @@ bool LightpackPluginInterface::Lock(QString sessionKey)
 						DEBUG_LOW_LEVEL << Q_FUNC_INFO << "add to end";
 						lockSessionKeys.insert(lockSessionKeys.count(),sessionKey);
 					}
-					if (lockSessionKeys[0].indexOf("API", 0) != -1)
+					if (lockSessionKeys[0].indexOf(QStringLiteral("API"), 0) != -1)
 						emit updateDeviceLockStatus(DeviceLocked::Api,lockSessionKeys);
 					else
 						emit updateDeviceLockStatus(DeviceLocked::Plugin, lockSessionKeys);
@@ -273,7 +273,7 @@ bool LightpackPluginInterface::Lock(QString sessionKey)
 
 }
 
-bool LightpackPluginInterface::UnLock(QString sessionKey)
+bool LightpackPluginInterface::UnLock(const QString& sessionKey)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 		if (lockSessionKeys[0]==sessionKey)
@@ -291,7 +291,7 @@ bool LightpackPluginInterface::UnLock(QString sessionKey)
 			}
 			else
 			{
-				if (lockSessionKeys[0].indexOf("API", 0) != -1)
+				if (lockSessionKeys[0].indexOf(QStringLiteral("API"), 0) != -1)
 					emit updateDeviceLockStatus(DeviceLocked::Api,lockSessionKeys);
 				else
 					emit updateDeviceLockStatus(DeviceLocked::Plugin, lockSessionKeys);
@@ -302,7 +302,7 @@ bool LightpackPluginInterface::UnLock(QString sessionKey)
 			if (lockSessionKeys.indexOf(sessionKey)!= -1)
 			{
 				lockSessionKeys.removeOne(sessionKey);
-				if (lockSessionKeys[0].indexOf("API", 0) != -1)
+				if (lockSessionKeys[0].indexOf(QStringLiteral("API"), 0) != -1)
 					emit updateDeviceLockStatus(DeviceLocked::Api,lockSessionKeys);
 				else
 					emit updateDeviceLockStatus(DeviceLocked::Plugin, lockSessionKeys);
@@ -313,7 +313,7 @@ bool LightpackPluginInterface::UnLock(QString sessionKey)
 }
 
 
-void LightpackPluginInterface::SetLockAlive(QString sessionKey)
+void LightpackPluginInterface::SetLockAlive(const QString& sessionKey)
 {
 	if (lockSessionKeys.isEmpty()) return;
 	if (lockSessionKeys[0]!=sessionKey) return;
@@ -321,7 +321,7 @@ void LightpackPluginInterface::SetLockAlive(QString sessionKey)
 }
 
 // TODO: setcolor
-bool LightpackPluginInterface::SetColors(QString sessionKey, int r, int g, int b)
+bool LightpackPluginInterface::SetColors(const QString& sessionKey, int r, int g, int b)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0]!=sessionKey) return false;
@@ -335,7 +335,7 @@ bool LightpackPluginInterface::SetColors(QString sessionKey, int r, int g, int b
 	return true;
 }
 
-bool LightpackPluginInterface::SetFrame(QString sessionKey, QList<QColor> colors)
+bool LightpackPluginInterface::SetFrame(const QString& sessionKey, QList<QColor> colors)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0]!=sessionKey) return false;
@@ -350,7 +350,7 @@ bool LightpackPluginInterface::SetFrame(QString sessionKey, QList<QColor> colors
 	return true;
 }
 
-bool LightpackPluginInterface::SetColor(QString sessionKey, int ind,int r, int g, int b)
+bool LightpackPluginInterface::SetColor(const QString& sessionKey, int ind,int r, int g, int b)
 {
 	DEBUG_MID_LEVEL << Q_FUNC_INFO << sessionKey;
 	if (lockSessionKeys.isEmpty()) return false;
@@ -363,7 +363,7 @@ bool LightpackPluginInterface::SetColor(QString sessionKey, int ind,int r, int g
 	return true;
 }
 
-bool LightpackPluginInterface::SetGamma(QString sessionKey, double gamma)
+bool LightpackPluginInterface::SetGamma(const QString& sessionKey, double gamma)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0]!=sessionKey) return false;
@@ -375,7 +375,7 @@ bool LightpackPluginInterface::SetGamma(QString sessionKey, double gamma)
 			return false;
 }
 
-bool LightpackPluginInterface::SetBrightness(QString sessionKey, int brightness)
+bool LightpackPluginInterface::SetBrightness(const QString& sessionKey, int brightness)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0]!=sessionKey) return false;
@@ -387,7 +387,7 @@ bool LightpackPluginInterface::SetBrightness(QString sessionKey, int brightness)
 			return false;
 }
 
-bool LightpackPluginInterface::SetSmooth(QString sessionKey, int smooth)
+bool LightpackPluginInterface::SetSmooth(const QString& sessionKey, int smooth)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0]!=sessionKey) return false;
@@ -399,7 +399,7 @@ bool LightpackPluginInterface::SetSmooth(QString sessionKey, int smooth)
 			return false;
 }
 
-bool LightpackPluginInterface::SetProfile(QString sessionKey,QString profile)
+bool LightpackPluginInterface::SetProfile(const QString& sessionKey, const QString& profile)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0]!=sessionKey) return false;
@@ -412,7 +412,7 @@ bool LightpackPluginInterface::SetProfile(QString sessionKey,QString profile)
 			return false;
 }
 
-bool LightpackPluginInterface::SetDevice(QString sessionKey,QString device)
+bool LightpackPluginInterface::SetDevice(const QString& sessionKey, const QString& device)
 {
 	qWarning() << Q_FUNC_INFO << "Unsupported/deprectated API/Plugin command: SetDevice";
 	return false;
@@ -429,7 +429,7 @@ bool LightpackPluginInterface::SetDevice(QString sessionKey,QString device)
 			return false;
 }
 
-bool LightpackPluginInterface::SetStatus(QString sessionKey, int status)
+bool LightpackPluginInterface::SetStatus(const QString& sessionKey, int status)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << status;
 	if (lockSessionKeys.isEmpty()) return false;
@@ -449,7 +449,7 @@ bool LightpackPluginInterface::SetStatus(QString sessionKey, int status)
 			return false;
 }
 
-bool LightpackPluginInterface::SetLeds(QString sessionKey, QList<QRect> leds)
+bool LightpackPluginInterface::SetLeds(const QString& sessionKey, QList<QRect> leds)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0]!=sessionKey) return false;
@@ -465,7 +465,7 @@ bool LightpackPluginInterface::SetLeds(QString sessionKey, QList<QRect> leds)
 	return true;
 }
 
-bool LightpackPluginInterface::NewProfile(QString sessionKey, QString profile)
+bool LightpackPluginInterface::NewProfile(const QString& sessionKey, const QString& profile)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0]!=sessionKey) return false;
@@ -477,7 +477,7 @@ bool LightpackPluginInterface::NewProfile(QString sessionKey, QString profile)
 		return true;
 }
 
-bool LightpackPluginInterface::DeleteProfile(QString sessionKey, QString profile)
+bool LightpackPluginInterface::DeleteProfile(const QString& sessionKey, const QString& profile)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0]!=sessionKey) return false;
@@ -494,7 +494,7 @@ bool LightpackPluginInterface::DeleteProfile(QString sessionKey, QString profile
 		return false;
 }
 
-bool LightpackPluginInterface::SetBacklight(QString sessionKey, int backlight)
+bool LightpackPluginInterface::SetBacklight(const QString& sessionKey, int backlight)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0]!=sessionKey) return false;
@@ -519,7 +519,7 @@ bool LightpackPluginInterface::SetBacklight(QString sessionKey, int backlight)
 	return false;
 }
 
-bool LightpackPluginInterface::SetCountLeds(QString sessionKey, int countLeds)
+bool LightpackPluginInterface::SetCountLeds(const QString& sessionKey, int countLeds)
 {
 	qWarning() << Q_FUNC_INFO << "Unsupported/deprectated API/Plugin command: SetCountLeds";
 	return false;
@@ -535,7 +535,7 @@ bool LightpackPluginInterface::SetCountLeds(QString sessionKey, int countLeds)
 
 
 #ifdef SOUNDVIZ_SUPPORT
-bool LightpackPluginInterface::SetSoundVizColors(QString sessionKey, QColor min, QColor max)
+bool LightpackPluginInterface::SetSoundVizColors(const QString& sessionKey, QColor min, QColor max)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0] != sessionKey) return false;
@@ -547,7 +547,7 @@ bool LightpackPluginInterface::SetSoundVizColors(QString sessionKey, QColor min,
 	return true;
 }
 
-bool LightpackPluginInterface::SetSoundVizLiquidMode(QString sessionKey, bool enabled)
+bool LightpackPluginInterface::SetSoundVizLiquidMode(const QString& sessionKey, bool enabled)
 {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0] != sessionKey) return false;
@@ -559,7 +559,7 @@ bool LightpackPluginInterface::SetSoundVizLiquidMode(QString sessionKey, bool en
 }
 #endif
 
-bool LightpackPluginInterface::SetPersistOnUnlock(QString sessionKey, bool enabled) {
+bool LightpackPluginInterface::SetPersistOnUnlock(const QString& sessionKey, bool enabled) {
 	if (lockSessionKeys.isEmpty()) return false;
 	if (lockSessionKeys[0] != sessionKey) return false;
 
@@ -714,26 +714,26 @@ bool LightpackPluginInterface::GetPersistOnUnlock()
 
 QString LightpackPluginInterface::GetPluginsDir()
 {
-	return	QString(Settings::getApplicationDirPath() + "Plugins");
+	return	QString(Settings::getApplicationDirPath() + QStringLiteral("Plugins"));
 }
 
 // TODO: settings (global or profile?)
-void LightpackPluginInterface::SetSettingProfile(QString key, QVariant value)
+void LightpackPluginInterface::SetSettingProfile(const QString& key, const QVariant& value)
 {
 	Settings::setValue(key,value);
 }
 
-QVariant LightpackPluginInterface::GetSettingProfile(QString key)
+QVariant LightpackPluginInterface::GetSettingProfile(const QString& key)
 {
 	return Settings::value(key);
 }
 
-void LightpackPluginInterface::SetSettingMain(QString key, QVariant value)
+void LightpackPluginInterface::SetSettingMain(const QString& key, const QVariant& value)
 {
 	Settings::setValueMain(key,value);
 }
 
-QVariant LightpackPluginInterface::GetSettingMain(QString key)
+QVariant LightpackPluginInterface::GetSettingMain(const QString& key)
 {
 	return Settings::valueMain(key);
 }

--- a/Software/src/LightpackPluginInterface.cpp
+++ b/Software/src/LightpackPluginInterface.cpp
@@ -23,7 +23,7 @@ LightpackPluginInterface::LightpackPluginInterface(QObject *parent) :
 	initColors(10);
 	m_timerLock = new QTimer(this);
 	m_timerLock->start(5000); // check in 5000 ms
-	connect(m_timerLock, SIGNAL(timeout()), this, SLOT(timeoutLock()));
+	connect(m_timerLock, &QTimer::timeout, this, &LightpackPluginInterface::timeoutLock);
 	_plugins.clear();
 }
 

--- a/Software/src/LightpackPluginInterface.cpp
+++ b/Software/src/LightpackPluginInterface.cpp
@@ -1,5 +1,5 @@
 #include <QtGui>
-#include <QtWidgets/QApplication>
+#include <QApplication>
 #include "LightpackPluginInterface.hpp"
 #include "Plugin.hpp"
 #include "Settings.hpp"

--- a/Software/src/LightpackPluginInterface.cpp
+++ b/Software/src/LightpackPluginInterface.cpp
@@ -631,8 +631,10 @@ QString LightpackPluginInterface::GetProfile()
 
 QList<QRect> LightpackPluginInterface::GetLeds()
 {
+	const int number = Settings::getNumberOfLeds(Settings::getConnectedDevice());
 	QList<QRect> leds;
-	for (int i = 0; i < Settings::getNumberOfLeds(Settings::getConnectedDevice()); i++)
+	leds.reserve(number);
+	for (int i = 0; i < number; i++)
 	{
 		QPoint top = Settings::getLedPosition(i);
 		QSize size = Settings::getLedSize(i);

--- a/Software/src/LightpackPluginInterface.hpp
+++ b/Software/src/LightpackPluginInterface.hpp
@@ -4,8 +4,7 @@
 #include <QtGui>
 #include <QObject>
 #include "enums.hpp"
-
-class Plugin;
+#include "Plugin.hpp"
 
 class LightpackPluginInterface : public QObject
 {

--- a/Software/src/LightpackPluginInterface.hpp
+++ b/Software/src/LightpackPluginInterface.hpp
@@ -16,32 +16,32 @@ public:
 
  public slots:
 // Plugin section
-	QString GetSessionKey(QString module);
-	int CheckLock(QString sessionKey);
-	bool Lock(QString sessionKey);
+	QString GetSessionKey(const QString& module);
+	int CheckLock(const QString& sessionKey);
+	bool Lock(const QString& sessionKey);
 
 // need LOCK
-	bool UnLock(QString sessionKey);
-	bool SetStatus(QString sessionKey, int status);
-	bool SetColors(QString sessionKey, int r, int g, int b);
-	bool SetFrame(QString sessionKey, QList<QColor> colors);
-	bool SetColor(QString sessionKey, int ind,int r, int g, int b);
-	bool SetGamma(QString sessionKey, double gamma);
-	bool SetBrightness(QString sessionKey, int brightness);
-	bool SetCountLeds(QString sessionKey, int countLeds);
-	bool SetSmooth(QString sessionKey, int smooth);
-	bool SetProfile(QString sessionKey, QString profile);
-	bool SetDevice(QString sessionKey,QString device);
+	bool UnLock(const QString& sessionKey);
+	bool SetStatus(const QString& sessionKey, int status);
+	bool SetColors(const QString& sessionKey, int r, int g, int b);
+	bool SetFrame(const QString& sessionKey, QList<QColor> colors);
+	bool SetColor(const QString& sessionKey, int ind,int r, int g, int b);
+	bool SetGamma(const QString& sessionKey, double gamma);
+	bool SetBrightness(const QString& sessionKey, int brightness);
+	bool SetCountLeds(const QString& sessionKey, int countLeds);
+	bool SetSmooth(const QString& sessionKey, int smooth);
+	bool SetProfile(const QString& sessionKey, const QString& profile);
+	bool SetDevice(const QString& sessionKey, const QString& device);
 #ifdef SOUNDVIZ_SUPPORT
-	bool SetSoundVizColors(QString sessionKey, QColor min, QColor max);
-	bool SetSoundVizLiquidMode(QString sessionKey, bool enabled);
+	bool SetSoundVizColors(const QString& sessionKey, QColor min, QColor max);
+	bool SetSoundVizLiquidMode(const QString& sessionKey, bool enabled);
 #endif
-	bool SetPersistOnUnlock(QString sessionKey, bool enabled);
+	bool SetPersistOnUnlock(const QString& sessionKey, bool enabled);
 
-	bool SetLeds(QString sessionKey, QList<QRect> leds);
-	bool NewProfile(QString sessionKey, QString profile);
-	bool DeleteProfile(QString sessionKey, QString profile);
-	bool SetBacklight(QString sessionKey, int backlight);
+	bool SetLeds(const QString& sessionKey, QList<QRect> leds);
+	bool NewProfile(const QString& sessionKey, const QString& profile);
+	bool DeleteProfile(const QString& sessionKey, const QString& profile);
+	bool SetBacklight(const QString& sessionKey, int backlight);
 
 // no LOCK
 	QString Version();
@@ -66,16 +66,16 @@ public:
 
 // Settings
 	QString GetPluginsDir();
-	void SetSettingProfile(QString key, QVariant value);
-	QVariant GetSettingProfile(QString key);
-	void SetSettingMain(QString key, QVariant value);
-	QVariant GetSettingMain(QString key);
+	void SetSettingProfile(const QString& key, const QVariant& value);
+	QVariant GetSettingProfile(const QString& key);
+	void SetSettingMain(const QString& key, const QVariant& value);
+	QVariant GetSettingMain(const QString& key);
 
-	bool VerifySessionKey(QString sessionKey);
-	void SetLockAlive(QString sessionKey);
+	bool VerifySessionKey(const QString& sessionKey);
+	void SetLockAlive(const QString& sessionKey);
 
 signals:
-	void ChangeProfile(QString profile);
+	void ChangeProfile(const QString& profile);
 	void ChangeStatus(int status);
 	void ChangeLockStatus(bool lock);
 
@@ -83,7 +83,7 @@ signals:
 
 signals:
 	void requestBacklightStatus();
-	void updateDeviceLockStatus(DeviceLocked::DeviceLockStatus status, QList<QString> modules);
+	void updateDeviceLockStatus(const DeviceLocked::DeviceLockStatus status, const QList<QString>& modules);
 	void updateLedsColors(const QList<QRgb> & colors);
 	void updateGamma(double value);
 	void updateBrightness(int value);
@@ -93,17 +93,17 @@ signals:
 	void updateSoundVizMaxColor(QColor color);
 	void updateSoundVizLiquid(bool value);
 #endif
-	void updateProfile(QString profileName);
+	void updateProfile(const QString& profileName);
 	void updateStatus(Backlight::Status status);
 	void updateBacklight(Lightpack::Mode status);
 	void updateCountLeds(int value);
-	void changeDevice(QString device);
+	void changeDevice(const QString& device);
 
 
 public slots:
 	void setNumberOfLeds(int numberOfLeds);
 	void resultBacklightStatus(Backlight::Status status);
-	void changeProfile(QString profile);
+	void changeProfile(const QString& profile);
 	void refreshAmbilightEvaluated(double updateResultMs);
 	void refreshScreenRect(QRect rect);
 	void updateColorsCache(const QList<QRgb> & colors);
@@ -115,7 +115,7 @@ public slots:
 	void updateSoundVizMaxColorCache(QColor color);
 	void updateSoundVizLiquidCache(bool value);
 #endif
-	void updatePlugin(QList<Plugin*> plugins);
+	void updatePlugin(const QList<Plugin*>& plugins);
 
 private slots:
 	void timeoutLock();
@@ -149,8 +149,8 @@ private:
 	void initColors(int numberOfLeds);
 
 	QList<Plugin*> _plugins;
-	Plugin* findName(QString name);
-	Plugin* findSessionKey(QString sessionKey);
+	Plugin* findName(const QString& name);
+	Plugin* findSessionKey(const QString& sessionKey);
 };
 #endif
 

--- a/Software/src/LiquidColorGenerator.cpp
+++ b/Software/src/LiquidColorGenerator.cpp
@@ -48,7 +48,7 @@ LiquidColorGenerator::LiquidColorGenerator(QObject *parent) : QObject(parent)
 
 	m_isEnabled = false;
 	m_timer.setTimerType(Qt::PreciseTimer);
-	connect(&m_timer, SIGNAL(timeout()), this, SLOT(updateColor()));
+	connect(&m_timer, SIGNAL(timeout()), this, SLOT(doColorUpdate()));
 }
 
 void LiquidColorGenerator::start()
@@ -58,7 +58,7 @@ void LiquidColorGenerator::start()
 	m_isEnabled = true;
 
 	reset();
-	updateColor();
+	doColorUpdate();
 }
 
 void LiquidColorGenerator::stop()
@@ -90,7 +90,7 @@ void LiquidColorGenerator::reset()
 	m_unselectedColors.clear();
 }
 
-void LiquidColorGenerator::updateColor()
+void LiquidColorGenerator::doColorUpdate()
 {
 	DEBUG_HIGH_LEVEL << Q_FUNC_INFO << m_speed;
 

--- a/Software/src/LiquidColorGenerator.cpp
+++ b/Software/src/LiquidColorGenerator.cpp
@@ -131,14 +131,15 @@ QColor LiquidColorGenerator::generateColor()
 {
 	if (m_unselectedColors.empty())
 	{
+		m_unselectedColors.reserve(ColorsMoodLampCount);
 		for (int i = 0; i < ColorsMoodLampCount; i++)
 			m_unselectedColors << AvailableColors[i];
 	}
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-	int randIndex = m_rnd.bounded(std::max(1, m_unselectedColors.size()));
+	int randIndex = m_rnd.bounded(std::max((QList<QColor>::size_type)1, m_unselectedColors.size()));
 #else
-	int randIndex = qrand() % std::max(1, m_unselectedColors.size());
+	int randIndex = qrand() % std::max((QList<QColor>::size_type)1, m_unselectedColors.size());
 #endif
 
 	return m_unselectedColors.takeAt(randIndex);

--- a/Software/src/LiquidColorGenerator.cpp
+++ b/Software/src/LiquidColorGenerator.cpp
@@ -48,7 +48,7 @@ LiquidColorGenerator::LiquidColorGenerator(QObject *parent) : QObject(parent)
 
 	m_isEnabled = false;
 	m_timer.setTimerType(Qt::PreciseTimer);
-	connect(&m_timer, SIGNAL(timeout()), this, SLOT(doColorUpdate()));
+	connect(&m_timer, &QTimer::timeout, this, &LiquidColorGenerator::doColorUpdate);
 }
 
 void LiquidColorGenerator::start()

--- a/Software/src/LiquidColorGenerator.hpp
+++ b/Software/src/LiquidColorGenerator.hpp
@@ -49,13 +49,13 @@ public:
 
 public slots:
 	void setSpeed(int value);
-	
+
 private:
 	int generateDelay();
 	QColor generateColor();
 
 private slots:
-	void updateColor();
+	void doColorUpdate();
 
 private:
 	bool m_isEnabled;

--- a/Software/src/LogWriter.cpp
+++ b/Software/src/LogWriter.cpp
@@ -24,8 +24,12 @@ LogWriter::~LogWriter()
 
 int LogWriter::initWith(const QString& logsDirPath)
 {
+	#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+	#warning wrap log in QStringEncoder?
+	#else
 	// Using locale codec for console output in messageHandler(..) function ( cout << qstring.toStdString() )
 	QTextCodec::setCodecForLocale(QTextCodec::codecForLocale());
+	#endif
 
 	m_logsDir.setPath(logsDirPath);
 	if (m_logsDir.exists() == false) {

--- a/Software/src/LogWriter.cpp
+++ b/Software/src/LogWriter.cpp
@@ -39,7 +39,7 @@ int LogWriter::initWith(const QString& logsDirPath)
 	if (rotateLogFiles(m_logsDir) == false)
 		std::cerr << "Failed to rotate old log files." << std::endl;
 
-	const QString logFilePath = logsDirPath + "/Prismatik.0.log";
+	const QString logFilePath = logsDirPath + QStringLiteral("/Prismatik.0.log");
 	QScopedPointer<QFile> logFile(new QFile(logFilePath));
 	if (logFile->open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
 		QMutexLocker locker(&m_mutex);
@@ -52,8 +52,8 @@ int LogWriter::initWith(const QString& logsDirPath)
 #endif
 
 		const QDateTime currentDateTime(QDateTime::currentDateTime());
-		m_logStream << currentDateTime.date().toString("yyyy_MM_dd") << " ";
-		m_logStream << currentDateTime.time().toString("hh:mm:ss:zzz") << " Prismatik " << VERSION_STR;
+		m_logStream << currentDateTime.date().toString(QStringLiteral("yyyy_MM_dd")) << QStringLiteral(" ");
+		m_logStream << currentDateTime.time().toString(QStringLiteral("hh:mm:ss:zzz")) << QStringLiteral(" Prismatik ") << QStringLiteral(VERSION_STR);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
 		m_logStream << Qt::endl;
 #else
@@ -86,8 +86,8 @@ void LogWriter::writeMessage(const QString& msg, Level level)
 	Q_ASSERT(level >= Debug && level < LevelCount);
 	Q_STATIC_ASSERT(sizeof(s_logLevelNames)/sizeof(s_logLevelNames[0]) == LevelCount);
 
-	const QString timeMark = QDateTime::currentDateTime().time().toString("hh:mm:ss:zzz");
-	const QString finalMsg = QString("%1 %2: %3\n").arg(timeMark, s_logLevelNames[level], msg);
+	const QString timeMark = QDateTime::currentDateTime().time().toString(QStringLiteral("hh:mm:ss:zzz"));
+	const QString finalMsg = QStringLiteral("%1 %2: %3\n").arg(timeMark, s_logLevelNames[level], msg);
 	QMutexLocker locker(&m_mutex);
 	cerr << finalMsg.toStdString();
 	if (!m_disabled) {
@@ -124,7 +124,7 @@ bool LogWriter::rotateLogFiles(const QDir& logsDir)
 	if (!logsDir.exists())
 		return false;
 
-	QStringList logFiles = logsDir.entryList(QStringList("Prismatik.?.log"), QDir::Files, QDir::Name);
+	QStringList logFiles = logsDir.entryList(QStringList(QStringLiteral("Prismatik.?.log")), QDir::Files, QDir::Name);
 	// Delete all old files except last |StoreLogsLaunches| files.
 	for (int i = logFiles.count() - 1; i >= StoreLogsLaunches - 1; i--)
 	{
@@ -134,7 +134,7 @@ bool LogWriter::rotateLogFiles(const QDir& logsDir)
 		}
 	}
 
-	logFiles = logsDir.entryList(QStringList("Prismatik.?.log"), QDir::Files, QDir::Name);
+	logFiles = logsDir.entryList(QStringList(QStringList(QStringLiteral("Prismatik.?.log"))), QDir::Files, QDir::Name);
 	Q_ASSERT(logFiles.count() <= StoreLogsLaunches);
 	// Move Prismatik.[N].log file to Prismatik.[N+1].log
 	for (int i = logFiles.count() - 1; i >= 0; i--)
@@ -144,7 +144,7 @@ bool LogWriter::rotateLogFiles(const QDir& logsDir)
 
 		const int num = splitted.at(1).toInt();
 		const QString from = logsDir.absoluteFilePath(logFiles.at(i));
-		const QString to = logsDir.absoluteFilePath(QString("Prismatik.") + QString::number(num + 1) + ".log");
+		const QString to = logsDir.absoluteFilePath(QStringLiteral("Prismatik.") + QString::number(num + 1) + QStringLiteral(".log"));
 
 		if (QFile::exists(to))
 			QFile::remove(to);

--- a/Software/src/LogWriter.cpp
+++ b/Software/src/LogWriter.cpp
@@ -24,9 +24,7 @@ LogWriter::~LogWriter()
 
 int LogWriter::initWith(const QString& logsDirPath)
 {
-	#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-	#warning wrap log in QStringEncoder?
-	#else
+	#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	// Using locale codec for console output in messageHandler(..) function ( cout << qstring.toStdString() )
 	QTextCodec::setCodecForLocale(QTextCodec::codecForLocale());
 	#endif

--- a/Software/src/MacOSSession.h
+++ b/Software/src/MacOSSession.h
@@ -16,7 +16,11 @@ namespace SystemSession {
     public:
         MacOSEventFilter();
         ~MacOSEventFilter();
+        #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        bool nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result);
+        #else
         bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) Q_DECL_OVERRIDE;
+        #endif
     private:
         class NativeWrapper;
         NativeWrapper* _wrapper;

--- a/Software/src/MacOSSession.mm
+++ b/Software/src/MacOSSession.mm
@@ -88,7 +88,11 @@ namespace SystemSession
         _wrapper = nullptr;
     }
 
+    #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    bool MacOSEventFilter::nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result)
+    #else
     bool MacOSEventFilter::nativeEventFilter(const QByteArray& eventType, void* message, long* result)
+    #endif
     {
         Q_UNUSED(result);
         if (eventType != NSNotificationEventType)

--- a/Software/src/MoodLamp.cpp
+++ b/Software/src/MoodLamp.cpp
@@ -75,7 +75,7 @@ class _OBJ_NAME_ ## MoodLamp : public MoodLampBase \
 public:\
 _OBJ_NAME_ ## MoodLamp() : MoodLampBase() {};\
 ~_OBJ_NAME_ ## MoodLamp() = default;\
-static const char* const name() { return _LABEL_; };\
+static const char* name() { return _LABEL_; };\
 static MoodLampBase* create() { return new _OBJ_NAME_ ## MoodLamp(); };\
 \
 _BODY_\
@@ -139,9 +139,9 @@ public:
 			return false;
 
 		if (colors.size() > m_lightness.size()) {
-			const size_t oldSize = m_lightness.size();
+			const int oldSize = m_lightness.size();
 			m_lightness.reserve(colors.size());
-			for (size_t i = oldSize; i < colors.size(); ++i)
+			for (int i = oldSize; i < colors.size(); ++i)
 				m_lightness << 0;
 		}
 

--- a/Software/src/MoodLamp.cpp
+++ b/Software/src/MoodLamp.cpp
@@ -113,7 +113,7 @@ void MoodLampBase::populateNameList(QList<MoodLampLampInfo>& list, int& recommen
 
 DECLARE_LAMP(Static, "Static (default)",
 public:
-	int interval() const { return 50; };
+	std::chrono::milliseconds interval() const { return 50ms; };
 
 	bool shine(const QColor& newColor, QList<QRgb>& colors)
 	{

--- a/Software/src/MoodLamp.cpp
+++ b/Software/src/MoodLamp.cpp
@@ -96,8 +96,8 @@ namespace {
 }
 
 MoodLampBase* MoodLampBase::createWithID(const int id) {
-	QMap<int, MoodLampLampInfo>::const_iterator i = g_moodLampMap.find(id);
-	if (i != g_moodLampMap.end())
+	QMap<int, MoodLampLampInfo>::const_iterator i = g_moodLampMap.constFind(id);
+	if (i != g_moodLampMap.cend())
 		return i.value().factory();
 	qWarning() << Q_FUNC_INFO << "failed to find mood lamp ID: " << id;
 	return nullptr;

--- a/Software/src/MoodLamp.hpp
+++ b/Software/src/MoodLamp.hpp
@@ -33,8 +33,8 @@ class MoodLampBase;
 typedef MoodLampBase* (*LampFactory)();
 
 struct MoodLampLampInfo {
-	MoodLampLampInfo() { this->name = ""; this->id = -1; this->factory = nullptr; }
-	MoodLampLampInfo(QString name, LampFactory factory, int id) { this->name = name; this->id = id; this->factory = factory; }
+	MoodLampLampInfo() { this->name = QLatin1String(""); this->id = -1; this->factory = nullptr; }
+	MoodLampLampInfo(const QString& name, LampFactory factory, int id) { this->name = name; this->id = id; this->factory = factory; }
 	QString name;
 	LampFactory factory;
 	int id;
@@ -47,7 +47,7 @@ public:
 	MoodLampBase() { init(); };
 	virtual ~MoodLampBase() = default;
 
-	static const char* const name() { return "NO_NAME"; };
+	static const char* name() { return "NO_NAME"; };
 	static MoodLampBase* create() { Q_ASSERT_X(false, "MoodLampBase::create()", "not implemented"); return nullptr; };
 	static MoodLampBase* createWithID(const int id);
 	static void populateNameList(QList<MoodLampLampInfo>& list, int& recommended);

--- a/Software/src/MoodLamp.hpp
+++ b/Software/src/MoodLamp.hpp
@@ -58,5 +58,6 @@ public:
 protected:
 	size_t m_frames{ 0 };
 private:
+	Q_DISABLE_COPY(MoodLampBase)
 	const std::chrono::milliseconds DefaultInterval = 33ms;
 };

--- a/Software/src/MoodLamp.hpp
+++ b/Software/src/MoodLamp.hpp
@@ -28,6 +28,7 @@
 #include <QObject>
 #include <QColor>
 
+using namespace std::chrono_literals;
 class MoodLampBase;
 
 typedef MoodLampBase* (*LampFactory)();
@@ -40,7 +41,6 @@ struct MoodLampLampInfo {
 	int id;
 };
 Q_DECLARE_METATYPE(MoodLampLampInfo);
-
 class MoodLampBase
 {
 public:
@@ -53,10 +53,10 @@ public:
 	static void populateNameList(QList<MoodLampLampInfo>& list, int& recommended);
 
 	virtual void init() {};
-	virtual int interval() const { return DefaultInterval; };
+	virtual std::chrono::milliseconds interval() const { return DefaultInterval; };
 	virtual bool shine(const QColor& newColor, QList<QRgb>& colors) = 0;
 protected:
 	size_t m_frames{ 0 };
 private:
-	const int DefaultInterval = 33;
+	const std::chrono::milliseconds DefaultInterval = 33ms;
 };

--- a/Software/src/MoodLampManager.cpp
+++ b/Software/src/MoodLampManager.cpp
@@ -37,7 +37,7 @@ MoodLampManager::MoodLampManager(QObject *parent) : QObject(parent)
 	m_isMoodLampEnabled = false;
 
 	m_timer.setTimerType(Qt::PreciseTimer);
-	connect(&m_timer, SIGNAL(timeout()), this, SLOT(updateColors()));
+	connect(&m_timer, &QTimer::timeout, this, qOverload<>(&MoodLampManager::updateColors));
 	initFromSettings();
 }
 

--- a/Software/src/MoodLampManager.hpp
+++ b/Software/src/MoodLampManager.hpp
@@ -62,7 +62,8 @@ public slots:
 	void setSendDataOnlyIfColorsChanged(bool state);
 
 private slots:
-	void updateColors(const bool forceUpdate = false);
+	void updateColors(const bool forceUpdate);
+	void updateColors() { updateColors(false); };
 
 private:
 	void initColors(int numberOfLeds);

--- a/Software/src/Plugin.cpp
+++ b/Software/src/Plugin.cpp
@@ -23,7 +23,7 @@ Plugin::Plugin(const QString& name, const QString& path, QObject *parent) :
 	_pathPlugin = path;
 	QDir pluginPath(_pathPlugin);
 
-	const QString fileName(path+QStringLiteral("/")+name+QStringLiteral(".ini"));
+	const QString fileName(QStringLiteral("%1/%2.ini").arg(path, name));
 	if (!QFile::exists(fileName)) {
 		qWarning() << Q_FUNC_INFO << name << fileName << "does not exist, generating defaults, make sure to edit the file!";
 		if (!QFile::copy(QStringLiteral(":/plugin-template.ini"), fileName))
@@ -97,23 +97,23 @@ QIcon Plugin::Icon() const {
 
 
 int Plugin::getPriority() const {
-	const QString key = _name+QStringLiteral("/Priority");
+	const QString key = QStringLiteral("%1/Priority").arg(_name);
 	return Settings::valueMain(key).toInt();
 }
 
 void Plugin::setPriority(int priority) {
-	const QString key = _name+QStringLiteral("/Priority");
+	const QString key = QStringLiteral("%1/Priority").arg(_name);
 	Settings::setValueMain(key,priority);
 }
 
 bool Plugin::isEnabled() const {
-	const QString key = _name+QStringLiteral("/Enable");
+	const QString key = QStringLiteral("%1/Enable").arg(_name);
 	return Settings::valueMain(key).toBool();
 }
 
 void Plugin::setEnabled(bool enable) {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << _name << enable;
-	const QString key = _name+QStringLiteral("/Enable");
+	const QString key = QStringLiteral("%1/Enable").arg(_name);
 	Settings::setValueMain(key,enable);
 	if (!enable) Stop();
 	if (enable) Start();

--- a/Software/src/Plugin.cpp
+++ b/Software/src/Plugin.cpp
@@ -9,38 +9,38 @@
 using namespace SettingsScope;
 
 #if defined(Q_OS_WIN)
-	const QString kOsSpecificExecuteKey = "ExecuteOnWindows";
+	const QString kOsSpecificExecuteKey = QStringLiteral("ExecuteOnWindows");
 #elif defined(MAC_OS)
-	const QString kOsSpecificExecuteKey = "ExecuteOnOSX";
+	const QString kOsSpecificExecuteKey = QStringLiteral("ExecuteOnOSX");
 #elif defined(Q_OS_UNIX)
-	const QString kOsSpecificExecuteKey = "ExecuteOnNix";
+	const QString kOsSpecificExecuteKey = QStringLiteral("ExecuteOnNix");
 #endif
 
-Plugin::Plugin(QString name, QString path, QObject *parent) :
+Plugin::Plugin(const QString& name, const QString& path, QObject *parent) :
 	QObject(parent)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << name << path;
 	_pathPlugin = path;
 	QDir pluginPath(_pathPlugin);
 
-	const QString fileName(path+"/"+name+".ini");
+	const QString fileName(path+QStringLiteral("/")+name+QStringLiteral(".ini"));
 	if (!QFile::exists(fileName)) {
 		qWarning() << Q_FUNC_INFO << name << fileName << "does not exist, generating defaults, make sure to edit the file!";
-		if (!QFile::copy(":/plugin-template.ini", fileName))
+		if (!QFile::copy(QStringLiteral(":/plugin-template.ini"), fileName))
 			qWarning() << Q_FUNC_INFO << name << "failed to generate" << fileName;
 		else if (!QFile::setPermissions(fileName, QFile::permissions(fileName) | QFileDevice::WriteOwner))
 			qWarning() << Q_FUNC_INFO << name << "could not set write permissions to" << fileName;
 	}
 	QSettings settings(fileName, QSettings::IniFormat);
-	settings.beginGroup("Main");
-	_name = settings.value("Name", "").toString();
+	settings.beginGroup(QStringLiteral("Main"));
+	_name = settings.value(QStringLiteral("Name"), QLatin1String("")).toString();
 	if (_name.isEmpty())
 		_name = name;
 
 	if (settings.contains(kOsSpecificExecuteKey))
-		_arguments = settings.value(kOsSpecificExecuteKey, "").toString().split(' ');
+		_arguments = settings.value(kOsSpecificExecuteKey, QLatin1String("")).toString().split(' ');
 	else
-		_arguments = settings.value("Execute", "").toString().split(' ');
+		_arguments = settings.value(QStringLiteral("Execute"), QLatin1String("")).toString().split(' ');
 
 	if (!_arguments.isEmpty())
 		_exec = _arguments.takeFirst();
@@ -48,17 +48,17 @@ Plugin::Plugin(QString name, QString path, QObject *parent) :
 	if (_exec.isEmpty())
 		qWarning() << Q_FUNC_INFO << name << "no executable, check" << fileName;
 
-	_guid = settings.value("Guid", "").toString();
-	_author = settings.value("Author", "").toString();
-	_description = settings.value("Description", "").toString();
-	_version = settings.value("Version", "").toString();
+	_guid = settings.value(QStringLiteral("Guid"), QLatin1String("")).toString();
+	_author = settings.value(QStringLiteral("Author"), QLatin1String("")).toString();
+	_description = settings.value(QStringLiteral("Description"), QLatin1String("")).toString();
+	_version = settings.value(QStringLiteral("Version"), QLatin1String("")).toString();
 
-	const QString iconName = settings.value("Icon", "").toString();
+	const QString iconName = settings.value(QStringLiteral("Icon"), QLatin1String("")).toString();
 	const QString iconPath = pluginPath.absoluteFilePath(iconName);
 	if (!iconName.isEmpty() && QFile::exists(iconPath) && !QImageReader::imageFormat(iconPath).isEmpty())
 		_icon = QIcon(iconPath);
 	if (_icon.isNull())
-		_icon = QIcon(":/icons/plugins.png");
+		_icon = QIcon(QStringLiteral(":/icons/plugins.png"));
 
 	settings.endGroup();
 
@@ -97,23 +97,23 @@ QIcon Plugin::Icon() const {
 
 
 int Plugin::getPriority() const {
-	const QString key = _name+"/Priority";
+	const QString key = _name+QStringLiteral("/Priority");
 	return Settings::valueMain(key).toInt();
 }
 
 void Plugin::setPriority(int priority) {
-	const QString key = _name+"/Priority";
+	const QString key = _name+QStringLiteral("/Priority");
 	Settings::setValueMain(key,priority);
 }
 
 bool Plugin::isEnabled() const {
-	const QString key = _name+"/Enable";
+	const QString key = _name+QStringLiteral("/Enable");
 	return Settings::valueMain(key).toBool();
 }
 
 void Plugin::setEnabled(bool enable) {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << _name << enable;
-	const QString key = _name+"/Enable";
+	const QString key = _name+QStringLiteral("/Enable");
 	Settings::setValueMain(key,enable);
 	if (!enable) Stop();
 	if (enable) Start();

--- a/Software/src/Plugin.cpp
+++ b/Software/src/Plugin.cpp
@@ -133,7 +133,7 @@ void Plugin::Start()
 	connect(process, SIGNAL(errorOccurred(QProcess::ProcessError)), this, SLOT(errorOccurred(QProcess::ProcessError)));
 
 	connect(process, SIGNAL(started()), this, SLOT(started()));
-	connect(process, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(finished(int, QProcess::ExitStatus)));
+	connect(process, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(finished(int,QProcess::ExitStatus)));
 
 	connect(process, SIGNAL(readyReadStandardError()), this, SLOT(readyReadStandardError()));
 	connect(process, SIGNAL(readyReadStandardOutput()), this, SLOT(readyReadStandardOutput()));

--- a/Software/src/Plugin.cpp
+++ b/Software/src/Plugin.cpp
@@ -129,14 +129,14 @@ void Plugin::Start()
 
 	process->disconnect();
 
-	connect(process, SIGNAL(stateChanged(QProcess::ProcessState)), this, SLOT(stateChanged(QProcess::ProcessState)));
-	connect(process, SIGNAL(errorOccurred(QProcess::ProcessError)), this, SLOT(errorOccurred(QProcess::ProcessError)));
+	connect(process, &QProcess::stateChanged, this, &Plugin::stateChanged);
+	connect(process, &QProcess::errorOccurred, this, &Plugin::errorOccurred);
 
-	connect(process, SIGNAL(started()), this, SLOT(started()));
-	connect(process, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(finished(int,QProcess::ExitStatus)));
+	connect(process, &QProcess::started, this, &Plugin::started);
+	connect(process, qOverload<int,QProcess::ExitStatus>(&QProcess::finished), this, &Plugin::finished);
 
-	connect(process, SIGNAL(readyReadStandardError()), this, SLOT(readyReadStandardError()));
-	connect(process, SIGNAL(readyReadStandardOutput()), this, SLOT(readyReadStandardOutput()));
+	connect(process, &QProcess::readyReadStandardError, this, &Plugin::readyReadStandardError);
+	connect(process, &QProcess::readyReadStandardOutput, this, &Plugin::readyReadStandardOutput);
 
 	process->setEnvironment(QProcess::systemEnvironment());
 	process->setProgram(_exec);

--- a/Software/src/Plugin.hpp
+++ b/Software/src/Plugin.hpp
@@ -9,7 +9,7 @@ class Plugin : public QObject
 {
 	Q_OBJECT
 public:
-	Plugin(QString name, QString path,QObject *parent = 0);
+	Plugin(const QString& name, const QString& path, QObject *parent = 0);
 	~Plugin();
 
 	void Start();

--- a/Software/src/PluginsManager.cpp
+++ b/Software/src/PluginsManager.cpp
@@ -23,7 +23,7 @@ void PluginsManager::dropPlugins(){
 	//cleanAll();
 	for(QMap<QString, Plugin*>::iterator it = _plugins.begin(); it != _plugins.end(); ++it){
 		Plugin* p = it.value();
-		QString name = p->Name();
+		// QString name = p->Name();
 		p->Stop();
 		delete p;
 	}
@@ -33,18 +33,18 @@ void PluginsManager::dropPlugins(){
 void PluginsManager::reloadPlugins(){
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	dropPlugins();
-	LoadPlugins(QString(Settings::getApplicationDirPath() + "Plugins"));
+	LoadPlugins(Settings::getApplicationDirPath() + QStringLiteral("Plugins"));
 	StartPlugins();
 }
 
-void PluginsManager::LoadPlugins(QString path)
+void PluginsManager::LoadPlugins(const QString& path)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << path;
 
 	QDir dir(path);
 
 	if (!dir.exists()) {
-		dir.mkpath(".");
+		dir.mkpath(QStringLiteral("."));
 	}
 
 	QStringList lstDirs = dir.entryList(QDir::Dirs |
@@ -60,7 +60,7 @@ void PluginsManager::LoadPlugins(QString path)
 				continue;
 			}
 
-			Plugin* p = new Plugin(plugin,path+"/"+pluginDir,this);
+			Plugin* p = new Plugin(plugin,path+QStringLiteral("/")+pluginDir,this);
 			//DEBUG_LOW_LEVEL <<p->getName()<<	p->getAuthor() << p->getDescription() << p->getVersion();
 			//connect(p, SIGNAL(executed()), this, SIGNAL(pluginExecuted()));
 			_plugins[plugin] = p;

--- a/Software/src/PluginsManager.cpp
+++ b/Software/src/PluginsManager.cpp
@@ -20,10 +20,9 @@ PluginsManager::~PluginsManager()
 
 void PluginsManager::dropPlugins(){
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
-	//cleanAll();
+
 	for(QMap<QString, Plugin*>::iterator it = _plugins.begin(); it != _plugins.end(); ++it){
 		Plugin* p = it.value();
-		// QString name = p->Name();
 		p->Stop();
 		delete p;
 	}

--- a/Software/src/PluginsManager.cpp
+++ b/Software/src/PluginsManager.cpp
@@ -60,7 +60,7 @@ void PluginsManager::LoadPlugins(const QString& path)
 				continue;
 			}
 
-			Plugin* p = new Plugin(plugin,path+QStringLiteral("/")+pluginDir,this);
+			Plugin* p = new Plugin(plugin, QStringLiteral("%1/%2").arg(path, pluginDir), this);
 			//DEBUG_LOW_LEVEL <<p->getName()<<	p->getAuthor() << p->getDescription() << p->getVersion();
 			//connect(p, SIGNAL(executed()), this, SIGNAL(pluginExecuted()));
 			_plugins[plugin] = p;

--- a/Software/src/PluginsManager.cpp
+++ b/Software/src/PluginsManager.cpp
@@ -93,7 +93,7 @@ void PluginsManager::StartPlugins()
 			p->disconnect();
 			if (p->isEnabled())
 				p->Start();
-			connect(p, SIGNAL(pluginStateChanged(QProcess::ProcessState)), this, SLOT(onPluginStateChangedHandler()));
+			connect(p, &Plugin::pluginStateChanged, this, &PluginsManager::onPluginStateChangedHandler);
 		}
 
 }
@@ -109,9 +109,10 @@ void PluginsManager::StopPlugins()
 
 }
 
-void PluginsManager::onPluginStateChangedHandler()
+void PluginsManager::onPluginStateChangedHandler(QProcess::ProcessState state)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
+	Q_UNUSED(state)
 
 	emit updatePlugin(_plugins.values());
 }

--- a/Software/src/PluginsManager.hpp
+++ b/Software/src/PluginsManager.hpp
@@ -30,7 +30,7 @@ public slots:
 	void StopPlugins();
 
 private slots:
-	void onPluginStateChangedHandler();
+	void onPluginStateChangedHandler(QProcess::ProcessState state);
 
 };
 

--- a/Software/src/PluginsManager.hpp
+++ b/Software/src/PluginsManager.hpp
@@ -3,8 +3,7 @@
 #include <QObject>
 #include <QMap>
 #include <QProcess>
-
-class Plugin;
+#include "Plugin.hpp"
 
 class PluginsManager : public QObject
 {

--- a/Software/src/PluginsManager.hpp
+++ b/Software/src/PluginsManager.hpp
@@ -13,17 +13,17 @@ public:
 	PluginsManager(QObject *parent = 0);
 	virtual ~PluginsManager();
 
-	void LoadPlugins(QString path);
+	void LoadPlugins(const QString& path);
 	QList<Plugin*> getPluginList();
 	Plugin* getPlugin(const QString& name_);
-	
+
 private:
 	void dropPlugins();
 	QMap<QString, Plugin*> _plugins;
 
 signals:
 	void updatePlugin(QList<Plugin*>);
-	
+
 public slots:
 	void reloadPlugins();
 	void StartPlugins();

--- a/Software/src/PulseAudioSoundManager.cpp
+++ b/Software/src/PulseAudioSoundManager.cpp
@@ -310,10 +310,10 @@ void PulseAudioSoundManager::start(bool isEnabled)
 				qInfo() << "Pulseaudio device: Default device";
 			}
 
-			ret = pa_stream_connect_record(m_stream, dev.length() ? dev.toUtf8().constData() : nullptr, &buffer_attr, PA_STREAM_ADJUST_LATENCY);
+			ret = pa_stream_connect_record(m_stream, !dev.isEmpty() ? dev.toUtf8().constData() : nullptr, &buffer_attr, PA_STREAM_ADJUST_LATENCY);
 
 			if (ret != PA_OK) {
-				qCritical() << "Pulseaudio failed to connect to device" << (dev.length() ? dev : "Default device");
+				qCritical() << "Pulseaudio failed to connect to device" << (!dev.isEmpty() ? dev : QStringLiteral("Default device"));
 				goto unlock_and_fail;
 			}
 

--- a/Software/src/PulseAudioSoundManager.cpp
+++ b/Software/src/PulseAudioSoundManager.cpp
@@ -217,7 +217,7 @@ void PulseAudioSoundManager::addDevice(const pa_source_info *l, int eol)
 void PulseAudioSoundManager::populatePulseaudioDeviceList()
 {
 	m_devices.clear();
-	m_devices.push_back({"Default device", ""});
+	m_devices.push_back({QStringLiteral("Default device"), QLatin1String("")});
 
 	pa_operation *pa_op;
 	pa_op = pa_context_get_source_info_list(m_context,

--- a/Software/src/PulseAudioSoundManager.cpp
+++ b/Software/src/PulseAudioSoundManager.cpp
@@ -346,8 +346,9 @@ void PulseAudioSoundManager::start(bool isEnabled)
 		}
 
 		// setup update timer (40hz)
-		m_timer.start(25);
-		m_pa_alive_timer.start(1000);
+		using namespace std::chrono_literals;
+		m_timer.start(25ms);
+		m_pa_alive_timer.start(1s);
 	}
 	else
 	{

--- a/Software/src/PulseAudioSoundManager.cpp
+++ b/Software/src/PulseAudioSoundManager.cpp
@@ -105,7 +105,7 @@ static void pa_context_state_cb(pa_context *c, void *userdata)
 PulseAudioSoundManager::PulseAudioSoundManager(QObject *parent) : SoundManagerBase(parent)
 {
 	m_timer.setTimerType(Qt::PreciseTimer);
-	connect(&m_timer, SIGNAL(timeout()), this, SLOT(updateColors()));
+	connect(&m_timer, &QTimer::timeout, this, &PulseAudioSoundManager::updateColors);
 
 	m_pa_alive_timer.setTimerType(Qt::PreciseTimer);
 	connect(&m_pa_alive_timer, &QTimer::timeout, this, &PulseAudioSoundManager::checkPulse);

--- a/Software/src/PulseAudioSoundManager.hpp
+++ b/Software/src/PulseAudioSoundManager.hpp
@@ -48,6 +48,7 @@ enum w_type
 
 class PulseAudioSoundManager : public SoundManagerBase
 {
+	Q_OBJECT
 public:
 	PulseAudioSoundManager(QObject *parent = 0);
 	virtual ~PulseAudioSoundManager();

--- a/Software/src/SelectWidget.cpp
+++ b/Software/src/SelectWidget.cpp
@@ -1,5 +1,5 @@
 #include "SelectWidget.hpp"
-#include <QtWidgets/QScrollBar>
+#include <QScrollBar>
 #include <QResizeEvent>
 SelectWidget::SelectWidget() {
 	list = new QListWidget(this);

--- a/Software/src/SelectWidget.cpp
+++ b/Software/src/SelectWidget.cpp
@@ -5,8 +5,8 @@ SelectWidget::SelectWidget() {
 	list = new QListWidget(this);
 	upButton = new QPushButton(this);
 	downButton = new QPushButton(this);
-	connect(upButton, SIGNAL(clicked()), this, SLOT(MoveUp()));
-	connect(downButton, SIGNAL(clicked()), this, SLOT(MoveDown()));
+	connect(upButton, &QPushButton::clicked, this, &SelectWidget::MoveUp);
+	connect(downButton, &QPushButton::clicked, this, &SelectWidget::MoveDown);
 	list->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 }
 SelectWidget::SelectWidget(QWidget *parent) {
@@ -14,8 +14,8 @@ SelectWidget::SelectWidget(QWidget *parent) {
 	list = new QListWidget(this);
 	upButton = new QPushButton(this);
 	downButton = new QPushButton(this);
-	connect(upButton, SIGNAL(clicked()), this, SLOT(MoveUp()));
-	connect(downButton, SIGNAL(clicked()), this, SLOT(MoveDown()));
+	connect(upButton, &QPushButton::clicked, this, &SelectWidget::MoveUp);
+	connect(downButton, &QPushButton::clicked, this, &SelectWidget::MoveDown);
 	list->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 }
 void SelectWidget::MoveUp() {

--- a/Software/src/SelectWidget.hpp
+++ b/Software/src/SelectWidget.hpp
@@ -1,9 +1,9 @@
 #ifndef SELECTWIDGET_HPP
 #define SELECTWIDGET_HPP
 
-#include <QtWidgets/QWidget>
-#include <QtWidgets/QPushButton>
-#include <QtWidgets/QListWidget>
+#include <QWidget>
+#include <QPushButton>
+#include <QListWidget>
 
 		class SelectWidget: public QWidget {
 			Q_OBJECT

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -310,7 +310,9 @@ bool Settings::Initialize( const QString & applicationDirPath, bool isDebugLevel
 	bool settingsWasPresent = QFileInfo::exists(mainConfigPath);
 
 	m_mainConfig = new QSettings(mainConfigPath, QSettings::IniFormat);
+	#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	m_mainConfig->setIniCodec("UTF-8");
+	#endif
 
 	setNewOptionMain(Main::Key::MainConfigVersion,		Main::Value::MainConfigVersion /* rewrite */);
 	setNewOptionMain(Main::Key::ProfileLast,			Main::ProfileNameDefault);
@@ -400,8 +402,10 @@ bool Settings::Initialize( const QString & applicationDirPath, bool isDebugLevel
 	QString profileLast = getLastProfileName();
 
 	// Load last profile
-	m_currentProfile = new QSettings(getProfilesPath() + profileLast + QStringLiteral(".ini"), QSettings::IniFormat);
+	m_currentProfile = new QSettings(QStringLiteral("%1%2.ini").arg(getProfilesPath(), profileLast), QSettings::IniFormat);
+	#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	m_currentProfile->setIniCodec("UTF-8");
+	#endif
 
 	DEBUG_LOW_LEVEL << "Settings file:" << m_currentProfile->fileName();
 
@@ -469,7 +473,9 @@ void Settings::loadOrCreateProfile(const QString & profileName)
 	}
 
 	m_currentProfile = new QSettings(profileNewPath, QSettings::IniFormat);
+	#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	m_currentProfile->setIniCodec("UTF-8");
+	#endif
 
 	locker.unlock();
 	initCurrentProfile(false);
@@ -504,8 +510,10 @@ void Settings::renameCurrentProfile(const QString & profileName)
 		delete m_currentProfile;
 
 		// Update m_currentProfile point to new QSettings with configName
-		m_currentProfile = new QSettings(getProfilesPath() + profileName + QStringLiteral(".ini"), QSettings::IniFormat );
+		m_currentProfile = new QSettings(QStringLiteral("%1%2.ini").arg(getProfilesPath(), profileName), QSettings::IniFormat);
+		#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 		m_currentProfile->setIniCodec("UTF-8");
+		#endif
 
 		DEBUG_LOW_LEVEL << "Settings file renamed:" << m_currentProfile->fileName();
 

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -28,7 +28,7 @@
 
 #include <QtDebug>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QKeySequence>
 #include <QSize>
 #include <QPoint>
 #include <QFileInfo>

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -448,27 +448,27 @@ void Settings::loadOrCreateProfile(const QString & profileName)
 {
 	DEBUG_MID_LEVEL << Q_FUNC_INFO << profileName;
 
-
 	QMutexLocker locker(&m_mutex);
-	QString currentProfileFileName = m_currentProfile != NULL ? m_currentProfile->fileName() : NULL;
+	QString currentProfileFileName;
+	if (m_currentProfile != NULL)
+		currentProfileFileName = m_currentProfile->fileName();
 
-	if (currentProfileFileName != NULL
-		&& currentProfileFileName.compare(getProfilesPath() + profileName + QStringLiteral(".ini")) == 0)
+	const QString profileNewPath = QStringLiteral("%1%2.ini").arg(getProfilesPath(), profileName);
+
+	if (!currentProfileFileName.isEmpty()
+		&& currentProfileFileName.compare(profileNewPath) == 0)
 		return; //nothing to change, profile is already loaded
 
-	if (currentProfileFileName != NULL)
+	if (!currentProfileFileName.isEmpty())
 	{
 		// Copy current settings to new one
-		QString profileNewPath = getProfilesPath() + profileName + QStringLiteral(".ini");
-
 		if (currentProfileFileName != profileNewPath)
 			QFile::copy(currentProfileFileName, profileNewPath);
 
 		delete m_currentProfile;
 	}
 
-
-	m_currentProfile = new QSettings(getProfilesPath() + profileName + QStringLiteral(".ini"), QSettings::IniFormat );
+	m_currentProfile = new QSettings(profileNewPath, QSettings::IniFormat);
 	m_currentProfile->setIniCodec("UTF-8");
 
 	locker.unlock();

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -435,6 +435,7 @@ QStringList Settings::findAllProfiles()
 	QFileInfoList iniFiles = setsFile.absoluteDir().entryInfoList(QStringList(QStringLiteral("*.ini")));
 
 	QStringList settingsFiles;
+	settingsFiles.reserve(iniFiles.count());
 	for(int i=0; i<iniFiles.count(); i++){
 		QString compBaseName = iniFiles.at(i).completeBaseName();
 		settingsFiles.append(compBaseName);
@@ -1826,6 +1827,7 @@ QList<WBAdjustment> Settings::getLedCoefs()
 	QList<WBAdjustment> result;
 	const int numOfLeds = getNumberOfLeds(getConnectedDevice());
 
+	result.reserve(numOfLeds);
 	for (int led = 0; led < numOfLeds; ++led)
 		result.append(getLedAdjustment(led));
 

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -501,7 +501,7 @@ void Settings::renameCurrentProfile(const QString & profileName)
 
 	// Copy current settings to new one
 	QString profilesDir = QFileInfo( m_currentProfile->fileName() ).absoluteDir().absolutePath();
-	QString profileNewPath = profilesDir + QStringLiteral("/") + profileName + ".ini";
+	QString profileNewPath = QStringLiteral("%1/%2.ini").arg(profilesDir, profileName);
 
 	if (m_currentProfile->fileName() != profileNewPath)
 	{
@@ -1880,31 +1880,32 @@ void Settings::setLedCoefBlue(int ledIndex, double value)
 
 QSize Settings::getLedSize(int ledIndex)
 {
-	return value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::Size).toSize();
+	return value(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(ledIndex + 1), Profile::Key::Led::Size)).toSize();
 }
 
 void Settings::setLedSize(int ledIndex, QSize size)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
-	setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::Size, size);
+	setValue(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(ledIndex + 1), Profile::Key::Led::Size), size);
 	emit m_this->ledSizeChanged(ledIndex, size);
 }
 
 QPoint Settings::getLedPosition(int ledIndex)
 {
-	return value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::Position).toPoint();
+	return value(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(ledIndex + 1), Profile::Key::Led::Position)).toPoint();
 }
 
 void Settings::setLedPosition(int ledIndex, QPoint position)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
-	setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::Position, position);
+	setValue(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(ledIndex + 1), Profile::Key::Led::Position), position);
 	emit m_this->ledPositionChanged(ledIndex, position);
 }
 
 bool Settings::isLedEnabled(int ledIndex)
 {
-	QVariant result = value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::IsEnabled);
+
+	QVariant result = value(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(ledIndex + 1), Profile::Key::Led::IsEnabled));
 	if (result.isNull())
 		return Profile::Led::IsEnabledDefault;
 	else
@@ -1914,7 +1915,7 @@ bool Settings::isLedEnabled(int ledIndex)
 void Settings::setLedEnabled(int ledIndex, bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
-	setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::IsEnabled, isEnabled);
+	setValue(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(ledIndex + 1), Profile::Key::Led::IsEnabled), isEnabled);
 	emit m_this->ledEnabledChanged(ledIndex, isEnabled);
 }
 
@@ -2020,8 +2021,8 @@ int Settings::getValidGrabOverBrighten(int value)
 void Settings::setValidLedCoef(int ledIndex, const QString & keyCoef, double coef)
 {
 	if (coef < Profile::Led::CoefMin || coef > Profile::Led::CoefMax){
-		QString error = QStringLiteral("Error: outside the valid values (coef < ") +
-				QString::number(Profile::Led::CoefMin) + QStringLiteral(" || coef > ") + QString::number(Profile::Led::CoefMax) + QStringLiteral(").");
+		const QString error = QStringLiteral("Error: outside the valid values (coef < %1 || coef > %2)")
+			.arg(QString::number(Profile::Led::CoefMin), QString::number(Profile::Led::CoefMax));
 
 		qWarning() << Q_FUNC_INFO << "Settings bad value"
 					<< "[" + Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "]"
@@ -2030,19 +2031,19 @@ void Settings::setValidLedCoef(int ledIndex, const QString & keyCoef, double coe
 					<< "Convert to double error. Set it to default value" << keyCoef << "=" << Profile::Led::CoefDefault;
 		coef = Profile::Led::CoefDefault;
 	}
-	Settings::setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + keyCoef, coef);
+	Settings::setValue(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(ledIndex + 1), keyCoef), coef);
 }
 
 double Settings::getValidLedCoef(int ledIndex, const QString & keyCoef)
 {
 	bool ok = false;
-	double coef = Settings::value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + keyCoef).toDouble(&ok);
+	double coef = Settings::value(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(ledIndex + 1), keyCoef)).toDouble(&ok);
 	QString error;
 	if (ok == false){
 		error = QStringLiteral("Error: Convert to double.");
 	} else if (coef < Profile::Led::CoefMin || coef > Profile::Led::CoefMax){
-		error = QStringLiteral("Error: outside the valid values (coef < ") +
-				QString::number(Profile::Led::CoefMin) + QStringLiteral(" || coef > ") + QString::number(Profile::Led::CoefMax) + ").";
+		error = QStringLiteral("Error: outside the valid values (coef < %1 || coef > %2)")
+					.arg(QString::number(Profile::Led::CoefMin), QString::number(Profile::Led::CoefMax));
 	} else {
 		// OK
 		return coef;
@@ -2054,12 +2055,12 @@ double Settings::getValidLedCoef(int ledIndex, const QString & keyCoef)
 				<< error
 				<< "Set it to default value" << keyCoef << "=" << Profile::Led::CoefDefault;
 	coef = Profile::Led::CoefDefault;
-	Settings::setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + keyCoef, coef);
+	Settings::setValue(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(ledIndex + 1), keyCoef), coef);
 	return coef;
 }
 
 QString Settings::getProfilesPath() {
-	return m_applicationDirPath + QStringLiteral("Profiles/");
+	return QStringLiteral("%1Profiles/").arg(m_applicationDirPath);
 }
 
 bool Settings::isCheckForUpdatesEnabled() {
@@ -2144,18 +2145,18 @@ void Settings::initCurrentProfile(bool isResetDefault)
 		ledPosition = getDefaultPosition(i);
 
 
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::IsEnabled,
+		setNewOption(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(i + 1), Profile::Key::Led::IsEnabled),
 						Profile::Led::IsEnabledDefault, isResetDefault);
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::Position,
+		setNewOption(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(i + 1), Profile::Key::Led::Position),
 						ledPosition, isResetDefault);
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::Size,
+		setNewOption(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(i + 1), Profile::Key::Led::Size),
 						Profile::Led::SizeDefault, isResetDefault);
 
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::CoefRed,
+		setNewOption(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(i + 1), Profile::Key::Led::CoefRed),
 						Profile::Led::CoefDefault, isResetDefault);
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::CoefGreen,
+		setNewOption(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(i + 1), Profile::Key::Led::CoefGreen),
 						Profile::Led::CoefDefault, isResetDefault);
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::CoefBlue,
+		setNewOption(QStringLiteral("%1%2/%3").arg(Profile::Key::Led::Prefix, QString::number(i + 1), Profile::Key::Led::CoefBlue),
 						Profile::Led::CoefDefault, isResetDefault);
 	}
 

--- a/Software/src/Settings.cpp
+++ b/Software/src/Settings.cpp
@@ -63,115 +63,115 @@ namespace Main
 namespace Key
 {
 // [General]
-static const QString MainConfigVersion = "MainConfigVersion";
-static const QString ProfileLast = "ProfileLast";
-static const QString Language = "Language";
-static const QString DebugLevel = "DebugLevel";
-static const QString IsKeepLightsOnAfterExit = "IsKeepLightsOnAfterExit";
-static const QString IsKeepLightsOnAfterLock = "IsKeepLightsOnAfterLock";
-static const QString IsKeepLightsOnAfterSuspend = "IsKeepLightsOnAfterSuspend";
-static const QString IsKeepLightsOnAfterScreenOff = "IsKeepLightsOnAfterScreenOff";
-static const QString IsPingDeviceEverySecond = "IsPingDeviceEverySecond";
-static const QString IsUpdateFirmwareMessageShown = "IsUpdateFirmwareMessageShown";
-static const QString ConnectedDevice = "ConnectedDevice";
-static const QString SupportedDevices = "SupportedDevices";
-static const QString CheckForUpdates = "CheckForUpdates";
-static const QString InstallUpdates = "InstallForUpdates";
-static const QString AutoUpdatingVersion = "AutoUpdatingVersion";
+static const QString MainConfigVersion = QStringLiteral("MainConfigVersion");
+static const QString ProfileLast = QStringLiteral("ProfileLast");
+static const QString Language = QStringLiteral("Language");
+static const QString DebugLevel = QStringLiteral("DebugLevel");
+static const QString IsKeepLightsOnAfterExit = QStringLiteral("IsKeepLightsOnAfterExit");
+static const QString IsKeepLightsOnAfterLock = QStringLiteral("IsKeepLightsOnAfterLock");
+static const QString IsKeepLightsOnAfterSuspend = QStringLiteral("IsKeepLightsOnAfterSuspend");
+static const QString IsKeepLightsOnAfterScreenOff = QStringLiteral("IsKeepLightsOnAfterScreenOff");
+static const QString IsPingDeviceEverySecond = QStringLiteral("IsPingDeviceEverySecond");
+static const QString IsUpdateFirmwareMessageShown = QStringLiteral("IsUpdateFirmwareMessageShown");
+static const QString ConnectedDevice = QStringLiteral("ConnectedDevice");
+static const QString SupportedDevices = QStringLiteral("SupportedDevices");
+static const QString CheckForUpdates = QStringLiteral("CheckForUpdates");
+static const QString InstallUpdates = QStringLiteral("InstallForUpdates");
+static const QString AutoUpdatingVersion = QStringLiteral("AutoUpdatingVersion");
 
 // [Hotkeys]
 namespace Hotkeys
 {
-static const QString SettingsPrefix = "HotKeys/";
+static const QString SettingsPrefix = QStringLiteral("HotKeys/");
 }
 
 // [API]
 namespace Api
 {
-static const QString IsEnabled = "API/IsEnabled";
-static const QString ListenOnlyOnLoInterface = "API/ListenOnlyOnLoInterface";
-static const QString Port = "API/Port";
-static const QString AuthKey = "API/AuthKey";
+static const QString IsEnabled = QStringLiteral("API/IsEnabled");
+static const QString ListenOnlyOnLoInterface = QStringLiteral("API/ListenOnlyOnLoInterface");
+static const QString Port = QStringLiteral("API/Port");
+static const QString AuthKey = QStringLiteral("API/AuthKey");
 }
 namespace Adalight
 {
-static const QString NumberOfLeds = "Adalight/NumberOfLeds";
-static const QString ColorSequence = "Adalight/ColorSequence";
-static const QString Port = "Adalight/SerialPort";
-static const QString BaudRate = "Adalight/BaudRate";
-static const QString LedMilliAmps = "Adalight/LedMilliAmps";
-static const QString PowerSupplyAmps = "Adalight/PowerSupplyAmps";
+static const QString NumberOfLeds = QStringLiteral("Adalight/NumberOfLeds");
+static const QString ColorSequence = QStringLiteral("Adalight/ColorSequence");
+static const QString Port = QStringLiteral("Adalight/SerialPort");
+static const QString BaudRate = QStringLiteral("Adalight/BaudRate");
+static const QString LedMilliAmps = QStringLiteral("Adalight/LedMilliAmps");
+static const QString PowerSupplyAmps = QStringLiteral("Adalight/PowerSupplyAmps");
 }
 namespace Ardulight
 {
-static const QString NumberOfLeds = "Ardulight/NumberOfLeds";
-static const QString ColorSequence = "Ardulight/ColorSequence";
-static const QString Port = "Ardulight/SerialPort";
-static const QString BaudRate = "Ardulight/BaudRate";
-static const QString LedMilliAmps = "Ardulight/LedMilliAmps";
-static const QString PowerSupplyAmps = "Ardulight/PowerSupplyAmps";
+static const QString NumberOfLeds = QStringLiteral("Ardulight/NumberOfLeds");
+static const QString ColorSequence = QStringLiteral("Ardulight/ColorSequence");
+static const QString Port = QStringLiteral("Ardulight/SerialPort");
+static const QString BaudRate = QStringLiteral("Ardulight/BaudRate");
+static const QString LedMilliAmps = QStringLiteral("Ardulight/LedMilliAmps");
+static const QString PowerSupplyAmps = QStringLiteral("Ardulight/PowerSupplyAmps");
 }
 namespace AlienFx
 {
-static const QString NumberOfLeds = "AlienFx/NumberOfLeds";
-static const QString LedMilliAmps = "AlienFx/LedMilliAmps";
-static const QString PowerSupplyAmps = "AlienFx/PowerSupplyAmps";
+static const QString NumberOfLeds = QStringLiteral("AlienFx/NumberOfLeds");
+static const QString LedMilliAmps = QStringLiteral("AlienFx/LedMilliAmps");
+static const QString PowerSupplyAmps = QStringLiteral("AlienFx/PowerSupplyAmps");
 }
 namespace Lightpack
 {
-static const QString NumberOfLeds = "Lightpack/NumberOfLeds";
-static const QString LedMilliAmps = "Lightpack/LedMilliAmps";
-static const QString PowerSupplyAmps = "Lightpack/PowerSupplyAmps";
+static const QString NumberOfLeds = QStringLiteral("Lightpack/NumberOfLeds");
+static const QString LedMilliAmps = QStringLiteral("Lightpack/LedMilliAmps");
+static const QString PowerSupplyAmps = QStringLiteral("Lightpack/PowerSupplyAmps");
 }
 namespace Virtual
 {
-static const QString NumberOfLeds = "Virtual/NumberOfLeds";
-static const QString LedMilliAmps = "Virtual/LedMilliAmps";
-static const QString PowerSupplyAmps = "Virtual/PowerSupplyAmps";
+static const QString NumberOfLeds = QStringLiteral("Virtual/NumberOfLeds");
+static const QString LedMilliAmps = QStringLiteral("Virtual/LedMilliAmps");
+static const QString PowerSupplyAmps = QStringLiteral("Virtual/PowerSupplyAmps");
 }
 namespace Drgb
 {
-static const QString NumberOfLeds = "Drgb/NumberOfLeds";
-static const QString Address = "Drgb/Address";
-static const QString Port = "Drgb/Port";
-static const QString Timeout = "Drgb/Timeout";
-static const QString LedMilliAmps = "Drgb/LedMilliAmps";
-static const QString PowerSupplyAmps = "Drgb/PowerSupplyAmps";
+static const QString NumberOfLeds = QStringLiteral("Drgb/NumberOfLeds");
+static const QString Address = QStringLiteral("Drgb/Address");
+static const QString Port = QStringLiteral("Drgb/Port");
+static const QString Timeout = QStringLiteral("Drgb/Timeout");
+static const QString LedMilliAmps = QStringLiteral("Drgb/LedMilliAmps");
+static const QString PowerSupplyAmps = QStringLiteral("Drgb/PowerSupplyAmps");
 }
 namespace Dnrgb
 {
-static const QString NumberOfLeds = "Dnrgb/NumberOfLeds";
-static const QString Address = "Dnrgb/Address";
-static const QString Port = "Dnrgb/Port";
-static const QString Timeout = "Dnrgb/Timeout";
-static const QString LedMilliAmps = "Dnrgb/LedMilliAmps";
-static const QString PowerSupplyAmps = "Dnrgb/PowerSupplyAmps";
+static const QString NumberOfLeds = QStringLiteral("Dnrgb/NumberOfLeds");
+static const QString Address = QStringLiteral("Dnrgb/Address");
+static const QString Port = QStringLiteral("Dnrgb/Port");
+static const QString Timeout = QStringLiteral("Dnrgb/Timeout");
+static const QString LedMilliAmps = QStringLiteral("Dnrgb/LedMilliAmps");
+static const QString PowerSupplyAmps = QStringLiteral("Dnrgb/PowerSupplyAmps");
 }
 namespace Warls
 {
-static const QString NumberOfLeds = "Warls/NumberOfLeds";
-static const QString Address = "Warls/Address";
-static const QString Port = "Warls/Port";
-static const QString Timeout = "Warls/Timeout";
-static const QString LedMilliAmps = "Warls/LedMilliAmps";
-static const QString PowerSupplyAmps = "Warls/PowerSupplyAmps";
+static const QString NumberOfLeds = QStringLiteral("Warls/NumberOfLeds");
+static const QString Address = QStringLiteral("Warls/Address");
+static const QString Port = QStringLiteral("Warls/Port");
+static const QString Timeout = QStringLiteral("Warls/Timeout");
+static const QString LedMilliAmps = QStringLiteral("Warls/LedMilliAmps");
+static const QString PowerSupplyAmps = QStringLiteral("Warls/PowerSupplyAmps");
 }
 } /*Key*/
 
 namespace Value
 {
-static const QString MainConfigVersion = MAIN_CONFIG_FILE_VERSION;
+static const QString MainConfigVersion = QStringLiteral(MAIN_CONFIG_FILE_VERSION);
 
 namespace ConnectedDevice
 {
-static const QString LightpackDevice = "Lightpack";
-static const QString AlienFxDevice = "AlienFx";
-static const QString AdalightDevice = "Adalight";
-static const QString ArdulightDevice = "Ardulight";
-static const QString VirtualDevice = "Virtual";
-static const QString DrgbDevice = "DRGB";
-static const QString DnrgbDevice = "DNRGB";
-static const QString WarlsDevice = "WARLS";
+static const QString LightpackDevice = QStringLiteral("Lightpack");
+static const QString AlienFxDevice = QStringLiteral("AlienFx");
+static const QString AdalightDevice = QStringLiteral("Adalight");
+static const QString ArdulightDevice = QStringLiteral("Ardulight");
+static const QString VirtualDevice = QStringLiteral("Virtual");
+static const QString DrgbDevice = QStringLiteral("DRGB");
+static const QString DnrgbDevice = QStringLiteral("DNRGB");
+static const QString WarlsDevice = QStringLiteral("WARLS");
 }
 
 } /*Value*/
@@ -182,66 +182,66 @@ namespace Profile
 namespace Key
 {
 // [General]
-static const QString LightpackMode = "LightpackMode";
-static const QString IsBacklightEnabled = "IsBacklightEnabled";
+static const QString LightpackMode = QStringLiteral("LightpackMode");
+static const QString IsBacklightEnabled = QStringLiteral("IsBacklightEnabled");
 // [Grab]
 namespace Grab
 {
-static const QString Grabber = "Grab/Grabber";
-static const QString IsAvgColorsEnabled = "Grab/IsAvgColorsEnabled";
-static const QString IsSendDataOnlyIfColorsChanges = "Grab/IsSendDataOnlyIfColorsChanges";
-static const QString Slowdown = "Grab/Slowdown";
-static const QString LuminosityThreshold = "Grab/LuminosityThreshold";
-static const QString OverBrighten = "Grab/OverBrighten";
-static const QString IsMinimumLuminosityEnabled = "Grab/IsMinimumLuminosityEnabled";
-static const QString IsDx1011GrabberEnabled = "Grab/IsDX1011GrabberEnabled";
-static const QString IsDx9GrabbingEnabled = "Grab/IsDX9GrabbingEnabled";
-static const QString IsApplyBlueLightReductionEnabled = "Grab/IsApplyGammaRampEnabled";
-static const QString IsApplyColorTemperatureEnabled = "Grab/IsApplyColorTemperatureEnabled";
-static const QString ColorTemperature = "Grab/ColorTemperature";
-static const QString Gamma = "Grab/Gamma";
+static const QString Grabber = QStringLiteral("Grab/Grabber");
+static const QString IsAvgColorsEnabled = QStringLiteral("Grab/IsAvgColorsEnabled");
+static const QString IsSendDataOnlyIfColorsChanges = QStringLiteral("Grab/IsSendDataOnlyIfColorsChanges");
+static const QString Slowdown = QStringLiteral("Grab/Slowdown");
+static const QString LuminosityThreshold = QStringLiteral("Grab/LuminosityThreshold");
+static const QString OverBrighten = QStringLiteral("Grab/OverBrighten");
+static const QString IsMinimumLuminosityEnabled = QStringLiteral("Grab/IsMinimumLuminosityEnabled");
+static const QString IsDx1011GrabberEnabled = QStringLiteral("Grab/IsDX1011GrabberEnabled");
+static const QString IsDx9GrabbingEnabled = QStringLiteral("Grab/IsDX9GrabbingEnabled");
+static const QString IsApplyBlueLightReductionEnabled = QStringLiteral("Grab/IsApplyGammaRampEnabled");
+static const QString IsApplyColorTemperatureEnabled = QStringLiteral("Grab/IsApplyColorTemperatureEnabled");
+static const QString ColorTemperature = QStringLiteral("Grab/ColorTemperature");
+static const QString Gamma = QStringLiteral("Grab/Gamma");
 }
 // [MoodLamp]
 namespace MoodLamp
 {
-static const QString IsLiquidMode = "MoodLamp/LiquidMode";
-static const QString Color = "MoodLamp/Color";
-static const QString Speed = "MoodLamp/Speed";
-static const QString Lamp = "MoodLamp/Lamp";
+static const QString IsLiquidMode = QStringLiteral("MoodLamp/LiquidMode");
+static const QString Color = QStringLiteral("MoodLamp/Color");
+static const QString Speed = QStringLiteral("MoodLamp/Speed");
+static const QString Lamp = QStringLiteral("MoodLamp/Lamp");
 }
 // [SoundVisualizer]
 namespace SoundVisualizer
 {
-static const QString Device = "SoundVisualizer/Device";
-static const QString Visualizer = "SoundVisualizer/Visualizer";
-static const QString MinColor = "SoundVisualizer/MinColor";
-static const QString MaxColor = "SoundVisualizer/MaxColor";
-static const QString IsLiquidMode = "SoundVisualizer/LiquidMode";
-static const QString LiquidSpeed = "SoundVisualizer/LiquidSpeed";
+static const QString Device = QStringLiteral("SoundVisualizer/Device");
+static const QString Visualizer = QStringLiteral("SoundVisualizer/Visualizer");
+static const QString MinColor = QStringLiteral("SoundVisualizer/MinColor");
+static const QString MaxColor = QStringLiteral("SoundVisualizer/MaxColor");
+static const QString IsLiquidMode = QStringLiteral("SoundVisualizer/LiquidMode");
+static const QString LiquidSpeed = QStringLiteral("SoundVisualizer/LiquidSpeed");
 }
 // [Device]
 namespace Device
 {
-static const QString RefreshDelay = "Device/RefreshDelay";
-static const QString IsUsbPowerLedDisabled = "Device/IsUsbPowerLedDisabled";
-static const QString Smooth = "Device/Smooth";
-static const QString Brightness = "Device/Brightness";
-static const QString BrightnessCap = "Device/BrightnessCap";
-static const QString ColorDepth = "Device/ColorDepth";
-static const QString Gamma = "Device/Gamma";
-static const QString IsDitheringEnabled = "Device/IsDitheringEnabled";
+static const QString RefreshDelay = QStringLiteral("Device/RefreshDelay");
+static const QString IsUsbPowerLedDisabled = QStringLiteral("Device/IsUsbPowerLedDisabled");
+static const QString Smooth = QStringLiteral("Device/Smooth");
+static const QString Brightness = QStringLiteral("Device/Brightness");
+static const QString BrightnessCap = QStringLiteral("Device/BrightnessCap");
+static const QString ColorDepth = QStringLiteral("Device/ColorDepth");
+static const QString Gamma = QStringLiteral("Device/Gamma");
+static const QString IsDitheringEnabled = QStringLiteral("Device/IsDitheringEnabled");
 }
 // [LED_i]
 namespace Led
 {
 
-static const QString Prefix = "LED_";
-static const QString IsEnabled = "IsEnabled";
-static const QString Size = "Size";
-static const QString Position = "Position";
-static const QString CoefRed = "CoefRed";
-static const QString CoefGreen = "CoefGreen";
-static const QString CoefBlue = "CoefBlue";
+static const QString Prefix = QStringLiteral("LED_");
+static const QString IsEnabled = QStringLiteral("IsEnabled");
+static const QString Size = QStringLiteral("Size");
+static const QString Position = QStringLiteral("Position");
+static const QString CoefRed = QStringLiteral("CoefRed");
+static const QString CoefGreen = QStringLiteral("CoefGreen");
+static const QString CoefBlue = QStringLiteral("CoefBlue");
 }
 } /*Key*/
 
@@ -250,22 +250,22 @@ namespace Value
 
 namespace LightpackMode
 {
-static const QString Ambilight = "Ambilight";
-static const QString MoodLamp = "MoodLamp";
-static const QString SoundVisualizer = "SoundVisualizer";
+static const QString Ambilight = QStringLiteral("Ambilight");
+static const QString MoodLamp = QStringLiteral("MoodLamp");
+static const QString SoundVisualizer = QStringLiteral("SoundVisualizer");
 }
 
 namespace GrabberType
 {
-static const QString Qt = "Qt";
-static const QString QtEachWidget = "QtEachWidget";
-static const QString WinAPI = "WinAPI";
-static const QString WinAPIEachWidget = "WinAPIEachWidget";
-static const QString X11 = "X11";
-static const QString D3D9 = "D3D9";
-static const QString MacCoreGraphics = "MacCoreGraphics";
-static const QString MacAVFoundation = "MacAVFoundation";
-static const QString DDupl = "DDupl";
+static const QString Qt = QStringLiteral("Qt");
+static const QString QtEachWidget = QStringLiteral("QtEachWidget");
+static const QString WinAPI = QStringLiteral("WinAPI");
+static const QString WinAPIEachWidget = QStringLiteral("WinAPIEachWidget");
+static const QString X11 = QStringLiteral("X11");
+static const QString D3D9 = QStringLiteral("D3D9");
+static const QString MacCoreGraphics = QStringLiteral("MacCoreGraphics");
+static const QString MacAVFoundation = QStringLiteral("MacAVFoundation");
+static const QString DDupl = QStringLiteral("DDupl");
 }
 
 } /*Value*/
@@ -278,7 +278,7 @@ QSettings * Settings::m_mainConfig; // LightpackMain.conf contains last profile
 Settings * Settings::m_this = new Settings();
 
 // Path to directory there store application generated stuff
-QString Settings::m_applicationDirPath = "";
+QString Settings::m_applicationDirPath = QLatin1String("");
 
 QMap<SupportedDevices::DeviceType, QString> Settings::m_devicesTypeToNameMap;
 QMap<SupportedDevices::DeviceType, QString> Settings::m_devicesTypeToKeyNumberOfLedsMap;
@@ -297,17 +297,17 @@ bool Settings::Initialize( const QString & applicationDirPath, bool isDebugLevel
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 
-	if(m_applicationDirPath != "")
+	if(!m_applicationDirPath.isEmpty())
 		return true;
 
 	m_applicationDirPath = applicationDirPath;
 
 	// Append to the end of dir path '/'
 	if (m_applicationDirPath.lastIndexOf('/') != m_applicationDirPath.length() - 1)
-		m_applicationDirPath += "/";
+		m_applicationDirPath += QStringLiteral("/");
 
 	QString mainConfigPath = getMainConfigPath();
-	bool settingsWasPresent = QFileInfo(mainConfigPath).exists();
+	bool settingsWasPresent = QFileInfo::exists(mainConfigPath);
 
 	m_mainConfig = new QSettings(mainConfigPath, QSettings::IniFormat);
 	m_mainConfig->setIniCodec("UTF-8");
@@ -400,7 +400,7 @@ bool Settings::Initialize( const QString & applicationDirPath, bool isDebugLevel
 	QString profileLast = getLastProfileName();
 
 	// Load last profile
-	m_currentProfile = new QSettings(getProfilesPath() + profileLast + ".ini", QSettings::IniFormat);
+	m_currentProfile = new QSettings(getProfilesPath() + profileLast + QStringLiteral(".ini"), QSettings::IniFormat);
 	m_currentProfile->setIniCodec("UTF-8");
 
 	DEBUG_LOW_LEVEL << "Settings file:" << m_currentProfile->fileName();
@@ -432,7 +432,7 @@ QStringList Settings::findAllProfiles()
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 
 	QFileInfo setsFile(Settings::getProfilesPath());
-	QFileInfoList iniFiles = setsFile.absoluteDir().entryInfoList(QStringList("*.ini"));
+	QFileInfoList iniFiles = setsFile.absoluteDir().entryInfoList(QStringList(QStringLiteral("*.ini")));
 
 	QStringList settingsFiles;
 	for(int i=0; i<iniFiles.count(); i++){
@@ -452,13 +452,13 @@ void Settings::loadOrCreateProfile(const QString & profileName)
 	QString currentProfileFileName = m_currentProfile != NULL ? m_currentProfile->fileName() : NULL;
 
 	if (currentProfileFileName != NULL
-		&& currentProfileFileName.compare(getProfilesPath() + profileName + ".ini") == 0)
+		&& currentProfileFileName.compare(getProfilesPath() + profileName + QStringLiteral(".ini")) == 0)
 		return; //nothing to change, profile is already loaded
 
 	if (currentProfileFileName != NULL)
 	{
 		// Copy current settings to new one
-		QString profileNewPath = getProfilesPath() + profileName + ".ini";
+		QString profileNewPath = getProfilesPath() + profileName + QStringLiteral(".ini");
 
 		if (currentProfileFileName != profileNewPath)
 			QFile::copy(currentProfileFileName, profileNewPath);
@@ -467,7 +467,7 @@ void Settings::loadOrCreateProfile(const QString & profileName)
 	}
 
 
-	m_currentProfile = new QSettings(getProfilesPath() + profileName + ".ini", QSettings::IniFormat );
+	m_currentProfile = new QSettings(getProfilesPath() + profileName + QStringLiteral(".ini"), QSettings::IniFormat );
 	m_currentProfile->setIniCodec("UTF-8");
 
 	locker.unlock();
@@ -494,7 +494,7 @@ void Settings::renameCurrentProfile(const QString & profileName)
 
 	// Copy current settings to new one
 	QString profilesDir = QFileInfo( m_currentProfile->fileName() ).absoluteDir().absolutePath();
-	QString profileNewPath = profilesDir + "/" + profileName + ".ini";
+	QString profileNewPath = profilesDir + QStringLiteral("/") + profileName + ".ini";
 
 	if (m_currentProfile->fileName() != profileNewPath)
 	{
@@ -503,7 +503,7 @@ void Settings::renameCurrentProfile(const QString & profileName)
 		delete m_currentProfile;
 
 		// Update m_currentProfile point to new QSettings with configName
-		m_currentProfile = new QSettings(getProfilesPath() + profileName + ".ini", QSettings::IniFormat );
+		m_currentProfile = new QSettings(getProfilesPath() + profileName + QStringLiteral(".ini"), QSettings::IniFormat );
 		m_currentProfile->setIniCodec("UTF-8");
 
 		DEBUG_LOW_LEVEL << "Settings file renamed:" << m_currentProfile->fileName();
@@ -512,7 +512,7 @@ void Settings::renameCurrentProfile(const QString & profileName)
 	}
 
 	m_currentProfile->sync();
-	m_this->currentProfileNameChanged(profileName);
+	emit m_this->currentProfileNameChanged(profileName);
 }
 
 void Settings::removeCurrentProfile()
@@ -540,7 +540,7 @@ void Settings::removeCurrentProfile()
 
 	m_mainConfig->setValue(Main::Key::ProfileLast, Main::ProfileNameDefault);
 
-	m_this->currentProfileRemoved();
+	emit m_this->currentProfileRemoved();
 }
 
 QString Settings::getCurrentProfileName()
@@ -584,7 +584,7 @@ QString Settings::getApplicationDirPath()
 
 QString Settings::getMainConfigPath()
 {
-	QString mainConfPath = m_applicationDirPath + "main.conf";
+	QString mainConfPath = m_applicationDirPath + QStringLiteral("main.conf");
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << mainConfPath;
 	return mainConfPath;
 }
@@ -633,7 +633,7 @@ void Settings::setLanguage(const QString & language)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Language, language);
-	m_this->languageChanged(language);
+	emit m_this->languageChanged(language);
 }
 
 int Settings::getDebugLevel()
@@ -645,7 +645,7 @@ void Settings::setDebugLevel(int debugLvl)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::DebugLevel, debugLvl);
-	m_this->debugLevelChanged(debugLvl);
+	emit m_this->debugLevelChanged(debugLvl);
 }
 
 bool Settings::isApiEnabled()
@@ -657,7 +657,7 @@ void Settings::setIsApiEnabled(bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Api::IsEnabled, isEnabled);
-	m_this->apiServerSettingsChanged();
+	emit m_this->apiServerSettingsChanged();
 }
 
 bool Settings::isListenOnlyOnLoInterface()
@@ -669,7 +669,7 @@ void Settings::setListenOnlyOnLoInterface(bool localOnly)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Api::ListenOnlyOnLoInterface, localOnly);
-	m_this->apiServerSettingsChanged();
+	emit m_this->apiServerSettingsChanged();
 }
 
 int Settings::getApiPort()
@@ -681,7 +681,7 @@ void Settings::setApiPort(int apiPort)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Api::Port, apiPort);
-	m_this->apiServerSettingsChanged();
+	emit m_this->apiServerSettingsChanged();
 }
 
 QString Settings::getApiAuthKey()
@@ -695,7 +695,7 @@ void Settings::setApiKey(const QString & apiKey)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Api::AuthKey, apiKey);
-	m_this->apiKeyChanged(apiKey);
+	emit m_this->apiKeyChanged(apiKey);
 }
 
 bool Settings::isKeepLightsOnAfterExit()
@@ -707,7 +707,7 @@ void Settings::setKeepLightsOnAfterExit(bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::IsKeepLightsOnAfterExit, isEnabled);
-	m_this->keepLightsOnAfterExitChanged(isEnabled);
+	emit m_this->keepLightsOnAfterExitChanged(isEnabled);
 }
 
 bool Settings::isKeepLightsOnAfterLock()
@@ -719,7 +719,7 @@ void Settings::setKeepLightsOnAfterLock(bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::IsKeepLightsOnAfterLock, isEnabled);
-	m_this->keepLightsOnAfterLockChanged(isEnabled);
+	emit m_this->keepLightsOnAfterLockChanged(isEnabled);
 }
 
 bool Settings::isKeepLightsOnAfterSuspend()
@@ -731,7 +731,7 @@ void Settings::setKeepLightsOnAfterSuspend(bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::IsKeepLightsOnAfterSuspend, isEnabled);
-	m_this->keepLightsOnAfterSuspendChanged(isEnabled);
+	emit m_this->keepLightsOnAfterSuspendChanged(isEnabled);
 }
 
 bool Settings::isKeepLightsOnAfterScreenOff()
@@ -743,7 +743,7 @@ void Settings::setKeepLightsOnAfterScreenOff(bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::IsKeepLightsOnAfterScreenOff, isEnabled);
-	m_this->keepLightsOnAfterScreenOffChanged(isEnabled);
+	emit m_this->keepLightsOnAfterScreenOffChanged(isEnabled);
 }
 
 bool Settings::isPingDeviceEverySecond()
@@ -755,7 +755,7 @@ void Settings::setPingDeviceEverySecond(bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::IsPingDeviceEverySecond, isEnabled);
-	m_this->pingDeviceEverySecondEnabledChanged(isEnabled);
+	emit m_this->pingDeviceEverySecondEnabledChanged(isEnabled);
 }
 
 bool Settings::isUpdateFirmwareMessageShown()
@@ -767,14 +767,14 @@ void Settings::setUpdateFirmwareMessageShown(bool isShown)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::IsUpdateFirmwareMessageShown, isShown);
-	m_this->updateFirmwareMessageShownChanged(isShown);
+	emit m_this->updateFirmwareMessageShownChanged(isShown);
 }
 
 SupportedDevices::DeviceType Settings::getConnectedDevice()
 {
 	QString deviceName = valueMain(Main::Key::ConnectedDevice).toString();
 
-	if (m_devicesTypeToNameMap.values().contains(deviceName) == false)
+	if (std::find(m_devicesTypeToNameMap.cbegin(), m_devicesTypeToNameMap.cend(), deviceName) == m_devicesTypeToNameMap.cend())
 	{
 		qWarning() << Q_FUNC_INFO << Main::Key::ConnectedDevice << "in main config contains crap or unsupported device,"
 					<< "reset it to default value:" << Main::ConnectedDeviceDefault;
@@ -792,7 +792,7 @@ void Settings::setConnectedDevice(SupportedDevices::DeviceType device)
 	QString deviceName = m_devicesTypeToNameMap.value(device, Main::ConnectedDeviceDefault);
 
 	setValueMain(Main::Key::ConnectedDevice, deviceName);
-	m_this->connectedDeviceChanged(device);
+	emit m_this->connectedDeviceChanged(device);
 }
 
 QString Settings::getConnectedDeviceName()
@@ -803,17 +803,18 @@ QString Settings::getConnectedDeviceName()
 void Settings::setConnectedDeviceName(const QString & deviceName)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
-	if (deviceName == "")
+	if (deviceName.isEmpty())
 		return; // silent return
 
-	if (m_devicesTypeToNameMap.values().contains(deviceName) == false)
+	// if (m_devicesTypeToNameMap.values().contains(deviceName) == false)
+	if (std::find(m_devicesTypeToNameMap.cbegin(), m_devicesTypeToNameMap.cend(), deviceName) == m_devicesTypeToNameMap.cend())
 	{
 		qCritical() << Q_FUNC_INFO << "Failure during check the device name" << deviceName << "in m_devicesMap. The main config has not changed.";
 		return;
 	}
 
 	setValueMain(Main::Key::ConnectedDevice, deviceName);
-	m_this->connectedDeviceChanged(m_devicesTypeToNameMap.key(deviceName));
+	emit m_this->connectedDeviceChanged(m_devicesTypeToNameMap.key(deviceName));
 }
 
 QStringList Settings::getSupportedDevices()
@@ -842,7 +843,7 @@ void Settings::setHotkey(const QString &actionName, const QKeySequence &keySeque
 	} else {
 		setValueMain(key, keySequence.toString());
 	}
-	m_this->hotkeyChanged(actionName, keySequence, oldKeySequence);
+	emit m_this->hotkeyChanged(actionName, keySequence, oldKeySequence);
 }
 
 QString Settings::getAdalightSerialPortName()
@@ -854,7 +855,7 @@ void Settings::setAdalightSerialPortName(const QString & port)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Adalight::Port, port);
-	m_this->adalightSerialPortNameChanged(port);
+	emit m_this->adalightSerialPortNameChanged(port);
 }
 
 int Settings::getAdalightSerialPortBaudRate()
@@ -868,7 +869,7 @@ void Settings::setAdalightSerialPortBaudRate(const QString & baud)
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	// TODO: validator
 	setValueMain(Main::Key::Adalight::BaudRate, baud);
-	m_this->adalightSerialPortBaudRateChanged(baud);
+	emit m_this->adalightSerialPortBaudRateChanged(baud);
 }
 
 QString Settings::getArdulightSerialPortName()
@@ -880,7 +881,7 @@ void Settings::setArdulightSerialPortName(const QString & port)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Ardulight::Port, port);
-	m_this->ardulightSerialPortNameChanged(port);
+	emit m_this->ardulightSerialPortNameChanged(port);
 }
 
 int Settings::getArdulightSerialPortBaudRate()
@@ -894,7 +895,7 @@ void Settings::setArdulightSerialPortBaudRate(const QString & baud)
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	// TODO: validator
 	setValueMain(Main::Key::Ardulight::BaudRate, baud);
-	m_this->ardulightSerialPortBaudRateChanged(baud);
+	emit m_this->ardulightSerialPortBaudRateChanged(baud);
 }
 
 QString Settings::getDrgbAddress()
@@ -906,7 +907,7 @@ void Settings::setDrgbAddress(const QString& address)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Drgb::Address, address);
-	m_this->drgbAddressChanged(address);
+	emit m_this->drgbAddressChanged(address);
 }
 
 QString Settings::getDrgbPort()
@@ -918,7 +919,7 @@ void Settings::setDrgbPort(const QString& port)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Drgb::Port, port);
-	m_this->drgbPortChanged(port);
+	emit m_this->drgbPortChanged(port);
 }
 
 int Settings::getDrgbTimeout()
@@ -930,7 +931,7 @@ void Settings::setDrgbTimeout(const int timeout)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Drgb::Timeout, timeout);
-	m_this->drgbTimeoutChanged(timeout);
+	emit m_this->drgbTimeoutChanged(timeout);
 }
 
 QString Settings::getDnrgbAddress()
@@ -942,7 +943,7 @@ void Settings::setDnrgbAddress(const QString& address)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Dnrgb::Address, address);
-	m_this->dnrgbAddressChanged(address);
+	emit m_this->dnrgbAddressChanged(address);
 }
 
 QString Settings::getDnrgbPort()
@@ -954,7 +955,7 @@ void Settings::setDnrgbPort(const QString& port)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Dnrgb::Port, port);
-	m_this->dnrgbPortChanged(port);
+	emit m_this->dnrgbPortChanged(port);
 }
 
 int Settings::getDnrgbTimeout()
@@ -966,7 +967,7 @@ void Settings::setDnrgbTimeout(const int timeout)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Dnrgb::Timeout, timeout);
-	m_this->dnrgbTimeoutChanged(timeout);
+	emit m_this->dnrgbTimeoutChanged(timeout);
 }
 
 QString Settings::getWarlsAddress()
@@ -978,7 +979,7 @@ void Settings::setWarlsAddress(const QString& address)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Warls::Address, address);
-	m_this->warlsAddressChanged(address);
+	emit m_this->warlsAddressChanged(address);
 }
 
 QString Settings::getWarlsPort()
@@ -990,7 +991,7 @@ void Settings::setWarlsPort(const QString& port)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Warls::Port, port);
-	m_this->warlsPortChanged(port);
+	emit m_this->warlsPortChanged(port);
 }
 
 int Settings::getWarlsTimeout()
@@ -1002,7 +1003,7 @@ void Settings::setWarlsTimeout(const int timeout)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValueMain(Main::Key::Warls::Timeout, timeout);
-	m_this->warlsTimeoutChanged(timeout);
+	emit m_this->warlsTimeoutChanged(timeout);
 }
 
 QStringList Settings::getSupportedSerialPortBaudRates()
@@ -1010,20 +1011,20 @@ QStringList Settings::getSupportedSerialPortBaudRates()
 	QStringList list;
 
 	// TODO: Add more baud rates if need it
-	list.append("2000000");
-	list.append("1500000");
-	list.append("1000000");
-	list.append("921600");
-	list.append("500000");
-	list.append("460800");
-	list.append("256000");
-	list.append("230400");
-	list.append("153600");
-	list.append("128000");
+	list.append(QStringLiteral("2000000"));
+	list.append(QStringLiteral("1500000"));
+	list.append(QStringLiteral("1000000"));
+	list.append(QStringLiteral("921600"));
+	list.append(QStringLiteral("500000"));
+	list.append(QStringLiteral("460800"));
+	list.append(QStringLiteral("256000"));
+	list.append(QStringLiteral("230400"));
+	list.append(QStringLiteral("153600"));
+	list.append(QStringLiteral("128000"));
 
-	list.append("115200");
-	list.append("57600");
-	list.append("9600");
+	list.append(QStringLiteral("115200"));
+	list.append(QStringLiteral("57600"));
+	list.append(QStringLiteral("9600"));
 	return list;
 }
 
@@ -1050,7 +1051,7 @@ void Settings::setNumberOfLeds(SupportedDevices::DeviceType device, int numberOf
 
 	QString key = m_devicesTypeToKeyNumberOfLedsMap.value(device);
 
-	if (key == "")
+	if (key.isEmpty())
 	{
 		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device << "numberOfLeds ==" << numberOfLeds;
 		return;
@@ -1061,31 +1062,31 @@ void Settings::setNumberOfLeds(SupportedDevices::DeviceType device, int numberOf
 		using namespace SupportedDevices;
 		switch(device) {
 			case DeviceTypeLightpack:
-			m_this->lightpackNumberOfLedsChanged(numberOfLeds);
+			emit m_this->lightpackNumberOfLedsChanged(numberOfLeds);
 			break;
 
 			case DeviceTypeAdalight:
-			m_this->adalightNumberOfLedsChanged(numberOfLeds);
+			emit m_this->adalightNumberOfLedsChanged(numberOfLeds);
 			break;
 
 			case DeviceTypeArdulight:
-			m_this->ardulightNumberOfLedsChanged(numberOfLeds);
+			emit m_this->ardulightNumberOfLedsChanged(numberOfLeds);
 			break;
 
 			case DeviceTypeVirtual:
-			m_this->virtualNumberOfLedsChanged(numberOfLeds);
+			emit m_this->virtualNumberOfLedsChanged(numberOfLeds);
 			break;
 
 			case DeviceTypeDrgb:
-			m_this->drgbNumberOfLedsChanged(numberOfLeds);
+			emit m_this->drgbNumberOfLedsChanged(numberOfLeds);
 			break;
 
 			case DeviceTypeDnrgb:
-			m_this->dnrgbNumberOfLedsChanged(numberOfLeds);
+			emit m_this->dnrgbNumberOfLedsChanged(numberOfLeds);
 			break;
 
 			case DeviceTypeWarls:
-			m_this->warlsNumberOfLedsChanged(numberOfLeds);
+			emit m_this->warlsNumberOfLedsChanged(numberOfLeds);
 			break;
 		default:
 			qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device << "numberOfLeds ==" << numberOfLeds;
@@ -1097,7 +1098,7 @@ int Settings::getNumberOfLeds(SupportedDevices::DeviceType device)
 {
 	QString key = m_devicesTypeToKeyNumberOfLedsMap.value(device);
 
-	if (key == "")
+	if (key.isEmpty())
 	{
 		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device;
 		return MaximumNumberOfLeds::Default;
@@ -1117,7 +1118,7 @@ void Settings::setDeviceLedMilliAmps(const SupportedDevices::DeviceType device, 
 
 	const QString& key = m_devicesTypeToKeyLedMilliAmpsMap.value(device);
 
-	if (key == "")
+	if (key.isEmpty())
 	{
 		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device << "LedMilliAmps ==" << mAmps;
 		return;
@@ -1128,31 +1129,31 @@ void Settings::setDeviceLedMilliAmps(const SupportedDevices::DeviceType device, 
 		using namespace SupportedDevices;
 		switch(device) {
 			case DeviceTypeLightpack:
-			m_this->lightpackLedMilliAmpsChanged(mAmps);
+			emit m_this->lightpackLedMilliAmpsChanged(mAmps);
 			break;
 
 			case DeviceTypeAdalight:
-			m_this->adalightLedMilliAmpsChanged(mAmps);
+			emit m_this->adalightLedMilliAmpsChanged(mAmps);
 			break;
 
 			case DeviceTypeArdulight:
-			m_this->ardulightLedMilliAmpsChanged(mAmps);
+			emit m_this->ardulightLedMilliAmpsChanged(mAmps);
 			break;
 
 			case DeviceTypeVirtual:
-			m_this->virtualLedMilliAmpsChanged(mAmps);
+			emit m_this->virtualLedMilliAmpsChanged(mAmps);
 			break;
 
 			case DeviceTypeDrgb:
-			m_this->drgbLedMilliAmpsChanged(mAmps);
+			emit m_this->drgbLedMilliAmpsChanged(mAmps);
 			break;
 
 			case DeviceTypeDnrgb:
-			m_this->dnrgbLedMilliAmpsChanged(mAmps);
+			emit m_this->dnrgbLedMilliAmpsChanged(mAmps);
 			break;
 
 			case DeviceTypeWarls:
-			m_this->warlsLedMilliAmpsChanged(mAmps);
+			emit m_this->warlsLedMilliAmpsChanged(mAmps);
 			break;
 		default:
 			qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device << "LedMilliAmps ==" << mAmps;
@@ -1164,7 +1165,7 @@ int Settings::getDeviceLedMilliAmps(const SupportedDevices::DeviceType device)
 {
 	const QString& key = m_devicesTypeToKeyLedMilliAmpsMap.value(device);
 
-	if (key == "")
+	if (key.isEmpty())
 	{
 		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device;
 		return Main::Device::LedMilliAmpsDefault;
@@ -1185,7 +1186,7 @@ void Settings::setDevicePowerSupplyAmps(const SupportedDevices::DeviceType devic
 
 	const QString& key = m_devicesTypeToKeyPowerSupplyAmpsMap.value(device);
 
-	if (key == "")
+	if (key.isEmpty())
 	{
 		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device << "PowerSupplyAmps ==" << amps;
 		return;
@@ -1196,31 +1197,31 @@ void Settings::setDevicePowerSupplyAmps(const SupportedDevices::DeviceType devic
 		using namespace SupportedDevices;
 		switch(device) {
 			case DeviceTypeLightpack:
-			m_this->lightpackPowerSupplyAmpsChanged(amps);
+			emit m_this->lightpackPowerSupplyAmpsChanged(amps);
 			break;
 
 			case DeviceTypeAdalight:
-			m_this->adalightPowerSupplyAmpsChanged(amps);
+			emit m_this->adalightPowerSupplyAmpsChanged(amps);
 			break;
 
 			case DeviceTypeArdulight:
-			m_this->ardulightPowerSupplyAmpsChanged(amps);
+			emit m_this->ardulightPowerSupplyAmpsChanged(amps);
 			break;
 
 			case DeviceTypeVirtual:
-			m_this->virtualPowerSupplyAmpsChanged(amps);
+			emit m_this->virtualPowerSupplyAmpsChanged(amps);
 			break;
 
 			case DeviceTypeDrgb:
-			m_this->drgbPowerSupplyAmpsChanged(amps);
+			emit m_this->drgbPowerSupplyAmpsChanged(amps);
 			break;
 
 			case DeviceTypeDnrgb:
-			m_this->dnrgbPowerSupplyAmpsChanged(amps);
+			emit m_this->dnrgbPowerSupplyAmpsChanged(amps);
 			break;
 
 			case DeviceTypeWarls:
-			m_this->warlsPowerSupplyAmpsChanged(amps);
+			emit m_this->warlsPowerSupplyAmpsChanged(amps);
 			break;
 		default:
 			qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device << "PowerSupplyAmps ==" << amps;
@@ -1232,7 +1233,7 @@ double Settings::getDevicePowerSupplyAmps(const SupportedDevices::DeviceType dev
 {
 	const QString& key = m_devicesTypeToKeyPowerSupplyAmpsMap.value(device);
 
-	if (key == "")
+	if (key.isEmpty())
 	{
 		qCritical() << Q_FUNC_INFO << "Device type not recognized, device ==" << device;
 		return Main::Device::PowerSupplyAmpsDefault;
@@ -1242,7 +1243,7 @@ double Settings::getDevicePowerSupplyAmps(const SupportedDevices::DeviceType dev
 	return valueMain(key).toDouble();
 }
 
-void Settings::setColorSequence(SupportedDevices::DeviceType device, QString colorSequence)
+void Settings::setColorSequence(SupportedDevices::DeviceType device, const QString& colorSequence)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << device << colorSequence;
 	switch (device)
@@ -1259,7 +1260,7 @@ void Settings::setColorSequence(SupportedDevices::DeviceType device, QString col
 			qWarning() << Q_FUNC_INFO << "Unsupported device type: " << device << m_devicesTypeToNameMap.value(device);
 			return;
 	}
-	m_this->deviceColorSequenceChanged(colorSequence);
+	emit m_this->deviceColorSequenceChanged(colorSequence);
 }
 
 QString Settings::getColorSequence(SupportedDevices::DeviceType device)
@@ -1288,7 +1289,7 @@ void Settings::setGrabSlowdown(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Grab::Slowdown, getValidGrabSlowdown(value));
-	m_this->grabSlowdownChanged(value);
+	emit m_this->grabSlowdownChanged(value);
 }
 
 bool Settings::isBacklightEnabled()
@@ -1300,7 +1301,7 @@ void Settings::setIsBacklightEnabled(bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::IsBacklightEnabled, isEnabled);
-	m_this->backlightEnabledChanged(isEnabled);
+	emit m_this->backlightEnabledChanged(isEnabled);
 }
 
 bool Settings::isGrabAvgColorsEnabled()
@@ -1312,7 +1313,7 @@ void Settings::setGrabAvgColorsEnabled(bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Grab::IsAvgColorsEnabled, isEnabled);
-	m_this->grabAvgColorsEnabledChanged(isEnabled);
+	emit m_this->grabAvgColorsEnabledChanged(isEnabled);
 }
 
 int Settings::getGrabOverBrighten()
@@ -1324,7 +1325,7 @@ void Settings::setGrabOverBrighten(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Grab::OverBrighten, getValidGrabOverBrighten(value));
-	m_this->grabOverBrightenChanged(value);
+	emit m_this->grabOverBrightenChanged(value);
 }
 
 bool Settings::isGrabApplyBlueLightReductionEnabled()
@@ -1336,7 +1337,7 @@ void Settings::setGrabApplyBlueLightReductionEnabled(bool value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Grab::IsApplyBlueLightReductionEnabled, value);
-	m_this->grabApplyBlueLightReductionChanged(value);
+	emit m_this->grabApplyBlueLightReductionChanged(value);
 }
 
 bool Settings::isGrabApplyColorTemperatureEnabled()
@@ -1347,7 +1348,7 @@ void Settings::setGrabApplyColorTemperatureEnabled(bool value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Grab::IsApplyColorTemperatureEnabled, value);
-	m_this->grabApplyColorTemperatureChanged(value);
+	emit m_this->grabApplyColorTemperatureChanged(value);
 }
 int Settings::getGrabColorTemperature()
 {
@@ -1357,7 +1358,7 @@ void Settings::setGrabColorTemperature(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Grab::ColorTemperature, value);
-	m_this->grabColorTemperatureChanged(value);
+	emit m_this->grabColorTemperatureChanged(value);
 }
 double Settings::getGrabGamma()
 {
@@ -1367,7 +1368,7 @@ void Settings::setGrabGamma(double gamma)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Grab::Gamma, gamma);
-	m_this->grabGammaChanged(gamma);
+	emit m_this->grabGammaChanged(gamma);
 }
 
 bool Settings::isSendDataOnlyIfColorsChanges()
@@ -1379,7 +1380,7 @@ void Settings::setSendDataOnlyIfColorsChanges(bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Grab::IsSendDataOnlyIfColorsChanges, isEnabled);
-	m_this->sendDataOnlyIfColorsChangesChanged(isEnabled);
+	emit m_this->sendDataOnlyIfColorsChangesChanged(isEnabled);
 }
 
 int Settings::getLuminosityThreshold()
@@ -1391,7 +1392,7 @@ void Settings::setLuminosityThreshold(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Grab::LuminosityThreshold, getValidLuminosityThreshold(value));
-	m_this->luminosityThresholdChanged(value);
+	emit m_this->luminosityThresholdChanged(value);
 }
 
 bool Settings::isMinimumLuminosityEnabled()
@@ -1403,7 +1404,7 @@ void Settings::setMinimumLuminosityEnabled(bool value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Grab::IsMinimumLuminosityEnabled, value);
-	m_this->minimumLuminosityEnabledChanged(value);
+	emit m_this->minimumLuminosityEnabledChanged(value);
 }
 
 int Settings::getDeviceRefreshDelay()
@@ -1415,7 +1416,7 @@ void Settings::setDeviceRefreshDelay(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Device::RefreshDelay, getValidDeviceRefreshDelay(value));
-	m_this->deviceRefreshDelayChanged(value);
+	emit m_this->deviceRefreshDelayChanged(value);
 }
 
 bool Settings::isDeviceUsbPowerLedDisabled() {
@@ -1425,7 +1426,7 @@ bool Settings::isDeviceUsbPowerLedDisabled() {
 void Settings::setDeviceUsbPowerLedDisabled(bool isDisabled) {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Device::IsUsbPowerLedDisabled, isDisabled);
-	m_this->deviceUsbPowerLedDisabledChanged(isDisabled);
+	emit m_this->deviceUsbPowerLedDisabledChanged(isDisabled);
 }
 
 int Settings::getDeviceBrightness()
@@ -1437,7 +1438,7 @@ void Settings::setDeviceBrightness(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Device::Brightness, getValidDeviceBrightness(value));
-	m_this->deviceBrightnessChanged(value);
+	emit m_this->deviceBrightnessChanged(value);
 }
 
 int Settings::getDeviceBrightnessCap()
@@ -1449,7 +1450,7 @@ void Settings::setDeviceBrightnessCap(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Device::BrightnessCap, getValidDeviceBrightnessCap(value));
-	m_this->deviceBrightnessCapChanged(value);
+	emit m_this->deviceBrightnessCapChanged(value);
 }
 
 int Settings::getDeviceSmooth()
@@ -1461,7 +1462,7 @@ void Settings::setDeviceSmooth(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Device::Smooth, getValidDeviceSmooth(value));
-	m_this->deviceSmoothChanged(value);
+	emit m_this->deviceSmoothChanged(value);
 }
 
 int Settings::getDeviceColorDepth()
@@ -1473,7 +1474,7 @@ void Settings::setDeviceColorDepth(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Device::ColorDepth, getValidDeviceColorDepth(value));
-	m_this->deviceColorDepthChanged(value);
+	emit m_this->deviceColorDepthChanged(value);
 }
 
 double Settings::getDeviceGamma()
@@ -1485,7 +1486,7 @@ void Settings::setDeviceGamma(double gamma)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Device::Gamma, getValidDeviceGamma(gamma));
-	m_this->deviceGammaChanged(gamma);
+	emit m_this->deviceGammaChanged(gamma);
 }
 
 bool Settings::isDeviceDitheringEnabled()
@@ -1497,7 +1498,7 @@ void Settings::setDeviceDitheringEnabled(bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::Device::IsDitheringEnabled, isEnabled);
-	m_this->deviceDitheringEnabledChanged(isEnabled);
+	emit m_this->deviceDitheringEnabledChanged(isEnabled);
 }
 
 Grab::GrabberType Settings::getGrabberType()
@@ -1611,7 +1612,7 @@ void Settings::setGrabberType(Grab::GrabberType grabberType)
 		strGrabber = Profile::Grab::GrabberDefaultString;
 	}
 	setValue(Profile::Key::Grab::Grabber, strGrabber);
-	m_this->grabberTypeChanged(grabberType);
+	emit m_this->grabberTypeChanged(grabberType);
 }
 
 #ifdef D3D10_GRAB_SUPPORT
@@ -1621,7 +1622,7 @@ bool Settings::isDx1011GrabberEnabled() {
 
 void Settings::setDx1011GrabberEnabled(bool isEnabled) {
 	setValue(Profile::Key::Grab::IsDx1011GrabberEnabled, isEnabled);
-	m_this->dx1011GrabberEnabledChanged(isEnabled);
+	emit m_this->dx1011GrabberEnabledChanged(isEnabled);
 }
 
 bool Settings::isDx9GrabbingEnabled() {
@@ -1630,7 +1631,7 @@ bool Settings::isDx9GrabbingEnabled() {
 
 void Settings::setDx9GrabbingEnabled(bool isEnabled) {
 	setValue(Profile::Key::Grab::IsDx9GrabbingEnabled, isEnabled);
-	m_this->dx9GrabberEnabledChanged(isEnabled);
+	emit m_this->dx9GrabberEnabledChanged(isEnabled);
 }
 #endif
 
@@ -1670,18 +1671,18 @@ void Settings::setLightpackMode(Lightpack::Mode mode)
 	if (mode == Lightpack::AmbilightMode)
 	{
 		setValue(Profile::Key::LightpackMode, Profile::Value::LightpackMode::Ambilight);
-		m_this->lightpackModeChanged(mode);
+		emit m_this->lightpackModeChanged(mode);
 	}
 	else if (mode == Lightpack::MoodLampMode)
 	{
 		setValue(Profile::Key::LightpackMode, Profile::Value::LightpackMode::MoodLamp);
-		m_this->lightpackModeChanged(mode);
+		emit m_this->lightpackModeChanged(mode);
 	}
 #ifdef SOUNDVIZ_SUPPORT
 	else if (mode == Lightpack::SoundVisualizeMode)
 	{
 		setValue(Profile::Key::LightpackMode, Profile::Value::LightpackMode::SoundVisualizer);
-		m_this->lightpackModeChanged(mode);
+		emit m_this->lightpackModeChanged(mode);
 	}
 #endif
 	else
@@ -1700,7 +1701,7 @@ void Settings::setMoodLampLiquidMode(bool value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::MoodLamp::IsLiquidMode, value );
-	m_this->moodLampLiquidModeChanged(value);
+	emit m_this->moodLampLiquidModeChanged(value);
 }
 
 QColor Settings::getMoodLampColor()
@@ -1713,7 +1714,7 @@ void Settings::setMoodLampColor(QColor value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value.name();
 	setValue(Profile::Key::MoodLamp::Color, value.name() );
-	m_this->moodLampColorChanged(value);
+	emit m_this->moodLampColorChanged(value);
 }
 
 int Settings::getMoodLampSpeed()
@@ -1726,7 +1727,7 @@ void Settings::setMoodLampSpeed(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::MoodLamp::Speed, getValidMoodLampSpeed(value));
-	m_this->moodLampSpeedChanged(value);
+	emit m_this->moodLampSpeedChanged(value);
 }
 
 int Settings::getMoodLampLamp()
@@ -1739,7 +1740,7 @@ void Settings::setMoodLampLamp(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::MoodLamp::Lamp, value);
-	m_this->moodLampLampChanged(value);
+	emit m_this->moodLampLampChanged(value);
 }
 
 #ifdef SOUNDVIZ_SUPPORT
@@ -1752,7 +1753,7 @@ void Settings::setSoundVisualizerDevice(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value;
 	setValue(Profile::Key::SoundVisualizer::Device, value);
-	m_this->soundVisualizerDeviceChanged(value);
+	emit m_this->soundVisualizerDeviceChanged(value);
 }
 
 int Settings::getSoundVisualizerVisualizer()
@@ -1764,7 +1765,7 @@ void Settings::setSoundVisualizerVisualizer(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value;
 	setValue(Profile::Key::SoundVisualizer::Visualizer, value);
-	m_this->soundVisualizerVisualizerChanged(value);
+	emit m_this->soundVisualizerVisualizerChanged(value);
 }
 
 QColor Settings::getSoundVisualizerMinColor()
@@ -1777,7 +1778,7 @@ void Settings::setSoundVisualizerMinColor(QColor value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value.name();
 	setValue(Profile::Key::SoundVisualizer::MinColor, value.name());
-	m_this->soundVisualizerMinColorChanged(value);
+	emit m_this->soundVisualizerMinColorChanged(value);
 }
 
 QColor Settings::getSoundVisualizerMaxColor()
@@ -1790,7 +1791,7 @@ void Settings::setSoundVisualizerMaxColor(QColor value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << value.name();
 	setValue(Profile::Key::SoundVisualizer::MaxColor, value.name());
-	m_this->soundVisualizerMaxColorChanged(value);
+	emit m_this->soundVisualizerMaxColorChanged(value);
 }
 
 bool Settings::isSoundVisualizerLiquidMode()
@@ -1803,7 +1804,7 @@ void Settings::setSoundVisualizerLiquidMode(bool value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::SoundVisualizer::IsLiquidMode, value);
-	m_this->soundVisualizerLiquidModeChanged(value);
+	emit m_this->soundVisualizerLiquidModeChanged(value);
 }
 
 int Settings::getSoundVisualizerLiquidSpeed()
@@ -1816,7 +1817,7 @@ void Settings::setSoundVisualizerLiquidSpeed(int value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValue(Profile::Key::SoundVisualizer::LiquidSpeed, getValidSoundVisualizerLiquidSpeed(value));
-	m_this->soundVisualizerLiquidSpeedChanged(value);
+	emit m_this->soundVisualizerLiquidSpeedChanged(value);
 }
 #endif
 
@@ -1850,50 +1851,50 @@ void Settings::setLedCoefRed(int ledIndex, double value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValidLedCoef(ledIndex, Profile::Key::Led::CoefRed, value);
-	m_this->ledCoefRedChanged(ledIndex, value);
+	emit m_this->ledCoefRedChanged(ledIndex, value);
 }
 
 void Settings::setLedCoefGreen(int ledIndex, double value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValidLedCoef(ledIndex, Profile::Key::Led::CoefGreen, value);
-	m_this->ledCoefGreenChanged(ledIndex, value);
+	emit m_this->ledCoefGreenChanged(ledIndex, value);
 }
 
 void Settings::setLedCoefBlue(int ledIndex, double value)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	setValidLedCoef(ledIndex, Profile::Key::Led::CoefBlue, value);
-	m_this->ledCoefBlueChanged(ledIndex, value);
+	emit m_this->ledCoefBlueChanged(ledIndex, value);
 }
 
 QSize Settings::getLedSize(int ledIndex)
 {
-	return value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "/" + Profile::Key::Led::Size).toSize();
+	return value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::Size).toSize();
 }
 
 void Settings::setLedSize(int ledIndex, QSize size)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
-	setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "/" + Profile::Key::Led::Size, size);
-	m_this->ledSizeChanged(ledIndex, size);
+	setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::Size, size);
+	emit m_this->ledSizeChanged(ledIndex, size);
 }
 
 QPoint Settings::getLedPosition(int ledIndex)
 {
-	return value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "/" + Profile::Key::Led::Position).toPoint();
+	return value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::Position).toPoint();
 }
 
 void Settings::setLedPosition(int ledIndex, QPoint position)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
-	setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "/" + Profile::Key::Led::Position, position);
-	m_this->ledPositionChanged(ledIndex, position);
+	setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::Position, position);
+	emit m_this->ledPositionChanged(ledIndex, position);
 }
 
 bool Settings::isLedEnabled(int ledIndex)
 {
-	QVariant result = value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "/" + Profile::Key::Led::IsEnabled);
+	QVariant result = value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::IsEnabled);
 	if (result.isNull())
 		return Profile::Led::IsEnabledDefault;
 	else
@@ -1903,8 +1904,8 @@ bool Settings::isLedEnabled(int ledIndex)
 void Settings::setLedEnabled(int ledIndex, bool isEnabled)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
-	setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "/" + Profile::Key::Led::IsEnabled, isEnabled);
-	m_this->ledEnabledChanged(ledIndex, isEnabled);
+	setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + Profile::Key::Led::IsEnabled, isEnabled);
+	emit m_this->ledEnabledChanged(ledIndex, isEnabled);
 }
 
 int Settings::getValidDeviceRefreshDelay(int value)
@@ -2009,8 +2010,8 @@ int Settings::getValidGrabOverBrighten(int value)
 void Settings::setValidLedCoef(int ledIndex, const QString & keyCoef, double coef)
 {
 	if (coef < Profile::Led::CoefMin || coef > Profile::Led::CoefMax){
-		QString error = "Error: outside the valid values (coef < " +
-				QString::number(Profile::Led::CoefMin) + " || coef > " + QString::number(Profile::Led::CoefMax) + ").";
+		QString error = QStringLiteral("Error: outside the valid values (coef < ") +
+				QString::number(Profile::Led::CoefMin) + QStringLiteral(" || coef > ") + QString::number(Profile::Led::CoefMax) + QStringLiteral(").");
 
 		qWarning() << Q_FUNC_INFO << "Settings bad value"
 					<< "[" + Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "]"
@@ -2019,19 +2020,19 @@ void Settings::setValidLedCoef(int ledIndex, const QString & keyCoef, double coe
 					<< "Convert to double error. Set it to default value" << keyCoef << "=" << Profile::Led::CoefDefault;
 		coef = Profile::Led::CoefDefault;
 	}
-	Settings::setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "/" + keyCoef, coef);
+	Settings::setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + keyCoef, coef);
 }
 
 double Settings::getValidLedCoef(int ledIndex, const QString & keyCoef)
 {
 	bool ok = false;
-	double coef = Settings::value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "/" + keyCoef).toDouble(&ok);
+	double coef = Settings::value(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + keyCoef).toDouble(&ok);
 	QString error;
 	if (ok == false){
-		error = "Error: Convert to double.";
+		error = QStringLiteral("Error: Convert to double.");
 	} else if (coef < Profile::Led::CoefMin || coef > Profile::Led::CoefMax){
-		QString error = "Error: outside the valid values (coef < " +
-				QString::number(Profile::Led::CoefMin) + " || coef > " + QString::number(Profile::Led::CoefMax) + ").";
+		error = QStringLiteral("Error: outside the valid values (coef < ") +
+				QString::number(Profile::Led::CoefMin) + QStringLiteral(" || coef > ") + QString::number(Profile::Led::CoefMax) + ").";
 	} else {
 		// OK
 		return coef;
@@ -2043,12 +2044,12 @@ double Settings::getValidLedCoef(int ledIndex, const QString & keyCoef)
 				<< error
 				<< "Set it to default value" << keyCoef << "=" << Profile::Led::CoefDefault;
 	coef = Profile::Led::CoefDefault;
-	Settings::setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + "/" + keyCoef, coef);
+	Settings::setValue(Profile::Key::Led::Prefix + QString::number(ledIndex + 1) + QStringLiteral("/") + keyCoef, coef);
 	return coef;
 }
 
 QString Settings::getProfilesPath() {
-	return m_applicationDirPath + "Profiles/";
+	return m_applicationDirPath + QStringLiteral("Profiles/");
 }
 
 bool Settings::isCheckForUpdatesEnabled() {
@@ -2133,18 +2134,18 @@ void Settings::initCurrentProfile(bool isResetDefault)
 		ledPosition = getDefaultPosition(i);
 
 
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + "/" + Profile::Key::Led::IsEnabled,
+		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::IsEnabled,
 						Profile::Led::IsEnabledDefault, isResetDefault);
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + "/" + Profile::Key::Led::Position,
+		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::Position,
 						ledPosition, isResetDefault);
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + "/" + Profile::Key::Led::Size,
+		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::Size,
 						Profile::Led::SizeDefault, isResetDefault);
 
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + "/" + Profile::Key::Led::CoefRed,
+		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::CoefRed,
 						Profile::Led::CoefDefault, isResetDefault);
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + "/" + Profile::Key::Led::CoefGreen,
+		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::CoefGreen,
 						Profile::Led::CoefDefault, isResetDefault);
-		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + "/" + Profile::Key::Led::CoefBlue,
+		setNewOption(Profile::Key::Led::Prefix + QString::number(i + 1) + QStringLiteral("/") + Profile::Key::Led::CoefBlue,
 						Profile::Led::CoefDefault, isResetDefault);
 	}
 
@@ -2152,7 +2153,7 @@ void Settings::initCurrentProfile(bool isResetDefault)
 	QMutexLocker locker(&m_mutex);
 	m_currentProfile->sync();
 	locker.unlock();
-	m_this->currentProfileInited(getCurrentProfileName());
+	emit m_this->currentProfileInited(getCurrentProfileName());
 }
 
 
@@ -2294,7 +2295,7 @@ void Settings::initDevicesMap()
 void Settings::migrateSettings()
 {
 
-	if (valueMain(Main::Key::MainConfigVersion).toString() == "1.0") {
+	if (valueMain(Main::Key::MainConfigVersion).toString() == QStringLiteral("1.0")) {
 
 		if (getConnectedDevice() == SupportedDevices::DeviceTypeLightpack){
 
@@ -2322,21 +2323,21 @@ void Settings::migrateSettings()
 				Settings::setLedCoefBlue(i, remappedLeds[i].wbBlue);
 			}
 		}
-		setValueMain(Main::Key::MainConfigVersion, "2.0");
+		setValueMain(Main::Key::MainConfigVersion, QStringLiteral("2.0"));
 	}
-	if (valueMain(Main::Key::MainConfigVersion).toString() == "2.0") {
+	if (valueMain(Main::Key::MainConfigVersion).toString() == QStringLiteral("2.0")) {
 		// Disable ApiAuth by default
-		setApiKey("");
+		setApiKey(QLatin1String(""));
 
 		// Remove obsolete keys
-		QString authEnabledKey = "API/IsAuthEnabled";
+		QString authEnabledKey = QStringLiteral("API/IsAuthEnabled");
 		if(m_mainConfig->contains(authEnabledKey)) {
 			m_mainConfig->remove(authEnabledKey);
 		}
 
-		setValueMain(Main::Key::MainConfigVersion, "3.0");
+		setValueMain(Main::Key::MainConfigVersion, QStringLiteral("3.0"));
 	}
-	if (valueMain(Main::Key::MainConfigVersion).toString() == "3.0") {
+	if (valueMain(Main::Key::MainConfigVersion).toString() == QStringLiteral("3.0")) {
 #ifdef WINAPI_GRAB_SUPPORT
 		Settings::setGrabberType(Grab::GrabberTypeWinAPI);
 #endif
@@ -2351,7 +2352,7 @@ void Settings::migrateSettings()
 		Settings::setGrabberType(Grab::GrabberTypeMacCoreGraphics);
 #endif
 
-		setValueMain(Main::Key::MainConfigVersion, "4.0");
+		setValueMain(Main::Key::MainConfigVersion, QStringLiteral("4.0"));
 	}
 }
 } /*SettingsScope*/

--- a/Software/src/Settings.hpp
+++ b/Software/src/Settings.hpp
@@ -158,7 +158,7 @@ public:
 	static void setNumberOfLeds(SupportedDevices::DeviceType device, int numberOfLeds);
 	static int getNumberOfLeds(SupportedDevices::DeviceType device);
 
-	static void setColorSequence(SupportedDevices::DeviceType device, QString colorSequence);
+	static void setColorSequence(SupportedDevices::DeviceType device, const QString& colorSequence);
 	static QString getColorSequence(SupportedDevices::DeviceType device);
 
 	// Profile

--- a/Software/src/SettingsDefaults.hpp
+++ b/Software/src/SettingsDefaults.hpp
@@ -73,8 +73,8 @@ namespace SettingsScope
 namespace Main
 {
 // [General]
-static const QString ProfileNameDefault = "Lightpack";
-static const QString LanguageDefault = "<System>";
+static const QString ProfileNameDefault = QStringLiteral("Lightpack");
+static const QString LanguageDefault = QStringLiteral("<System>");
 static const Debug::DebugLevels DebugLevelDefault = Debug::ZeroLevel;
 static const bool IsKeepLightsOnAfterExit = false;
 static const bool IsKeepLightsOnAfterLock = true;
@@ -82,15 +82,15 @@ static const bool IsKeepLightsOnAfterSuspend = false;
 static const bool IsKeepLightsOnAfterScreenOff = true;
 static const bool IsPingDeviceEverySecond = true;
 static const bool IsUpdateFirmwareMessageShown = false;
-static const QString ConnectedDeviceDefault = "Lightpack";
-static const QString SupportedDevices = SUPPORTED_DEVICES; /* comma separated values! */
+static const QString ConnectedDeviceDefault = QStringLiteral("Lightpack");
+static const QString SupportedDevices = QStringLiteral(SUPPORTED_DEVICES); /* comma separated values! */
 static const bool CheckForUpdates = true;
 static const bool InstallUpdates = true;
 
 // [HotKeys]
 namespace HotKeys
 {
-static const QString HotkeyDefault = "Undefined";
+static const QString HotkeyDefault = QStringLiteral("Undefined");
 }
 
 // [API]
@@ -99,7 +99,7 @@ namespace Api
 static const bool IsEnabledDefault = false;
 static const bool ListenOnlyOnLoInterfaceDefault = true;
 static const int PortDefault = 3636;
-static const QString AuthKey = "";
+static const QString AuthKey = QLatin1String("");
 // See ApiKey generation in Settings initialization
 }
 namespace Device
@@ -110,16 +110,16 @@ static const double PowerSupplyAmpsDefault = 0.0;
 namespace Adalight
 {
 static const int NumberOfLedsDefault = 25;
-static const QString ColorSequence = "RGB";
-static const QString PortDefault = SERIAL_PORT_DEFAULT;
-static const QString BaudRateDefault = "115200";
+static const QString ColorSequence = QStringLiteral("RGB");
+static const QString PortDefault = QStringLiteral(SERIAL_PORT_DEFAULT);
+static const QString BaudRateDefault = QStringLiteral("115200");
 }
 namespace Ardulight
 {
 static const int NumberOfLedsDefault = 10;
-static const QString ColorSequence = "RGB";
-static const QString PortDefault = SERIAL_PORT_DEFAULT;
-static const QString BaudRateDefault = "115200";
+static const QString ColorSequence = QStringLiteral("RGB");
+static const QString PortDefault = QStringLiteral(SERIAL_PORT_DEFAULT);
+static const QString BaudRateDefault = QStringLiteral("115200");
 }
 namespace AlienFx
 {
@@ -136,22 +136,22 @@ static const int NumberOfLedsDefault = 10;
 namespace Drgb
 {
 static const int NumberOfLedsDefault = 10;
-static const QString AddressDefault = "127.0.0.1";
-static const QString PortDefault = "21324";
+static const QString AddressDefault = QStringLiteral("127.0.0.1");
+static const QString PortDefault = QStringLiteral("21324");
 static const int TimeoutDefault = 255;
 }
 namespace Dnrgb
 {
 static const int NumberOfLedsDefault = 10;
-static const QString AddressDefault = "127.0.0.1";
-static const QString PortDefault = "21324";
+static const QString AddressDefault = QStringLiteral("127.0.0.1");
+static const QString PortDefault = QStringLiteral("21324");
 static const int TimeoutDefault = 255;
 }
 namespace Warls
 {
 static const int NumberOfLedsDefault = 10;
-static const QString AddressDefault = "127.0.0.1";
-static const QString PortDefault = "21324";
+static const QString AddressDefault = QStringLiteral("127.0.0.1");
+static const QString PortDefault = QStringLiteral("21324");
 static const int TimeoutDefault = 255;
 }
 }
@@ -161,13 +161,13 @@ namespace Profile
 {
 // [General]
 static const bool IsBacklightEnabledDefault = true;
-static const QString LightpackModeDefault = "Ambilight";
+static const QString LightpackModeDefault = QStringLiteral("Ambilight");
 
 // [Grab]
 namespace Grab
 {
 static const ::Grab::GrabberType GrabberDefault = GRABMODE_DEFAULT;
-static const QString GrabberDefaultString = GRABMODE_DEFAULT_STR;
+static const QString GrabberDefaultString = QStringLiteral(GRABMODE_DEFAULT_STR);
 static const bool IsAvgColorsEnabledDefault = false;
 static const bool IsSendDataOnlyIfColorsChangesDefault = false;
 static const bool IsMinimumLuminosityEnabledDefault = true;
@@ -198,7 +198,7 @@ static const int LampDefault = 0;
 static const int SpeedMin = 1;
 static const int SpeedDefault = 50;
 static const int SpeedMax = 100;
-static const QString ColorDefault = "#00FF00";
+static const QString ColorDefault = QStringLiteral("#00FF00");
 static const bool IsLiquidModeDefault = true;
 }
 // [SoundVisualizer]
@@ -206,8 +206,8 @@ namespace SoundVisualizer
 {
 static const int DeviceDefault = -1;
 static const int VisualizerDefault = 0;
-static const QString MinColorDefault = "#301000";
-static const QString MaxColorDefault = "#0000FF";
+static const QString MinColorDefault = QStringLiteral("#301000");
+static const QString MaxColorDefault = QStringLiteral("#0000FF");
 static const bool IsLiquidModeDefault = true;
 static const int LiquidSpeedMin = 1;
 static const int LiquidSpeedDefault = 10;

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -55,13 +55,13 @@ using namespace SettingsScope;
 // ----------------------------------------------------------------------------
 namespace {
 #ifdef Q_OS_WIN
-const QString BaudrateWarningSign = " <b>!!!</b>";
+const QString BaudrateWarningSign = QStringLiteral(" <b>!!!</b>");
 #else
-const QString BaudrateWarningSign = " ⚠️";
+const QString BaudrateWarningSign = QStringLiteral(" ⚠️");
 #endif
 }
-const QString SettingsWindow::DeviceFirmvareVersionUndef = "undef";
-const QString SettingsWindow::LightpackDownloadsPageUrl = "http://code.google.com/p/lightpack/downloads/list";
+const QString SettingsWindow::DeviceFirmvareVersionUndef = QStringLiteral("undef");
+const QString SettingsWindow::LightpackDownloadsPageUrl = QStringLiteral("http://code.google.com/p/lightpack/downloads/list");
 
 // Indexes of supported modes listed in ui->comboBox_Modes and ui->stackedWidget_Modes
 const int SettingsWindow::GrabModeIndex = 0;
@@ -111,14 +111,14 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
 
 
 	m_labelStatusIcon = new QLabel(statusBar());
-	m_labelStatusIcon->setStyleSheet("QLabel{margin-right: .5em}");
-	m_labelStatusIcon->setPixmap(Settings::isBacklightEnabled() ? *(m_pixmapCache["on16"]) : *(m_pixmapCache["off16"]));
+	m_labelStatusIcon->setStyleSheet(QStringLiteral("QLabel{margin-right: .5em}"));
+	m_labelStatusIcon->setPixmap(Settings::isBacklightEnabled() ? *(m_pixmapCache[QStringLiteral("on16")]) : *(m_pixmapCache[QStringLiteral("off16")]));
 	labelProfile = new QLabel(statusBar());
-	labelProfile->setStyleSheet("margin-left:1em");
+	labelProfile->setStyleSheet(QStringLiteral("margin-left:1em"));
 	labelDevice = new QLabel(statusBar());
 	labelFPS	= new QLabel(statusBar());
 
-	statusBar()->setStyleSheet("QStatusBar{border-top: 1px solid; border-color: palette(midlight);} QLabel{margin:0.2em}");
+	statusBar()->setStyleSheet(QStringLiteral("QStatusBar{border-top: 1px solid; border-color: palette(midlight);} QLabel{margin:0.2em}"));
 	statusBar()->setSizeGripEnabled(false);
 	statusBar()->addWidget(labelProfile, 4);
 	statusBar()->addWidget(labelDevice, 4);
@@ -268,6 +268,8 @@ void SettingsWindow::connectSignalsSlots()
 	connect(ui->horizontalSlider_GammaCorrection, SIGNAL(valueChanged(int)), this, SLOT(onSliderDeviceGammaCorrection_valueChanged(int)));
 	connect(ui->checkBox_SendDataOnlyIfColorsChanges, SIGNAL(toggled(bool)), this, SLOT(onDeviceSendDataOnlyIfColorsChanged_toggled(bool)));
 
+	connect(ui->pbRunConfigurationWizard, SIGNAL(clicked()), this, SLOT(onRunConfigurationWizard_clicked()));
+
 	// Open Settings file
 	connect(ui->commandLinkButton_OpenSettings, SIGNAL(clicked()), this, SLOT(openCurrentProfile()));
 
@@ -293,7 +295,7 @@ void SettingsWindow::connectSignalsSlots()
 	connect(ui->radioButton_SoundVizLiquidMode, SIGNAL(toggled(bool)), this, SLOT(onSoundVizLiquidMode_Toggled(bool)));
 	connect(ui->horizontalSlider_SoundVizLiquidSpeed, SIGNAL(valueChanged(int)), this, SLOT(onSoundVizLiquidSpeed_valueChanged(int)));
 #ifdef Q_OS_MACOS
-	connect(ui->pushButton_SoundVizDeviceHelp, SIGNAL(clicked()), this, SLOT(on_pushButton_SoundVizDeviceHelp_clicked()));
+	connect(ui->pushButton_SoundVizDeviceHelp, SIGNAL(clicked()), this, SLOT(onSoundVizDeviceHelp_clicked()));
 #else
 	ui->pushButton_SoundVizDeviceHelp->hide();
 #endif // Q_OS_MACOS
@@ -374,7 +376,7 @@ void SettingsWindow::changeEvent(QEvent *e)
 
 		setWindowTitle(tr("Prismatik: %1").arg(ui->comboBox_Profiles->lineEdit()->text()));
 
-		ui->listWidget->addItem("dirty hack");
+		ui->listWidget->addItem(QStringLiteral("dirty hack"));
 		item = ui->listWidget->takeItem(ui->listWidget->count()-1);
 		delete item;
 		ui->listWidget->setCurrentRow(currentPage);
@@ -424,7 +426,7 @@ void SettingsWindow::updateStatusBar() {
 
 	this->labelProfile->setText(tr("Profile: %1").arg(Settings::getCurrentProfileName()));
 	this->labelDevice->setText(tr("Device: %1").arg(Settings::getConnectedDeviceName()));
-	this->labelFPS->setText(tr("FPS: %1").arg(""));
+	this->labelFPS->setText(tr("FPS: %1").arg(QLatin1String("")));
 }
 
 void SettingsWindow::updateDeviceTabWidgetsVisibility()
@@ -513,29 +515,29 @@ int SettingsWindow::getLigtpackFirmwareVersionMajor()
 
 void SettingsWindow::onPostInit() {
 	updateUiFromSettings();
-	this->requestFirmwareVersion();
-	this->requestMoodLampLamps();
+	emit requestFirmwareVersion();
+	emit requestMoodLampLamps();
 #ifdef SOUNDVIZ_SUPPORT
-	this->requestSoundVizDevices();
-	this->requestSoundVizVisualizers();
+	emit requestSoundVizDevices();
+	emit requestSoundVizVisualizers();
 #endif
 
 	if (m_trayIcon) {
 		bool updateJustFailed = false;
 		if (!Settings::getAutoUpdatingVersion().isEmpty()) {
-			if (Settings::getAutoUpdatingVersion() != VERSION_STR) {
-				m_trayIcon->showMessage(tr("Prismatik was updated"), tr("Successfully updated to version %1.").arg(VERSION_STR));
+			if (Settings::getAutoUpdatingVersion() != QStringLiteral(VERSION_STR)) {
+				m_trayIcon->showMessage(tr("Prismatik was updated"), tr("Successfully updated to version %1.").arg(QStringLiteral(VERSION_STR)));
 			} else {
 				QMessageBox::critical(
 					this,
 					tr("Prismatik automatic update failed"),
 					tr("There was a problem when trying to automatically update Prismatik to the latest version.\n")
-					+ tr("You are still on version %1.\n").arg(VERSION_STR)
+					+ tr("You are still on version %1.\n").arg(QStringLiteral(VERSION_STR))
 					+ tr("Installing updates automatically was disabled."));
 				updateJustFailed = true;
 				ui->checkBox_installUpdates->setChecked(false);
 			}
-			Settings::setAutoUpdatingVersion("");
+			Settings::setAutoUpdatingVersion(QLatin1String(""));
 		}
 
 		if (Settings::isCheckForUpdatesEnabled() && !updateJustFailed)
@@ -579,11 +581,11 @@ void SettingsWindow::onSetApiPort_Clicked()
 		emit updateApiPort(port);
 
 		ui->lineEdit_ApiPort->setStyleSheet(this->styleSheet());
-		ui->lineEdit_ApiPort->setToolTip("");
+		ui->lineEdit_ApiPort->setToolTip(QLatin1String(""));
 	} else {
-		QString errorMessage = "Convert to 'int' fail";
+		QString errorMessage = QStringLiteral("Convert to 'int' fail");
 
-		ui->lineEdit_ApiPort->setStyleSheet("background-color:red;");
+		ui->lineEdit_ApiPort->setStyleSheet(QStringLiteral("background-color:red;"));
 		ui->lineEdit_ApiPort->setToolTip(errorMessage);
 
 		qWarning() << Q_FUNC_INFO << errorMessage << "port:" << ui->lineEdit_ApiPort->text();
@@ -632,7 +634,7 @@ void SettingsWindow::onOpenLogs_clicked()
 	QDesktopServices::openUrl(QUrl(LogWriter::getLogsDir().absolutePath()));
 }
 
-void SettingsWindow::setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus status,	QList<QString> modules)
+void SettingsWindow::setDeviceLockViaAPI(const DeviceLocked::DeviceLockStatus status,	const QList<QString>& modules)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << status;
 	m_deviceLockStatus = status;
@@ -737,7 +739,7 @@ void SettingsWindow::startBacklight()
 
 
 	if (m_deviceLockKey.count()==0)
-		m_deviceLockModule = "";
+		m_deviceLockModule = QLatin1String("");
 
 	updateTrayAndActionStates();
 }
@@ -776,45 +778,45 @@ void SettingsWindow::updateTrayAndActionStates()
 	switch (m_backlightStatus)
 	{
 	case Backlight::StatusOn:
-		ui->pushButton_EnableDisableDevice->setIcon(QIcon(*m_pixmapCache["off16"]));
+		ui->pushButton_EnableDisableDevice->setIcon(QIcon(*m_pixmapCache[QStringLiteral("off16")]));
 		ui->pushButton_EnableDisableDevice->setText("	" + tr("Turn lights OFF"));
 
 		if (m_deviceLockStatus == DeviceLocked::Api)
 		{
-			m_labelStatusIcon->setPixmap(*m_pixmapCache["lock16"]);
+			m_labelStatusIcon->setPixmap(*m_pixmapCache[QStringLiteral("lock16")]);
 			if (m_trayIcon)
 				m_trayIcon->setStatus(SysTrayIcon::StatusLockedByApi);
 		} else
 			if (m_deviceLockStatus == DeviceLocked::Plugin)
 			{
-				m_labelStatusIcon->setPixmap(*m_pixmapCache["lock16"]);
+				m_labelStatusIcon->setPixmap(*m_pixmapCache[QStringLiteral("lock16")]);
 				if (m_trayIcon)
 					m_trayIcon->setStatus(SysTrayIcon::StatusLockedByPlugin, &m_deviceLockModule);
 			} else
 				if (m_deviceLockStatus == DeviceLocked::ApiPersist)
 				{
-					m_labelStatusIcon->setPixmap(*m_pixmapCache["persist16"]);
+					m_labelStatusIcon->setPixmap(*m_pixmapCache[QStringLiteral("persist16")]);
 					if (m_trayIcon)
 						m_trayIcon->setStatus(SysTrayIcon::StatusApiPersist);
 				} else {
-						m_labelStatusIcon->setPixmap(*m_pixmapCache["on16"]);
+						m_labelStatusIcon->setPixmap(*m_pixmapCache[QStringLiteral("on16")]);
 						if (m_trayIcon)
 							m_trayIcon->setStatus(SysTrayIcon::StatusOn);
 				}
 		break;
 
 	case Backlight::StatusOff:
-		m_labelStatusIcon->setPixmap(*m_pixmapCache["off16"]);
-		ui->pushButton_EnableDisableDevice->setIcon(QIcon(*m_pixmapCache["on16"]));
-		ui->pushButton_EnableDisableDevice->setText("	" + tr("Turn lights ON"));
+		m_labelStatusIcon->setPixmap(*m_pixmapCache[QStringLiteral("off16")]);
+		ui->pushButton_EnableDisableDevice->setIcon(QIcon(*m_pixmapCache[QStringLiteral("on16")]));
+		ui->pushButton_EnableDisableDevice->setText(QStringLiteral("	") + tr("Turn lights ON"));
 		if (m_trayIcon)
 			m_trayIcon->setStatus(SysTrayIcon::StatusOff);
 		break;
 
 	case Backlight::StatusDeviceError:
-		m_labelStatusIcon->setPixmap(*m_pixmapCache["error16"]);
-		ui->pushButton_EnableDisableDevice->setIcon(QIcon(*m_pixmapCache["off16"]));
-		ui->pushButton_EnableDisableDevice->setText("	" + tr("Turn lights OFF"));
+		m_labelStatusIcon->setPixmap(*m_pixmapCache[QStringLiteral("error16")]);
+		ui->pushButton_EnableDisableDevice->setIcon(QIcon(*m_pixmapCache[QStringLiteral("off16")]));
+		ui->pushButton_EnableDisableDevice->setText(QStringLiteral("	") + tr("Turn lights OFF"));
 		if (m_trayIcon)
 			m_trayIcon->setStatus(SysTrayIcon::StatusError);
 		break;
@@ -928,9 +930,9 @@ void SettingsWindow::requestBacklightStatus()
 	emit resultBacklightStatus(m_backlightStatus);
 }
 
-void SettingsWindow::onApiServer_ErrorOnStartListening(QString errorMessage)
+void SettingsWindow::onApiServer_ErrorOnStartListening(const QString& errorMessage)
 {
-	ui->lineEdit_ApiPort->setStyleSheet("background-color:red;");
+	ui->lineEdit_ApiPort->setStyleSheet(QStringLiteral("background-color:red;"));
 	ui->lineEdit_ApiPort->setToolTip(errorMessage);
 }
 
@@ -949,18 +951,18 @@ void SettingsWindow::processMessage(const QString &message)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << message;
 
-	if (message == "on")
+	if (message == QStringLiteral("on"))
 		setBacklightStatus(Backlight::StatusOn);
-	else if (message == "off")
+	else if (message == QStringLiteral("off"))
 		setBacklightStatus(Backlight::StatusOff);
-	else if (message.startsWith("set-profile ")) {
+	else if (message.startsWith(QStringLiteral("set-profile "))) {
 		QString profile = message.mid(12);
 		profileSwitch(profile);
-	} else if (message == "quitForWizard") {
+	} else if (message == QStringLiteral("quitForWizard")) {
 		qWarning() << "Wizard was started, quitting!";
 		LightpackApplication::quit();
 	} else if (m_trayIcon != NULL) { // "alreadyRunning"
-		qWarning(qPrintable(message));
+		qWarning() << message;
 		m_trayIcon->showMessage(SysTrayIcon::MessageAnotherInstance);
 		this->show();
 		this->activateWindow();
@@ -1123,12 +1125,12 @@ void SettingsWindow::ledDeviceFirmwareVersionResult(const QString & fwVersion)
 
 	if (Settings::getConnectedDevice() == SupportedDevices::DeviceTypeLightpack)
 	{
-		if (m_deviceFirmwareVersion == "5.0" || m_deviceFirmwareVersion == "4.3")
+		if (m_deviceFirmwareVersion == QStringLiteral("5.0") || m_deviceFirmwareVersion == QStringLiteral("4.3"))
 		{
-			aboutDialogFirmwareString += QString(" ") +
-					"(<a href=\"" + LightpackDownloadsPageUrl + "\">" +
+			aboutDialogFirmwareString += QStringLiteral(" ") +
+					QStringLiteral("(<a href=\"") + LightpackDownloadsPageUrl + QStringLiteral("\">") +
 					tr("update firmware") +
-					"</a>)";
+					QStringLiteral("</a>)");
 
 			if (Settings::isUpdateFirmwareMessageShown() == false)
 			{
@@ -1163,7 +1165,7 @@ void SettingsWindow::refreshAmbilightEvaluated(double updateResultMs)
 	QString fpsText = QString::number(hz, 'f', 0);
 	if (ui->comboBox_LightpackModes->currentIndex() == GrabModeIndex) {
 		const double maxHz = 1000.0 / ui->spinBox_GrabSlowdown->value(); // cap with display refresh rate?
-		fpsText += " / " + QString::number(maxHz, 'f', 0);
+		fpsText += QStringLiteral(" / ") + QString::number(maxHz, 'f', 0);
 	}
 	ui->label_GrabFrequency_value->setText(fpsText);
 
@@ -1213,7 +1215,7 @@ void SettingsWindow::clearBaudrateWarning()
 
 	ui->label_GrabFrequency_value->setPalette(palette);
 	this->labelFPS->setPalette(palette);
-	this->labelFPS->setToolTip("");
+	this->labelFPS->setToolTip(QLatin1String(""));
 
 	this->labelFPS->setText(this->labelFPS->text().remove(BaudrateWarningSign));
 }
@@ -1453,7 +1455,7 @@ void SettingsWindow::onLightpackModeChanged(Lightpack::Mode mode)
 		DEBUG_LOW_LEVEL << "LightpacckMode unsuppotred value =" << mode;
 		break;
 	}
-	backlightStatusChanged(m_backlightStatus);
+	emit backlightStatusChanged(m_backlightStatus);
 }
 
 void SettingsWindow::onMoodLampColor_changed(QColor color)
@@ -1577,10 +1579,10 @@ void SettingsWindow::openFile(const QString &filePath)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 
-	QString filePrefix = "file://";
+	QString filePrefix = QStringLiteral("file://");
 
 #ifdef Q_OS_WIN
-	filePrefix = "file:///";
+	filePrefix = QStringLiteral("file:///");
 #endif
 
 	QDesktopServices::openUrl(QUrl(filePrefix + filePath, QUrl::TolerantMode));
@@ -1614,7 +1616,7 @@ void SettingsWindow::profileRename()
 		return;
 	}
 
-	if (configName == "")
+	if (configName.isEmpty())
 	{
 		configName = Settings::getCurrentProfileName();
 		DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Profile name is empty, return back to" << configName;
@@ -1664,9 +1666,9 @@ void SettingsWindow::profileTraySwitch(const QString &profileName)
 	return;
 }
 
-void SettingsWindow::profileSwitchCombobox(QString profile)
+void SettingsWindow::profileSwitchCombobox(const QString& profile)
 {
-	int index = ui->comboBox_Profiles->findText(profile);
+	const int index = ui->comboBox_Profiles->findText(profile);
 	ui->comboBox_Profiles->setCurrentIndex(index);
 }
 
@@ -1681,7 +1683,7 @@ void SettingsWindow::profileNew()
 		while(ui->comboBox_Profiles->findText(profileName +" "+ QString::number(i)) != -1){
 			i++;
 		}
-		profileName += + " " + QString::number(i);
+		profileName += QStringLiteral(" ") + QString::number(i);
 	}
 
 	ui->comboBox_Profiles->insertItem(0, profileName);
@@ -1757,11 +1759,11 @@ void SettingsWindow::settingsProfileChanged_UpdateUI(const QString &profileName)
 
 void SettingsWindow::initPixmapCache()
 {
-	m_pixmapCache.insert("lock16", new QPixmap(QPixmap(":/icons/lock.png").scaledToWidth(16, Qt::SmoothTransformation)));
-	m_pixmapCache.insert("on16", new QPixmap(QPixmap(":/icons/on.png").scaledToWidth(16, Qt::SmoothTransformation)) );
-	m_pixmapCache.insert("off16", new QPixmap(QPixmap(":/icons/off.png").scaledToWidth(16, Qt::SmoothTransformation)) );
-	m_pixmapCache.insert("error16", new QPixmap(QPixmap(":/icons/error.png").scaledToWidth(16, Qt::SmoothTransformation)) );
-	m_pixmapCache.insert("persist16", new QPixmap(QPixmap(":/icons/persist.png").scaledToWidth(16, Qt::SmoothTransformation)));
+	m_pixmapCache.insert(QStringLiteral("lock16"), new QPixmap(QPixmap(QStringLiteral(":/icons/lock.png")).scaledToWidth(16, Qt::SmoothTransformation)));
+	m_pixmapCache.insert(QStringLiteral("on16"), new QPixmap(QPixmap(QStringLiteral(":/icons/on.png")).scaledToWidth(16, Qt::SmoothTransformation)) );
+	m_pixmapCache.insert(QStringLiteral("off16"), new QPixmap(QPixmap(QStringLiteral(":/icons/off.png")).scaledToWidth(16, Qt::SmoothTransformation)) );
+	m_pixmapCache.insert(QStringLiteral("error16"), new QPixmap(QPixmap(QStringLiteral(":/icons/error.png")).scaledToWidth(16, Qt::SmoothTransformation)) );
+	m_pixmapCache.insert(QStringLiteral("persist16"), new QPixmap(QPixmap(QStringLiteral(":/icons/persist.png")).scaledToWidth(16, Qt::SmoothTransformation)));
 }
 
 //void SettingsWindow::handleConnectedDeviceChange(const SupportedDevices::DeviceType deviceType) {
@@ -1779,13 +1781,13 @@ void SettingsWindow::initLanguages()
 
 	ui->comboBox_Language->clear();
 	ui->comboBox_Language->addItem(tr("System default"));
-	ui->comboBox_Language->addItem("English");
-	ui->comboBox_Language->addItem("Russian");
-	ui->comboBox_Language->addItem("Ukrainian");
+	ui->comboBox_Language->addItem(QStringLiteral("English"));
+	ui->comboBox_Language->addItem(QStringLiteral("Russian"));
+	ui->comboBox_Language->addItem(QStringLiteral("Ukrainian"));
 
 	int langIndex = 0; // "System default"
 	QString langSaved = Settings::getLanguage();
-	if(langSaved != "<System>"){
+	if(langSaved != QStringLiteral("<System>")){
 		langIndex = ui->comboBox_Language->findText(langSaved);
 	}
 	ui->comboBox_Language->setCurrentIndex(langIndex);
@@ -1813,9 +1815,9 @@ void SettingsWindow::loadTranslation(const QString & language)
 		DEBUG_LOW_LEVEL << "System locale" << locale;
 		Settings::setLanguage(SettingsScope::Main::LanguageDefault);
 	}
-	else if (language == "English") locale = "en_EN"; // :/translations/en_EN.qm
-	else if (language == "Russian") locale = "ru_RU"; // :/translations/ru_RU.qm
-	else if (language == "Ukrainian") locale = "uk_UA"; // :/translations/uk_UA.qm
+	else if (language == QStringLiteral("English")) locale = QStringLiteral("en_EN"); // :/translations/en_EN.qm
+	else if (language == QStringLiteral("Russian")) locale = QStringLiteral("ru_RU"); // :/translations/ru_RU.qm
+	else if (language == QStringLiteral("Ukrainian")) locale = QStringLiteral("uk_UA"); // :/translations/uk_UA.qm
 	// append line for new language/locale here
 	else {
 		qWarning() << "Language" << language << "not found. Set to default" << SettingsScope::Main::LanguageDefault;
@@ -1824,7 +1826,7 @@ void SettingsWindow::loadTranslation(const QString & language)
 		Settings::setLanguage(SettingsScope::Main::LanguageDefault);
 	}
 
-	QString pathToLocale = QString(":/translations/") + locale;
+	QString pathToLocale = QStringLiteral(":/translations/") + locale;
 
 	if(m_translator != NULL){
 		qApp->removeTranslator(m_translator);
@@ -1832,7 +1834,7 @@ void SettingsWindow::loadTranslation(const QString & language)
 		m_translator = NULL;
 	}
 
-	if(locale == "en_EN" /* default no need to translate */){
+	if(locale == QStringLiteral("en_EN") /* default no need to translate */){
 		DEBUG_LOW_LEVEL << "Translation removed, using default locale" << locale;
 		return;
 	}
@@ -2107,7 +2109,7 @@ void SettingsWindow::showHelpOf(QObject *object)
 }
 
 #if defined(SOUNDVIZ_SUPPORT) && defined(Q_OS_MACOS)
-void SettingsWindow::on_pushButton_SoundVizDeviceHelp_clicked()
+void SettingsWindow::onSoundVizDeviceHelp_clicked()
 {
 	showHelpOf(ui->pushButton_SoundVizDeviceHelp);
 }
@@ -2173,7 +2175,7 @@ bool SettingsWindow::toPriority(Plugin* s1 ,Plugin* s2 )
 	return s1->getPriority() > s2->getPriority();
 }
 
-void SettingsWindow::updatePlugin(QList<Plugin*> plugins)
+void SettingsWindow::updatePlugin(const QList<Plugin*>& plugins)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 
@@ -2225,11 +2227,11 @@ void SettingsWindow::pluginSwitch(int index)
 
 	if (index == -1)
 	{
-		ui->label_PluginName->setText("");
-		ui->label_PluginAuthor->setText("");
-		ui->label_PluginVersion->setText("");
-		ui->tb_PluginDescription->setText("");
-		ui->label_PluginIcon->setPixmap(QIcon(":/plugin/Plugin.png").pixmap(50,50));
+		ui->label_PluginName->setText(QLatin1String(""));
+		ui->label_PluginAuthor->setText(QLatin1String(""));
+		ui->label_PluginVersion->setText(QLatin1String(""));
+		ui->tb_PluginDescription->setText(QLatin1String(""));
+		ui->label_PluginIcon->setPixmap(QIcon(QStringLiteral(":/plugin/Plugin.png")).pixmap(50,50));
 		return;
 	}
 
@@ -2288,15 +2290,15 @@ void SettingsWindow::savePriorityPlugin()
 QString SettingsWindow::getPluginName(const Plugin *plugin) const
 {
 	if (plugin->state() == QProcess::Running) {
-		return plugin->Name().append(" (running)");
+		return plugin->Name().append(QStringLiteral(" (running)"));
 	} else {
-		return plugin->Name().append(" (not running)");
+		return plugin->Name().append(QStringLiteral(" (not running)"));
 	}
 }
 
-void SettingsWindow::on_pbRunConfigurationWizard_clicked()
+void SettingsWindow::onRunConfigurationWizard_clicked()
 {
-	const QStringList args("--wizard");
+	const QStringList args(QStringLiteral("--wizard"));
 	QString cmdLine(QApplication::applicationFilePath());
 #ifdef Q_OS_WIN
 	cmdLine.prepend('"');

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -92,10 +92,15 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
 #endif
 
 	// Check windows reserved symbols in profile input name
+	#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+	QRegularExpressionValidator *validatorProfileName = new QRegularExpressionValidator(QRegularExpression("[^<>:\"/\\|?*]*"), this);
+	QRegularExpressionValidator *validatorApiKey = new QRegularExpressionValidator(QRegularExpression("[a-zA-Z0-9{}_-]*"), this);
+	#else
 	QRegExpValidator *validatorProfileName = new QRegExpValidator(QRegExp("[^<>:\"/\\|?*]*"), this);
-	ui->comboBox_Profiles->lineEdit()->setValidator(validatorProfileName);
-
 	QRegExpValidator *validatorApiKey = new QRegExpValidator(QRegExp("[a-zA-Z0-9{}_-]*"), this);
+	#endif
+
+	ui->comboBox_Profiles->lineEdit()->setValidator(validatorProfileName);
 	ui->lineEdit_ApiKey->setValidator(validatorApiKey);
 
 	// hide main tabbar

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -25,8 +25,8 @@
  */
 
 #include <QtAlgorithms>
-#include <QtWidgets/QStatusBar>
-#include <QtWidgets/QMenu>
+#include <QStatusBar>
+#include <QMenu>
 #include "LightpackApplication.hpp"
 
 #include "SettingsWindow.hpp"

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -27,7 +27,6 @@
 #include <QtAlgorithms>
 #include <QtWidgets/QStatusBar>
 #include <QtWidgets/QMenu>
-#include <QtWidgets/QDesktopWidget>
 #include "LightpackApplication.hpp"
 
 #include "SettingsWindow.hpp"

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -1803,7 +1803,7 @@ void SettingsWindow::loadTranslation(const QString & language)
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << language;
 
-	Settings::setLanguage(language);
+	QString settingsLanguage = language;
 
 	QString locale = QLocale::system().name();
 
@@ -1816,8 +1816,14 @@ void SettingsWindow::loadTranslation(const QString & language)
 	// and only when all this done - append new line
 	// locale - name of translation binary file form resources: %locale%.qm
 	if(ui->comboBox_Language->currentIndex() == 0 /* System */){
+		settingsLanguage = SettingsScope::Main::LanguageDefault;
 		DEBUG_LOW_LEVEL << "System locale" << locale;
-		Settings::setLanguage(SettingsScope::Main::LanguageDefault);
+
+		if (locale.startsWith(QStringLiteral("en_"))) locale = QStringLiteral("en_EN"); // :/translations/en_EN.qm
+		else if (locale.startsWith(QStringLiteral("ru_"))) locale = QStringLiteral("ru_RU"); // :/translations/ru_RU.qm
+		else if (locale.startsWith(QStringLiteral("uk_"))) locale = QStringLiteral("uk_UA"); // :/translations/uk_UA.qm
+
+		DEBUG_LOW_LEVEL << "System translation" << locale;
 	}
 	else if (language == QStringLiteral("English")) locale = QStringLiteral("en_EN"); // :/translations/en_EN.qm
 	else if (language == QStringLiteral("Russian")) locale = QStringLiteral("ru_RU"); // :/translations/ru_RU.qm
@@ -1827,10 +1833,12 @@ void SettingsWindow::loadTranslation(const QString & language)
 		qWarning() << "Language" << language << "not found. Set to default" << SettingsScope::Main::LanguageDefault;
 		DEBUG_LOW_LEVEL << "System locale" << locale;
 
-		Settings::setLanguage(SettingsScope::Main::LanguageDefault);
+		settingsLanguage = SettingsScope::Main::LanguageDefault;
 	}
 
-	QString pathToLocale = QStringLiteral(":/translations/") + locale;
+	Settings::setLanguage(settingsLanguage);
+
+	const QString pathToLocale = QStringLiteral(":/translations/%1").arg(locale);
 
 	if(m_translator != NULL){
 		qApp->removeTranslator(m_translator);

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -47,7 +47,6 @@
 #include <QMessageBox>
 #include "PrismatikMath.hpp"
 
-
 using namespace SettingsScope;
 
 // ----------------------------------------------------------------------------
@@ -203,7 +202,8 @@ void SettingsWindow::changePage(int page)
 	ui->tabWidget->setCurrentIndex(page);
 	if (page == 5) {
 		ui->textBrowser->verticalScrollBar()->setValue(0);
-		m_smoothScrollTimer.setInterval(100);
+		using namespace std::chrono_literals;
+		m_smoothScrollTimer.setInterval(100ms);
 		m_smoothScrollTimer.start();
 	} else {
 		m_smoothScrollTimer.stop();
@@ -1035,7 +1035,8 @@ void SettingsWindow::showAbout()
 	ui->tabWidget->setCurrentWidget(ui->tabAbout);
 	this->show();
 
-	m_smoothScrollTimer.setInterval(100);
+	using namespace std::chrono_literals;
+	m_smoothScrollTimer.setInterval(100ms);
 	connect(&m_smoothScrollTimer, SIGNAL(timeout()), this, SLOT(scrollThanks()));
 	m_smoothScrollTimer.start();
 }
@@ -1196,7 +1197,8 @@ void SettingsWindow::refreshAmbilightEvaluated(double updateResultMs)
 			.arg(PrismatikMath::theoreticalMaxFrameRate(ledCount, baudRate), 0, 'f', 0)
 			.arg(std::round(PrismatikMath::theoreticalMinBaudRate(ledCount, m_maxFPS) / 100.0) * 100.0, 0, 'f', 0);
 			this->labelFPS->setToolTip(toolTipMsg);
-			m_baudrateWarningClearTimer.start(15000);
+			using namespace std::chrono_literals;
+			m_baudrateWarningClearTimer.start(15s);
 		} else
 			palette.setColor(QPalette::WindowText, defaultPalette.color(QPalette::WindowText));
 

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -814,7 +814,7 @@ void SettingsWindow::updateTrayAndActionStates()
 	case Backlight::StatusOff:
 		m_labelStatusIcon->setPixmap(*m_pixmapCache[QStringLiteral("off16")]);
 		ui->pushButton_EnableDisableDevice->setIcon(QIcon(*m_pixmapCache[QStringLiteral("on16")]));
-		ui->pushButton_EnableDisableDevice->setText(QStringLiteral("	") + tr("Turn lights ON"));
+		ui->pushButton_EnableDisableDevice->setText(QStringLiteral("	%1").arg(tr("Turn lights ON")));
 		if (m_trayIcon)
 			m_trayIcon->setStatus(SysTrayIcon::StatusOff);
 		break;
@@ -822,7 +822,7 @@ void SettingsWindow::updateTrayAndActionStates()
 	case Backlight::StatusDeviceError:
 		m_labelStatusIcon->setPixmap(*m_pixmapCache[QStringLiteral("error16")]);
 		ui->pushButton_EnableDisableDevice->setIcon(QIcon(*m_pixmapCache[QStringLiteral("off16")]));
-		ui->pushButton_EnableDisableDevice->setText(QStringLiteral("	") + tr("Turn lights OFF"));
+		ui->pushButton_EnableDisableDevice->setText(QStringLiteral("	%1").arg(tr("Turn lights OFF")));
 		if (m_trayIcon)
 			m_trayIcon->setStatus(SysTrayIcon::StatusError);
 		break;
@@ -1134,10 +1134,7 @@ void SettingsWindow::ledDeviceFirmwareVersionResult(const QString & fwVersion)
 	{
 		if (m_deviceFirmwareVersion == QStringLiteral("5.0") || m_deviceFirmwareVersion == QStringLiteral("4.3"))
 		{
-			aboutDialogFirmwareString += QStringLiteral(" ") +
-					QStringLiteral("(<a href=\"") + LightpackDownloadsPageUrl + QStringLiteral("\">") +
-					tr("update firmware") +
-					QStringLiteral("</a>)");
+			aboutDialogFirmwareString += QStringLiteral(" (<a href=\"%1\">%2</a>").arg(LightpackDownloadsPageUrl, tr("update firmware"));
 
 			if (Settings::isUpdateFirmwareMessageShown() == false)
 			{
@@ -1172,7 +1169,7 @@ void SettingsWindow::refreshAmbilightEvaluated(double updateResultMs)
 	QString fpsText = QString::number(hz, 'f', 0);
 	if (ui->comboBox_LightpackModes->currentIndex() == GrabModeIndex) {
 		const double maxHz = 1000.0 / ui->spinBox_GrabSlowdown->value(); // cap with display refresh rate?
-		fpsText += QStringLiteral(" / ") + QString::number(maxHz, 'f', 0);
+		fpsText += QStringLiteral(" / %1").arg(QString::number(maxHz, 'f', 0));
 	}
 	ui->label_GrabFrequency_value->setText(fpsText);
 
@@ -1691,7 +1688,7 @@ void SettingsWindow::profileNew()
 		while(ui->comboBox_Profiles->findText(profileName +" "+ QString::number(i)) != -1){
 			i++;
 		}
-		profileName += QStringLiteral(" ") + QString::number(i);
+		profileName += QStringLiteral(" %1").arg(QString::number(i));
 	}
 
 	ui->comboBox_Profiles->insertItem(0, profileName);

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -226,131 +226,131 @@ void SettingsWindow::connectSignalsSlots()
 
 //	if (m_trayIcon!=NULL)
 //	{
-//		connect(m_trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(onTrayIcon_Activated(QSystemTrayIcon::ActivationReason)));
-//		connect(m_trayIcon, SIGNAL(messageClicked()), this, SLOT(onTrayIcon_MessageClicked()));
+//		connect(m_trayIcon, &SysTrayIcon::activated, this, &SettingsWindow::onTrayIcon_Activated);
+//		connect(m_trayIcon, &SysTrayIcon::messageClicked, this, &SettingsWindow::onTrayIcon_MessageClicked);
 //	}
 
-	connect(ui->listWidget, SIGNAL(currentRowChanged(int)), this, SLOT(changePage(int)));
-	connect(ui->spinBox_GrabSlowdown, SIGNAL(valueChanged(int)), this, SLOT(onGrabSlowdown_valueChanged(int)));
-	connect(ui->spinBox_LuminosityThreshold, SIGNAL(valueChanged(int)), this, SLOT(onLuminosityThreshold_valueChanged(int)));
-	connect(ui->radioButton_MinimumLuminosity, SIGNAL(toggled(bool)), this, SLOT(onMinimumLumosity_toggled(bool)));
-	connect(ui->radioButton_LuminosityDeadZone, SIGNAL(toggled(bool)), this, SLOT(onMinimumLumosity_toggled(bool)));
-	connect(ui->checkBox_GrabIsAvgColors, SIGNAL(toggled(bool)), this, SLOT(onGrabIsAvgColors_toggled(bool)));
-	connect(ui->spinBox_GrabOverBrighten, SIGNAL(valueChanged(int)), this, SLOT(onGrabOverBrighten_valueChanged(int)));
-	connect(ui->checkBox_GrabApplyBlueLightReduction, SIGNAL(toggled(bool)), this, SLOT(onGrabApplyBlueLightReduction_toggled(bool)));
-	connect(ui->checkBox_GrabApplyColorTemperature, SIGNAL(toggled(bool)), this, SLOT(onGrabApplyColorTemperature_toggled(bool)));
-	connect(ui->horizontalSlider_GrabColorTemperature, SIGNAL(valueChanged(int)), this, SLOT(onGrabColorTemperature_valueChanged(int)));
-	connect(ui->horizontalSlider_GrabGamma, SIGNAL(valueChanged(int)), this, SLOT(onSliderGrabGamma_valueChanged(int)));
-	connect(ui->doubleSpinBox_GrabGamma, SIGNAL(valueChanged(double)), this, SLOT(onGrabGamma_valueChanged(double)));
+	connect(ui->listWidget, &QListWidget::currentRowChanged, this, &SettingsWindow::changePage);
+	connect(ui->spinBox_GrabSlowdown, qOverload<int>(&QSpinBox::valueChanged), this, &SettingsWindow::onGrabSlowdown_valueChanged);
+	connect(ui->spinBox_LuminosityThreshold, qOverload<int>(&QSpinBox::valueChanged), this, &SettingsWindow::onLuminosityThreshold_valueChanged);
+	connect(ui->radioButton_MinimumLuminosity, &QRadioButton::toggled, this, &SettingsWindow::onMinimumLumosity_toggled);
+	connect(ui->radioButton_LuminosityDeadZone, &QRadioButton::toggled, this, &SettingsWindow::onMinimumLumosity_toggled);
+	connect(ui->checkBox_GrabIsAvgColors, &QCheckBox::toggled, this, &SettingsWindow::onGrabIsAvgColors_toggled);
+	connect(ui->spinBox_GrabOverBrighten, qOverload<int>(&QSpinBox::valueChanged), this, &SettingsWindow::onGrabOverBrighten_valueChanged);
+	connect(ui->checkBox_GrabApplyBlueLightReduction, &QCheckBox::toggled, this, &SettingsWindow::onGrabApplyBlueLightReduction_toggled);
+	connect(ui->checkBox_GrabApplyColorTemperature, &QCheckBox::toggled, this, &SettingsWindow::onGrabApplyColorTemperature_toggled);
+	connect(ui->horizontalSlider_GrabColorTemperature, &QSlider::valueChanged, this, &SettingsWindow::onGrabColorTemperature_valueChanged);
+	connect(ui->horizontalSlider_GrabGamma, &QSlider::valueChanged, this, &SettingsWindow::onSliderGrabGamma_valueChanged);
+	connect(ui->doubleSpinBox_GrabGamma, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &SettingsWindow::onGrabGamma_valueChanged);
 
-	connect(ui->radioButton_GrabWidgetsDontShow, SIGNAL(toggled(bool)), this, SLOT( onDontShowLedWidgets_Toggled(bool)));
-	connect(ui->radioButton_Colored, SIGNAL(toggled(bool)), this, SLOT(onSetColoredLedWidgets(bool)));
-	connect(ui->radioButton_White, SIGNAL(toggled(bool)), this, SLOT(onSetWhiteLedWidgets(bool)));
+	connect(ui->radioButton_GrabWidgetsDontShow, &QRadioButton::toggled, this, &SettingsWindow:: onDontShowLedWidgets_Toggled);
+	connect(ui->radioButton_Colored, &QRadioButton::toggled, this, &SettingsWindow::onSetColoredLedWidgets);
+	connect(ui->radioButton_White, &QRadioButton::toggled, this, &SettingsWindow::onSetWhiteLedWidgets);
 
-	connect(ui->radioButton_LiquidColorMoodLampMode, SIGNAL(toggled(bool)), this, SLOT(onMoodLampLiquidMode_Toggled(bool)));
-	connect(ui->horizontalSlider_MoodLampSpeed, SIGNAL(valueChanged(int)), this, SLOT(onMoodLampSpeed_valueChanged(int)));
-	connect(ui->comboBox_MoodLampLamp, SIGNAL(currentIndexChanged(int)), this, SLOT(onMoodLampLamp_currentIndexChanged(int)));
+	connect(ui->radioButton_LiquidColorMoodLampMode, &QRadioButton::toggled, this, &SettingsWindow::onMoodLampLiquidMode_Toggled);
+	connect(ui->horizontalSlider_MoodLampSpeed, &QSlider::valueChanged, this, &SettingsWindow::onMoodLampSpeed_valueChanged);
+	connect(ui->comboBox_MoodLampLamp, qOverload<int>(&QComboBox::currentIndexChanged), this, &SettingsWindow::onMoodLampLamp_currentIndexChanged);
 
 	// Main options
-	connect(ui->comboBox_LightpackModes, SIGNAL(currentIndexChanged(int)), this, SLOT(onLightpackModes_currentIndexChanged(int)));
-	connect(ui->comboBox_Language, SIGNAL(activated(QString)), this, SLOT(loadTranslation(QString)));
-	connect(ui->pushButton_EnableDisableDevice, SIGNAL(clicked()), this, SLOT(toggleBacklight()));
+	connect(ui->comboBox_LightpackModes, qOverload<int>(&QComboBox::currentIndexChanged), this, &SettingsWindow::onLightpackModes_currentIndexChanged);
+	connect(ui->comboBox_Language, &QComboBox::currentTextChanged, this, &SettingsWindow::loadTranslation);
+	connect(ui->pushButton_EnableDisableDevice, &QPushButton::clicked, this, &SettingsWindow::toggleBacklight);
 
 	// Device options
-	connect(ui->spinBox_DeviceRefreshDelay, SIGNAL(valueChanged(int)), this, SLOT(onDeviceRefreshDelay_valueChanged(int)));
-	connect(ui->checkBox_DisableUsbPowerLed, SIGNAL(toggled(bool)), this, SLOT(onDisableUsbPowerLed_toggled(bool)));
-	connect(ui->spinBox_DeviceSmooth, SIGNAL(valueChanged(int)), this, SLOT(onDeviceSmooth_valueChanged(int)));
-	connect(ui->spinBox_DeviceBrightness, SIGNAL(valueChanged(int)), this, SLOT(onDeviceBrightness_valueChanged(int)));
-	connect(ui->spinBox_DeviceBrightnessCap, SIGNAL(valueChanged(int)), this, SLOT(onDeviceBrightnessCap_valueChanged(int)));
-	connect(ui->spinBox_DeviceColorDepth, SIGNAL(valueChanged(int)), this, SLOT(onDeviceColorDepth_valueChanged(int)));
-	connect(ui->doubleSpinBox_DeviceGamma, SIGNAL(valueChanged(double)), this, SLOT(onDeviceGammaCorrection_valueChanged(double)));
-	connect(ui->checkBox_EnableDithering, SIGNAL(toggled(bool)), this, SLOT(onDeviceDitheringEnabled_toggled(bool)));
-	connect(ui->horizontalSlider_GammaCorrection, SIGNAL(valueChanged(int)), this, SLOT(onSliderDeviceGammaCorrection_valueChanged(int)));
-	connect(ui->checkBox_SendDataOnlyIfColorsChanges, SIGNAL(toggled(bool)), this, SLOT(onDeviceSendDataOnlyIfColorsChanged_toggled(bool)));
+	connect(ui->spinBox_DeviceRefreshDelay, qOverload<int>(&QSpinBox::valueChanged), this, &SettingsWindow::onDeviceRefreshDelay_valueChanged);
+	connect(ui->checkBox_DisableUsbPowerLed, &QCheckBox::toggled, this, &SettingsWindow::onDisableUsbPowerLed_toggled);
+	connect(ui->spinBox_DeviceSmooth, qOverload<int>(&QSpinBox::valueChanged), this, &SettingsWindow::onDeviceSmooth_valueChanged);
+	connect(ui->spinBox_DeviceBrightness, qOverload<int>(&QSpinBox::valueChanged), this, &SettingsWindow::onDeviceBrightness_valueChanged);
+	connect(ui->spinBox_DeviceBrightnessCap, qOverload<int>(&QSpinBox::valueChanged), this, &SettingsWindow::onDeviceBrightnessCap_valueChanged);
+	connect(ui->spinBox_DeviceColorDepth, qOverload<int>(&QSpinBox::valueChanged), this, &SettingsWindow::onDeviceColorDepth_valueChanged);
+	connect(ui->doubleSpinBox_DeviceGamma, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &SettingsWindow::onDeviceGammaCorrection_valueChanged);
+	connect(ui->checkBox_EnableDithering, &QCheckBox::toggled, this, &SettingsWindow::onDeviceDitheringEnabled_toggled);
+	connect(ui->horizontalSlider_GammaCorrection, &QSlider::valueChanged, this, &SettingsWindow::onSliderDeviceGammaCorrection_valueChanged);
+	connect(ui->checkBox_SendDataOnlyIfColorsChanges, &QCheckBox::toggled, this, &SettingsWindow::onDeviceSendDataOnlyIfColorsChanged_toggled);
 
-	connect(ui->pbRunConfigurationWizard, SIGNAL(clicked()), this, SLOT(onRunConfigurationWizard_clicked()));
+	connect(ui->pbRunConfigurationWizard, &QPushButton::clicked, this, &SettingsWindow::onRunConfigurationWizard_clicked);
 
 	// Open Settings file
-	connect(ui->commandLinkButton_OpenSettings, SIGNAL(clicked()), this, SLOT(openCurrentProfile()));
+	connect(ui->commandLinkButton_OpenSettings, &QCommandLinkButton::clicked, this, &SettingsWindow::openCurrentProfile);
 
 	// Connect profile signals to this slots
-	connect(ui->comboBox_Profiles->lineEdit(), SIGNAL(editingFinished()) /* or returnPressed() */, this, SLOT(profileRename()));
-	connect(ui->comboBox_Profiles, SIGNAL(currentIndexChanged(QString)), this, SLOT(profileSwitch(QString)));
+	connect(ui->comboBox_Profiles->lineEdit(), &QLineEdit::editingFinished /* or returnPressed() */, this, &SettingsWindow::profileRename);
+	connect(ui->comboBox_Profiles, &QComboBox::currentTextChanged, this, &SettingsWindow::profileSwitch);
 
-	connect(Settings::settingsSingleton(), SIGNAL(currentProfileInited(QString)), this, SLOT(handleProfileLoaded(QString)), Qt::QueuedConnection);
+	connect(Settings::settingsSingleton(), &Settings::currentProfileInited, this, &SettingsWindow::handleProfileLoaded);
 
-	// connect(Settings::settingsSingleton(), SIGNAL(hotkeyChanged(QString,QKeySequence,QKeySequence)), this, SLOT(onHotkeyChanged(QString,QKeySequence,QKeySequence)));
-	connect(Settings::settingsSingleton(), SIGNAL(lightpackModeChanged(Lightpack::Mode)), this, SLOT(onLightpackModeChanged(Lightpack::Mode)));
+	// connect(Settings::settingsSingleton(), SIGNAL(hotkeyChanged(QString,QKeySequence,QKeySequence)), this, &SettingsWindow::onHotkeyChanged);
+	connect(Settings::settingsSingleton(), &Settings::lightpackModeChanged, this, &SettingsWindow::onLightpackModeChanged);
 
-	connect(ui->pushButton_ProfileNew, SIGNAL(clicked()), this, SLOT(profileNew()));
-	connect(ui->pushButton_ProfileResetToDefault, SIGNAL(clicked()), this, SLOT(profileResetToDefaultCurrent()));
-	connect(ui->pushButton_DeleteProfile, SIGNAL(clicked()), this, SLOT(profileDeleteCurrent()));
+	connect(ui->pushButton_ProfileNew, &QPushButton::clicked, this, &SettingsWindow::profileNew);
+	connect(ui->pushButton_ProfileResetToDefault, &QPushButton::clicked, this, &SettingsWindow::profileResetToDefaultCurrent);
+	connect(ui->pushButton_DeleteProfile, &QPushButton::clicked, this, &SettingsWindow::profileDeleteCurrent);
 
-	connect(ui->pushButton_SelectColorMoodLamp, SIGNAL(colorChanged(QColor)), this, SLOT(onMoodLampColor_changed(QColor)));
+	connect(ui->pushButton_SelectColorMoodLamp, &ColorButton::colorChanged, this, &SettingsWindow::onMoodLampColor_changed);
 #ifdef SOUNDVIZ_SUPPORT
-	connect(ui->comboBox_SoundVizDevice, SIGNAL(currentIndexChanged(int)), this, SLOT(onSoundVizDevice_currentIndexChanged(int)));
-	connect(ui->comboBox_SoundVizVisualizer, SIGNAL(currentIndexChanged(int)), this, SLOT(onSoundVizVisualizer_currentIndexChanged(int)));
-	connect(ui->pushButton_SelectColorSoundVizMin, SIGNAL(colorChanged(QColor)), this, SLOT(onSoundVizMinColor_changed(QColor)));
-	connect(ui->pushButton_SelectColorSoundVizMax, SIGNAL(colorChanged(QColor)), this, SLOT(onSoundVizMaxColor_changed(QColor)));
-	connect(ui->radioButton_SoundVizLiquidMode, SIGNAL(toggled(bool)), this, SLOT(onSoundVizLiquidMode_Toggled(bool)));
-	connect(ui->horizontalSlider_SoundVizLiquidSpeed, SIGNAL(valueChanged(int)), this, SLOT(onSoundVizLiquidSpeed_valueChanged(int)));
+	connect(ui->comboBox_SoundVizDevice, qOverload<int>(&QComboBox::currentIndexChanged), this, &SettingsWindow::onSoundVizDevice_currentIndexChanged);
+	connect(ui->comboBox_SoundVizVisualizer, qOverload<int>(&QComboBox::currentIndexChanged), this, &SettingsWindow::onSoundVizVisualizer_currentIndexChanged);
+	connect(ui->pushButton_SelectColorSoundVizMin, &ColorButton::colorChanged, this, &SettingsWindow::onSoundVizMinColor_changed);
+	connect(ui->pushButton_SelectColorSoundVizMax, &ColorButton::colorChanged, this, &SettingsWindow::onSoundVizMaxColor_changed);
+	connect(ui->radioButton_SoundVizLiquidMode, &QRadioButton::toggled, this, &SettingsWindow::onSoundVizLiquidMode_Toggled);
+	connect(ui->horizontalSlider_SoundVizLiquidSpeed, &QSlider::valueChanged, this, &SettingsWindow::onSoundVizLiquidSpeed_valueChanged);
 #ifdef Q_OS_MACOS
-	connect(ui->pushButton_SoundVizDeviceHelp, SIGNAL(clicked()), this, SLOT(onSoundVizDeviceHelp_clicked()));
+	connect(ui->pushButton_SoundVizDeviceHelp, &QPushButton::clicked, this, &SettingsWindow::onSoundVizDeviceHelp_clicked);
 #else
 	ui->pushButton_SoundVizDeviceHelp->hide();
 #endif // Q_OS_MACOS
 
 #endif// SOUNDVIZ_SUPPORT
-	connect(ui->checkBox_KeepLightsOnAfterExit, SIGNAL(toggled(bool)), this, SLOT(onKeepLightsAfterExit_Toggled(bool)));
-	connect(ui->checkBox_KeepLightsOnAfterLockComputer, SIGNAL(toggled(bool)), this, SLOT(onKeepLightsAfterLock_Toggled(bool)));
-	connect(ui->checkBox_KeepLightsOnAfterSuspend, SIGNAL(toggled(bool)), this, SLOT(onKeepLightsAfterSuspend_Toggled(bool)));
-	connect(ui->checkBox_KeepLightsOnAfterScreenOff, SIGNAL(toggled(bool)), this, SLOT(onKeepLightsAfterScreenOff_Toggled(bool)));
+	connect(ui->checkBox_KeepLightsOnAfterExit, &QCheckBox::toggled, this, &SettingsWindow::onKeepLightsAfterExit_Toggled);
+	connect(ui->checkBox_KeepLightsOnAfterLockComputer, &QCheckBox::toggled, this, &SettingsWindow::onKeepLightsAfterLock_Toggled);
+	connect(ui->checkBox_KeepLightsOnAfterSuspend, &QCheckBox::toggled, this, &SettingsWindow::onKeepLightsAfterSuspend_Toggled);
+	connect(ui->checkBox_KeepLightsOnAfterScreenOff, &QCheckBox::toggled, this, &SettingsWindow::onKeepLightsAfterScreenOff_Toggled);
 
 	// Dev tab
 #ifdef WINAPI_GRAB_SUPPORT
-	connect(ui->radioButton_GrabWinAPI, SIGNAL(toggled(bool)), this, SLOT(onGrabberChanged()));
+	connect(ui->radioButton_GrabWinAPI, &QRadioButton::toggled, this, &SettingsWindow::onGrabberChanged);
 #endif
 #ifdef DDUPL_GRAB_SUPPORT
-	connect(ui->radioButton_GrabDDupl, SIGNAL(toggled(bool)), this, SLOT(onGrabberChanged()));
+	connect(ui->radioButton_GrabDDupl, &QRadioButton::toggled, this, &SettingsWindow::onGrabberChanged);
 #endif
 #ifdef X11_GRAB_SUPPORT
-	connect(ui->radioButton_GrabX11, SIGNAL(toggled(bool)), this, SLOT(onGrabberChanged()));
+	connect(ui->radioButton_GrabX11, &QRadioButton::toggled, this, &SettingsWindow::onGrabberChanged);
 #endif
 #ifdef MAC_OS_AV_GRAB_SUPPORT
-	connect(ui->radioButton_GrabMacAVFoundation, SIGNAL(toggled(bool)), this, SLOT(onGrabberChanged()));
+	connect(ui->radioButton_GrabMacAVFoundation, &QRadioButton::toggled, this, &SettingsWindow::onGrabberChanged);
 #endif
 #ifdef MAC_OS_CG_GRAB_SUPPORT
-	connect(ui->radioButton_GrabMacCoreGraphics, SIGNAL(toggled(bool)), this, SLOT(onGrabberChanged()));
+	connect(ui->radioButton_GrabMacCoreGraphics, &QRadioButton::toggled, this, &SettingsWindow::onGrabberChanged);
 #endif
 #ifdef D3D10_GRAB_SUPPORT
-	connect(ui->checkBox_EnableDx1011Capture, SIGNAL(toggled(bool)), this, SLOT(onDx1011CaptureEnabledChanged(bool)));
-	connect(ui->checkBox_EnableDx9Capture, SIGNAL(toggled(bool)), this, SLOT(onDx9CaptureEnabledChanged(bool)));
+	connect(ui->checkBox_EnableDx1011Capture, &QCheckBox::toggled, this, &SettingsWindow::onDx1011CaptureEnabledChanged);
+	connect(ui->checkBox_EnableDx9Capture, &QCheckBox::toggled, this, &SettingsWindow::onDx9CaptureEnabledChanged);
 #endif
 
 
 	// Dev tab configure API (port, apikey)
-	connect(ui->groupBox_Api, SIGNAL(toggled(bool)), this, SLOT(onEnableApi_Toggled(bool)));
-	connect(ui->checkBox_listenOnlyOnLoInterface, SIGNAL(toggled(bool)), this, SLOT(onListenOnlyOnLoInterface_Toggled(bool)));
-	connect(ui->lineEdit_ApiPort, SIGNAL(editingFinished()), this, SLOT(onSetApiPort_Clicked()));
-	//connect(ui->checkBox_IsApiAuthEnabled, SIGNAL(toggled(bool)), this, SLOT(onIsApiAuthEnabled_Toggled(bool)));
-	connect(ui->pushButton_GenerateNewApiKey, SIGNAL(clicked()), this, SLOT(onGenerateNewApiKey_Clicked()));
-	connect(ui->lineEdit_ApiKey, SIGNAL(editingFinished()), this, SLOT(onApiKey_EditingFinished()));
+	connect(ui->groupBox_Api, &QGroupBox::toggled, this, &SettingsWindow::onEnableApi_Toggled);
+	connect(ui->checkBox_listenOnlyOnLoInterface, &QCheckBox::toggled, this, &SettingsWindow::onListenOnlyOnLoInterface_Toggled);
+	connect(ui->lineEdit_ApiPort, &QLineEdit::editingFinished, this, &SettingsWindow::onSetApiPort_Clicked);
+	//connect(ui->checkBox_IsApiAuthEnabled, &QCheckBox::toggled, this, &SettingsWindow::onIsApiAuthEnabled_Toggled);
+	connect(ui->pushButton_GenerateNewApiKey, &QPushButton::clicked, this, &SettingsWindow::onGenerateNewApiKey_Clicked);
+	connect(ui->lineEdit_ApiKey, &QLineEdit::editingFinished, this, &SettingsWindow::onApiKey_EditingFinished);
 
-	connect(ui->spinBox_LoggingLevel, SIGNAL(valueChanged(int)), this, SLOT(onLoggingLevel_valueChanged(int)));
-	connect(ui->toolButton_OpenLogs, SIGNAL(clicked()), this, SLOT(onOpenLogs_clicked()));
-	connect(ui->checkBox_PingDeviceEverySecond, SIGNAL(toggled(bool)), this, SLOT(onPingDeviceEverySecond_Toggled(bool)));
+	connect(ui->spinBox_LoggingLevel, qOverload<int>(&QSpinBox::valueChanged), this, &SettingsWindow::onLoggingLevel_valueChanged);
+	connect(ui->toolButton_OpenLogs, &QToolButton::clicked, this, &SettingsWindow::onOpenLogs_clicked);
+	connect(ui->checkBox_PingDeviceEverySecond, &QCheckBox::toggled, this, &SettingsWindow::onPingDeviceEverySecond_Toggled);
 
 	//Plugins
 	//	connected during setupUi by name:
 	//	connect(ui->list_Plugins,SIGNAL(currentRowChanged(int)),this,SLOT(on_list_Plugins_itemClicked(QListWidgetItem *)));
-	connect(ui->pushButton_UpPriority, SIGNAL(clicked()), this, SLOT(MoveUpPlugin()));
-	connect(ui->pushButton_DownPriority, SIGNAL(clicked()), this, SLOT(MoveDownPlugin()));
+	connect(ui->pushButton_UpPriority, &QPushButton::clicked, this, &SettingsWindow::MoveUpPlugin);
+	connect(ui->pushButton_DownPriority, &QPushButton::clicked, this, &SettingsWindow::MoveDownPlugin);
 
 	// About page
-	connect(&m_smoothScrollTimer, SIGNAL(timeout()), this, SLOT(scrollThanks()));
-	connect(ui->checkBox_checkForUpdates, SIGNAL(toggled(bool)), this, SLOT(onCheckBox_checkForUpdates_Toggled(bool)));
-	connect(ui->checkBox_installUpdates, SIGNAL(toggled(bool)), this, SLOT(onCheckBox_installUpdates_Toggled(bool)));
-	connect(&m_baudrateWarningClearTimer, SIGNAL(timeout()), this, SLOT(clearBaudrateWarning()));
+	connect(&m_smoothScrollTimer, &QTimer::timeout, this, &SettingsWindow::scrollThanks);
+	connect(ui->checkBox_checkForUpdates, &QCheckBox::toggled, this, &SettingsWindow::onCheckBox_checkForUpdates_Toggled);
+	connect(ui->checkBox_installUpdates, &QCheckBox::toggled, this, &SettingsWindow::onCheckBox_installUpdates_Toggled);
+	connect(&m_baudrateWarningClearTimer, &QTimer::timeout, this, &SettingsWindow::clearBaudrateWarning);
 }
 
 // ----------------------------------------------------------------------------
@@ -1039,7 +1039,7 @@ void SettingsWindow::showAbout()
 
 	using namespace std::chrono_literals;
 	m_smoothScrollTimer.setInterval(100ms);
-	connect(&m_smoothScrollTimer, SIGNAL(timeout()), this, SLOT(scrollThanks()));
+	connect(&m_smoothScrollTimer, &QTimer::timeout, this, &SettingsWindow::scrollThanks);
 	m_smoothScrollTimer.start();
 }
 
@@ -1732,7 +1732,7 @@ void SettingsWindow::profilesLoadAll()
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO << "found profiles:" << profiles;
 
 
-	disconnect(ui->comboBox_Profiles, SIGNAL(currentIndexChanged(QString)), this, SLOT(profileSwitch(QString)));
+	disconnect(ui->comboBox_Profiles, &QComboBox::currentTextChanged, this, &SettingsWindow::profileSwitch);
 
 	for (int i = 0; i < profiles.count(); i++)
 	{
@@ -1740,7 +1740,7 @@ void SettingsWindow::profilesLoadAll()
 			ui->comboBox_Profiles->addItem(profiles.at(i));
 	}
 
-	connect(ui->comboBox_Profiles, SIGNAL(currentIndexChanged(QString)), this, SLOT(profileSwitch(QString)));
+	connect(ui->comboBox_Profiles, &QComboBox::currentTextChanged, this, &SettingsWindow::profileSwitch);
 }
 
 void SettingsWindow::settingsProfileChanged_UpdateUI(const QString &profileName)
@@ -1862,15 +1862,15 @@ void SettingsWindow::createTrayIcon()
 {
 	DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 	m_trayIcon = new SysTrayIcon();
-	connect(m_trayIcon, SIGNAL(quit()), this, SLOT(quit()));
-	connect(m_trayIcon, SIGNAL(showSettings()), this, SLOT(showSettings()));
-	connect(m_trayIcon, SIGNAL(toggleSettings()), this, SLOT(toggleSettings()));
-	connect(m_trayIcon, SIGNAL(backlightOn()), this, SLOT(backlightOn()));
-	connect(m_trayIcon, SIGNAL(backlightOff()), this, SLOT(backlightOff()));
-	connect(m_trayIcon, SIGNAL(profileSwitched(QString)), this, SLOT(profileTraySwitch(QString)));
+	connect(m_trayIcon, &SysTrayIcon::quit, this, &SettingsWindow::quit);
+	connect(m_trayIcon, &SysTrayIcon::showSettings, this, &SettingsWindow::showSettings);
+	connect(m_trayIcon, &SysTrayIcon::toggleSettings, this, &SettingsWindow::toggleSettings);
+	connect(m_trayIcon, &SysTrayIcon::backlightOn, this, &SettingsWindow::backlightOn);
+	connect(m_trayIcon, &SysTrayIcon::backlightOff, this, &SettingsWindow::backlightOff);
+	connect(m_trayIcon, &SysTrayIcon::profileSwitched, this, &SettingsWindow::profileTraySwitch);
 
 	m_trayIcon->init();
-	connect(this, SIGNAL(backlightStatusChanged(Backlight::Status)), this, SLOT(updateTrayAndActionStates()));
+	connect(this, &SettingsWindow::backlightStatusChanged, this, &SettingsWindow::updateTrayAndActionStates);
 }
 
 void SettingsWindow::updateUiFromSettings()

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -540,8 +540,10 @@ void SettingsWindow::onPostInit() {
 			Settings::setAutoUpdatingVersion(QLatin1String(""));
 		}
 
-		if (Settings::isCheckForUpdatesEnabled() && !updateJustFailed)
-			QTimer::singleShot(10000, m_trayIcon, SLOT(checkUpdate()));
+		if (Settings::isCheckForUpdatesEnabled() && !updateJustFailed) {
+			using namespace std::chrono_literals;
+			QTimer::singleShot(10s, m_trayIcon, &SysTrayIcon::checkUpdate);
+		}
 	}
 }
 

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -277,7 +277,7 @@ void SettingsWindow::connectSignalsSlots()
 	connect(ui->comboBox_Profiles->lineEdit(), SIGNAL(editingFinished()) /* or returnPressed() */, this, SLOT(profileRename()));
 	connect(ui->comboBox_Profiles, SIGNAL(currentIndexChanged(QString)), this, SLOT(profileSwitch(QString)));
 
-	connect(Settings::settingsSingleton(), SIGNAL(currentProfileInited(const QString &)), this, SLOT(handleProfileLoaded(QString)), Qt::QueuedConnection);
+	connect(Settings::settingsSingleton(), SIGNAL(currentProfileInited(QString)), this, SLOT(handleProfileLoaded(QString)), Qt::QueuedConnection);
 
 	// connect(Settings::settingsSingleton(), SIGNAL(hotkeyChanged(QString,QKeySequence,QKeySequence)), this, SLOT(onHotkeyChanged(QString,QKeySequence,QKeySequence)));
 	connect(Settings::settingsSingleton(), SIGNAL(lightpackModeChanged(Lightpack::Mode)), this, SLOT(onLightpackModeChanged(Lightpack::Mode)));

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -127,6 +127,7 @@ public slots:
 	void showSettings(); /* using in actions */
 	void hideSettings(); /* used in closeEvent(..) */
 	void toggleSettings(); /* using in iconActivated(..) */
+	void onPostInit();
 
 protected:
 	virtual void changeEvent(QEvent *e);
@@ -151,7 +152,6 @@ private slots:
 #endif
 #endif
 	void showAbout(); /* using in actions */
-	void onPostInit();
 
 	void scrollThanks();
 

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -39,14 +39,13 @@
 #endif
 #include "ColorButton.hpp"
 #include "enums.hpp"
-
+#include "Plugin.hpp"
 
 namespace Ui {
 	class SettingsWindow;
 }
 
 class GrabManager; // forward declaration
-class Plugin;
 class SysTrayIcon;
 
 class SettingsWindow : public QMainWindow {

--- a/Software/src/SettingsWindow.hpp
+++ b/Software/src/SettingsWindow.hpp
@@ -98,7 +98,7 @@ public slots:
 	void refreshAmbilightEvaluated(double updateResultMs);
 	void updateUiFromSettings();
 
-	void setDeviceLockViaAPI(DeviceLocked::DeviceLockStatus status,	QList<QString> modules);
+	void setDeviceLockViaAPI(const DeviceLocked::DeviceLockStatus status, const QList<QString>& modules);
 	void setBacklightStatus(Backlight::Status);
 	void setModeChanged(Lightpack::Mode);
 	void backlightOn(); /* using in actions */
@@ -106,10 +106,10 @@ public slots:
 	void profilesLoadAll();
 	void profileSwitch(const QString & configName);
 	void handleProfileLoaded(const QString & configName);
-	void profileSwitchCombobox(QString profile);
+	void profileSwitchCombobox(const QString& profile);
 	void updateVirtualLedsColors(const QList<QRgb> & colors);
 	void requestBacklightStatus();
-	void onApiServer_ErrorOnStartListening(QString errorMessage);
+	void onApiServer_ErrorOnStartListening(const QString& errorMessage);
 	void onPingDeviceEverySecond_Toggled(bool state);
 	void processMessage(const QString &message);
 
@@ -119,7 +119,7 @@ public slots:
 	void updateAvailableSoundVizVisualizers(const QList<SoundManagerVisualizerInfo> & visualizers, int recommended);
 #endif
 
-	void updatePlugin(QList<Plugin*> plugins);
+	void updatePlugin(const QList<Plugin*>& plugins);
 
 	void onFocus();
 	void onBlur();
@@ -147,7 +147,7 @@ private slots:
 	void onSoundVizLiquidMode_Toggled(bool isLiquidMode);
 	void onSoundVizLiquidSpeed_valueChanged(int value);
 #ifdef Q_OS_MACOS
-	void on_pushButton_SoundVizDeviceHelp_clicked();
+	void onSoundVizDeviceHelp_clicked();
 #endif
 #endif
 	void showAbout(); /* using in actions */
@@ -239,7 +239,7 @@ private slots:
 	void onKeepLightsAfterSuspend_Toggled(bool isEnabled);
 	void onKeepLightsAfterScreenOff_Toggled(bool isEnabled);
 
-	void on_pbRunConfigurationWizard_clicked();
+	void onRunConfigurationWizard_clicked();
 
 	void onCheckBox_checkForUpdates_Toggled(bool isEnabled);
 	void onCheckBox_installUpdates_Toggled(bool isEnabled);

--- a/Software/src/SoundManagerBase.hpp
+++ b/Software/src/SoundManagerBase.hpp
@@ -54,7 +54,7 @@ signals:
 	void visualizerFrametime(const double);
 
 public:
-	virtual void start(bool isEnabled) { Q_UNUSED(isEnabled); Q_ASSERT(("Not implemented", false)); };
+	virtual void start(bool isEnabled) { Q_UNUSED(isEnabled); Q_ASSERT_X(false, "SoundManagerBase::start()", "not implemented"); };
 
 	// Common options
 	void reset();

--- a/Software/src/SoundManagerBase.hpp
+++ b/Software/src/SoundManagerBase.hpp
@@ -31,8 +31,8 @@
 #include "SoundVisualizer.hpp"
 
 struct SoundManagerDeviceInfo {
-	SoundManagerDeviceInfo(){ this->name = ""; this->id = -1; }
-	SoundManagerDeviceInfo(QString name, int id){ this->name = name; this->id = id; }
+	SoundManagerDeviceInfo(){ this->name = QLatin1String(""); this->id = -1; }
+	SoundManagerDeviceInfo(const QString& name, int id){ this->name = name; this->id = id; }
 	QString name;
 	int id;
 };
@@ -91,9 +91,9 @@ protected:
 	bool	m_isInited{false};
 	int		m_device{-1};
 	bool	m_isSendDataOnlyIfColorsChanged{false};
-	
+
 	float*	m_fft{nullptr};
-	
+
 	QElapsedTimer m_elapsedTimer;
 	size_t m_frames{ 1 };
 };

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -63,8 +63,8 @@ namespace {
 
 SoundVisualizerBase* SoundVisualizerBase::createWithID(const int id)
 {
-	QMap<int, SoundManagerVisualizerInfo>::const_iterator i = visualizerMap.find(id);
-	if (i != visualizerMap.end())
+	QMap<int, SoundManagerVisualizerInfo>::const_iterator i = visualizerMap.constFind(id);
+	if (i != visualizerMap.cend())
 		return i.value().factory();
 	qWarning() << Q_FUNC_INFO << "failed to find visualizer ID: " << id;
 	return nullptr;

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -40,10 +40,10 @@ public:\
 _OBJ_NAME_ ## SoundVisualizer() = default;\
 ~_OBJ_NAME_ ## SoundVisualizer() = default;\
 \
-static const char* const name() { return _LABEL_; };\
+static const char* name() { return _LABEL_; };\
 static SoundVisualizerBase* create() { return new _OBJ_NAME_ ## SoundVisualizer(); };\
 \
-const bool visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors);\
+bool visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors);\
 _BODY_\
 };\
 struct _OBJ_NAME_ ## Register {\
@@ -87,7 +87,7 @@ private:
 	const int SpecHeight = 1000;
 );
 
-const bool PrismatikSoundVisualizer::visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors)
+bool PrismatikSoundVisualizer::visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors)
 {
 	size_t b0 = 0;
 	bool changed = false;
@@ -142,7 +142,7 @@ private:
 	const uint8_t FadeOutSpeed = 12;
 );
 
-const bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors)
+bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors)
 {
 	bool changed = false;
 	const size_t middleLed = std::floor(colors.size() / 2);
@@ -191,7 +191,7 @@ const bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const
 			oldColor.setHsl(oldColor.hue(), oldColor.saturation(), luminosity);
 			color = oldColor.rgb();
 		}
-			
+
 		// peak A
 		QRgb colorA = Settings::isLedEnabled(idxA) ? color : 0;
 		changed = changed || (colors[idxA] != colorA);

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -137,7 +137,7 @@ DECLARE_VISUALIZER(TwinPeaks, "Twin Peaks",
 public:
 private:
 	float m_previousPeak{ 0.0f };
-	size_t m_prevThresholdLed{ 0 };
+	unsigned int m_prevThresholdLed{ 0 };
 	double m_speedCoef = 1.0;
 	const uint8_t FadeOutSpeed = 12;
 );
@@ -145,12 +145,12 @@ private:
 bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors)
 {
 	bool changed = false;
-	const size_t middleLed = std::floor(colors.size() / 2);
+	const unsigned int middleLed = std::floor(colors.size() / 2);
 
 	// most sensitive Hz range for humans
 	// this assumes 44100Hz sample rate
-	const size_t optimalHzMin = 1950 / (44100 / 2 / fftSize); // 2kHz
-	const size_t optimalHzMax = 5050 / (44100 / 2 / fftSize); // 5kHz
+	const unsigned int optimalHzMin = 1950 / (44100 / 2 / (unsigned int)fftSize); // 2kHz
+	const unsigned int optimalHzMax = 5050 / (44100 / 2 / (unsigned int)fftSize); // 5kHz
 
 	float currentPeak = 0.0f;
 	for (size_t i = 0; i < fftSize; ++i) {
@@ -165,7 +165,7 @@ bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const size_
 	else
 		m_previousPeak = std::max(0.0f, m_previousPeak - (fftSize * 0.000005f)); // lower the stale peak so it doesn't persist forever
 
-	const size_t thresholdLed = m_previousPeak != 0.0f ? middleLed * (currentPeak / m_previousPeak) : 0;
+	const unsigned int thresholdLed = m_previousPeak != 0.0f ? middleLed * (currentPeak / m_previousPeak) : 0;
 
 	// if leds move a lot with x% amplitude, increase fade speed
 	if (std::abs((int)(thresholdLed - m_prevThresholdLed)) > middleLed * 0.2)
@@ -173,8 +173,8 @@ bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const size_
 	else // reset on slow down
 		m_speedCoef = 1.0;// std::max(1.0, speedCoef - 2.0);
 
-	for (int idxA = 0; idxA < middleLed; ++idxA) {
-		const int idxB = colors.size() - 1 - idxA;
+	for (unsigned int idxA = 0; idxA < middleLed; ++idxA) {
+		const unsigned int idxB = colors.size() - 1 - idxA;
 		QRgb color = 0;
 		if (idxA < thresholdLed) {
 			QColor from = m_isLiquidMode ? m_generator.current() : m_minColor;

--- a/Software/src/SoundVisualizer.cpp
+++ b/Software/src/SoundVisualizer.cpp
@@ -173,8 +173,8 @@ bool TwinPeaksSoundVisualizer::visualize(const float* const fftData, const size_
 	else // reset on slow down
 		m_speedCoef = 1.0;// std::max(1.0, speedCoef - 2.0);
 
-	for (size_t idxA = 0; idxA < middleLed; ++idxA) {
-		const size_t idxB = colors.size() - 1 - idxA;
+	for (int idxA = 0; idxA < middleLed; ++idxA) {
+		const int idxB = colors.size() - 1 - idxA;
 		QRgb color = 0;
 		if (idxA < thresholdLed) {
 			QColor from = m_isLiquidMode ? m_generator.current() : m_minColor;

--- a/Software/src/SoundVisualizer.hpp
+++ b/Software/src/SoundVisualizer.hpp
@@ -33,8 +33,8 @@ class SoundVisualizerBase;
 typedef SoundVisualizerBase* (*VisualizerFactory)();
 
 struct SoundManagerVisualizerInfo {
-	SoundManagerVisualizerInfo() { this->name = ""; this->id = -1; this->factory = nullptr; }
-	SoundManagerVisualizerInfo(QString name, VisualizerFactory factory, int id) { this->name = name; this->id = id; this->factory = factory; }
+	SoundManagerVisualizerInfo() { this->name = QLatin1String(""); this->id = -1; this->factory = nullptr; }
+	SoundManagerVisualizerInfo(const QString& name, VisualizerFactory factory, int id) { this->name = name; this->id = id; this->factory = factory; }
 	QString name;
 	VisualizerFactory factory;
 	int id;
@@ -44,7 +44,7 @@ Q_DECLARE_METATYPE(SoundManagerVisualizerInfo);
 class SoundVisualizerBase
 {
 public:
-	static const char* const name() { return "NO_NAME"; };
+	static const char* name() { return "NO_NAME"; };
 	static SoundVisualizerBase* create() { Q_ASSERT_X(false, "SoundVisualizerBase::create()", "not implemented"); return nullptr; };
 	static void populateNameList(QList<SoundManagerVisualizerInfo>&, int& recommended);
 	static SoundVisualizerBase* createWithID(const int id);
@@ -75,7 +75,7 @@ public:
 		m_generator.setSpeed(speed);
 	}
 
-	const bool isRunning() const {
+	bool isRunning() const {
 		return m_isRunning;
 	}
 
@@ -99,7 +99,7 @@ public:
 
 	virtual void clear(const int /*numberOfLeds*/) {};
 
-	virtual const bool visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors) = 0;
+	virtual bool visualize(const float* const fftData, const size_t fftSize, QList<QRgb>& colors) = 0;
 	void interpolateColor(QRgb& outColor, const QColor& from, const QColor& to, const double value, const double maxValue) {
 		QColor rgb;
 		rgb.setRed(from.red() + (to.red() - from.red()) * (value / maxValue));

--- a/Software/src/UpdatesProcessor.cpp
+++ b/Software/src/UpdatesProcessor.cpp
@@ -63,8 +63,12 @@ void UpdatesProcessor::requestUpdates()
 	QNetworkRequest request(QUrl(UPDATE_CHECK_URL));
 	request.setSslConfiguration(QSslConfiguration::defaultConfiguration());
 	_reply = _networkMan.get(request);
-	connect(_reply, SIGNAL(finished()), this, SIGNAL(readyRead()));
-	connect(_reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(error(QNetworkReply::NetworkError)));
+	connect(_reply, &QNetworkReply::finished, this, &UpdatesProcessor::readyRead);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+	connect(_reply, &QNetworkReply::errorOccurred, this, &UpdatesProcessor::error);
+#else
+	connect(_reply, qOverload<QNetworkReply::NetworkError>(&QNetworkReply::error), this, &UpdatesProcessor::error);
+#endif
 }
 
 QList<UpdateInfo> UpdatesProcessor::readUpdates()
@@ -118,8 +122,13 @@ void UpdatesProcessor::loadUpdate(UpdateInfo& info)
 #endif
 
 	_reply = _networkMan.get(request);
-	connect(_reply, SIGNAL(finished()), this, SLOT(updatePgkLoaded()));
-	connect(_reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(error(QNetworkReply::NetworkError)));
+	connect(_reply, &QNetworkReply::finished, this, &UpdatesProcessor::updatePgkLoaded);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+	connect(_reply, &QNetworkReply::errorOccurred, this, &UpdatesProcessor::error);
+#else
+	connect(_reply, qOverload<QNetworkReply::NetworkError>(&QNetworkReply::error), this, &UpdatesProcessor::error);
+#endif
+
 #else
 	qWarning() << Q_FUNC_INFO << "Trying to load update on non-windows platform -- ignored";
 #endif
@@ -154,8 +163,12 @@ void UpdatesProcessor::updatePgkLoaded()
 #endif
 
 	_reply = _networkMan.get(request);
-	connect(_reply, SIGNAL(finished()), this, SLOT(updateSigLoaded()));
-	connect(_reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(error(QNetworkReply::NetworkError)));
+	connect(_reply, &QNetworkReply::finished, this, &UpdatesProcessor::updateSigLoaded);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+	connect(_reply, &QNetworkReply::errorOccurred, this, &UpdatesProcessor::error);
+#else
+	connect(_reply, qOverload<QNetworkReply::NetworkError>(&QNetworkReply::error), this, &UpdatesProcessor::error);
+#endif
 }
 
 void UpdatesProcessor::updateSigLoaded()

--- a/Software/src/WindowsSession.cpp
+++ b/Software/src/WindowsSession.cpp
@@ -37,7 +37,11 @@ namespace SystemSession
 		DEBUG_MID_LEVEL << Q_FUNC_INFO << "Event Filter is set up";
 	}
 
+	#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+	bool WindowsEventFilter::nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result)
+	#else
 	bool WindowsEventFilter::nativeEventFilter(const QByteArray& eventType, void* message, long* result)
+	#endif
 	{
 		Q_UNUSED(result);
 		Q_UNUSED(eventType);

--- a/Software/src/WindowsSession.hpp
+++ b/Software/src/WindowsSession.hpp
@@ -41,7 +41,11 @@ namespace SystemSession {
 	public:
 		WindowsEventFilter();
 		~WindowsEventFilter();
+		#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+		bool nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result);
+		#else
 		bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) Q_DECL_OVERRIDE;
+		#endif
 	private:
 		HPOWERNOTIFY m_powerSettingNotificationHandle;
 	};

--- a/Software/src/WindowsSoundManager.cpp
+++ b/Software/src/WindowsSoundManager.cpp
@@ -36,7 +36,7 @@ WindowsSoundManager::WindowsSoundManager(int hWnd, QObject *parent) : SoundManag
 	m_hWnd = hWnd;
 
 	m_timer.setTimerType(Qt::PreciseTimer);
-	connect(&m_timer, SIGNAL(timeout()), this, SLOT(updateColors()));
+	connect(&m_timer, &QTimer::timeout, this, &WindowsSoundManager::updateColors);
 }
 
 WindowsSoundManager::~WindowsSoundManager()

--- a/Software/src/WindowsSoundManager.cpp
+++ b/Software/src/WindowsSoundManager.cpp
@@ -47,7 +47,7 @@ WindowsSoundManager::~WindowsSoundManager()
 bool WindowsSoundManager::init() {
 	BASS_SetConfig(BASS_CONFIG_UNICODE, true);
 	// initialize "no sound" BASS device
-	if (!BASS_Init(0, 44100, 0, (HWND)m_hWnd, NULL)) {
+	if (!BASS_Init(0, 44100, 0, (HWND)IntToPtr(m_hWnd), NULL)) {
 		qCritical() << Q_FUNC_INFO << "Can't initialize BASS" << BASS_ErrorGetCode();
 		m_isInited = false;
 		return false;

--- a/Software/src/WindowsSoundManager.hpp
+++ b/Software/src/WindowsSoundManager.hpp
@@ -30,6 +30,7 @@
 
 class WindowsSoundManager : public SoundManagerBase
 {
+	Q_OBJECT
 public:
 	WindowsSoundManager(int hWnd, QObject *parent = 0);
 	virtual ~WindowsSoundManager();

--- a/Software/src/debug.h
+++ b/Software/src/debug.h
@@ -51,7 +51,7 @@ namespace Debug
 	};
 #ifndef NO_QT
 	inline const QString toString(QRect rect) {
-		return QString("x=%1, y=%2, width=%3, height=%4").arg(QString::number(rect.x())
+		return QStringLiteral("x=%1, y=%2, width=%3, height=%4").arg(QString::number(rect.x())
 																, QString::number(rect.y())
 																, QString::number(rect.width())
 																, QString::number(rect.height()));

--- a/Software/src/hidapi/linux/hid-libusb.c
+++ b/Software/src/hidapi/linux/hid-libusb.c
@@ -305,7 +305,7 @@ static int is_language_supported(libusb_device_handle *dev, uint16_t lang)
 static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 {
 	char buf[512];
-	size_t len;
+	int len;
 	wchar_t *str = NULL;
 	wchar_t wbuf[256];
 
@@ -334,7 +334,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 
 	buf[sizeof(buf)-1] = '\0';
 
-	if (len+1 < sizeof(buf))
+	if ((size_t)len+1 < sizeof(buf))
 		buf[len+1] = '\0';
 
 	/* Initialize iconv. */
@@ -345,7 +345,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	/* Convert to UTF-32 (wchar_t on glibc systems).
 	   Skip the first character (2-bytes). */
 	inptr = buf+2;
-	inbytes = len-2;
+	inbytes = (size_t)len-2;
 	outptr = (char*) wbuf;
 	outbytes = sizeof(wbuf);
 	res = iconv(ic, &inptr, &inbytes, &outptr, &outbytes);
@@ -743,7 +743,6 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 
 	libusb_device **devs;
 	libusb_device *usb_dev;
-	ssize_t num_devs;
 	int res;
 	int d = 0;
 	int good_open = 0;
@@ -753,7 +752,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 	if (!initialized)
 		hid_init();
 
-	num_devs = libusb_get_device_list(NULL, &devs);
+	libusb_get_device_list(NULL, &devs);
 	while ((usb_dev = devs[d++]) != NULL) {
 		struct libusb_device_descriptor desc;
 		struct libusb_config_descriptor *conf_desc = NULL;

--- a/Software/src/hidapi/linux/hid-libusb.c
+++ b/Software/src/hidapi/linux/hid-libusb.c
@@ -10,7 +10,7 @@
  Libusb Version - 8/13/2010
 
  Copyright 2009, All Rights Reserved.
- 
+
  At the discretion of the user of this library,
  this software may be licensed under the terms of the
  GNU Public License v3, a BSD-Style license, or the
@@ -74,23 +74,23 @@ struct input_report {
 struct hid_device_ {
 	/* Handle to the actual device. */
 	libusb_device_handle *device_handle;
-	
+
 	/* Endpoint information */
 	int input_endpoint;
 	int output_endpoint;
 	int input_ep_max_packet_size;
 
-	/* The interface number of the HID */	
+	/* The interface number of the HID */
 	int interface;
-	
+
 	/* Indexes of Strings */
 	int manufacturer_index;
 	int product_index;
 	int serial_index;
-	
+
 	/* Whether blocking reads are used */
 	int blocking; /* boolean */
-	
+
 	/* Read thread objects */
 	pthread_t thread;
 	pthread_mutex_t mutex; /* Protects input_reports */
@@ -110,7 +110,7 @@ static int return_data(hid_device *dev, unsigned char *data, size_t length);
 
 static hid_device *new_hid_device(void)
 {
-	hid_device *dev = calloc(1, sizeof(hid_device));
+	hid_device *dev = (hid_device *)calloc(1, sizeof(hid_device));
 	dev->device_handle = NULL;
 	dev->input_endpoint = 0;
 	dev->output_endpoint = 0;
@@ -123,11 +123,11 @@ static hid_device *new_hid_device(void)
 	dev->shutdown_thread = 0;
 	dev->transfer = NULL;
 	dev->input_reports = NULL;
-	
+
 	pthread_mutex_init(&dev->mutex, NULL);
 	pthread_cond_init(&dev->condition, NULL);
 	pthread_barrier_init(&dev->barrier, NULL, 2);
-	
+
 	return dev;
 }
 
@@ -188,13 +188,13 @@ static int get_usage(uint8_t *report_descriptor, size_t size,
 	int size_code;
 	int data_len, key_size;
 	int usage_found = 0, usage_page_found = 0;
-	
+
 	while (i < size) {
 		int key = report_descriptor[i];
 		int key_cmd = key & 0xfc;
 
 		//printf("key: %02hhx\n", key);
-		
+
 		if ((key & 0xf0) == 0xf0) {
 			/* This is a Long Item. The next byte contains the
 			   length of the data section (value) for this key.
@@ -229,7 +229,7 @@ static int get_usage(uint8_t *report_descriptor, size_t size,
 			};
 			key_size = 1;
 		}
-		
+
 		if (key_cmd == 0x4) {
 			*usage_page  = get_bytes(report_descriptor, size, data_len, i);
 			usage_page_found = 1;
@@ -243,11 +243,11 @@ static int get_usage(uint8_t *report_descriptor, size_t size,
 
 		if (usage_page_found && usage_found)
 			return 0; /* success */
-		
+
 		/* Skip over this key and it's associated data */
 		i += data_len + key_size;
 	}
-	
+
 	return -1; /* failure */
 }
 #endif // INVASIVE_GET_USAGE
@@ -259,7 +259,7 @@ static uint16_t get_first_language(libusb_device_handle *dev)
 {
 	uint16_t buf[32];
 	int len;
-	
+
 	/* Get the string from libusb. */
 	len = libusb_get_string_descriptor(dev,
 			0x0, /* String ID */
@@ -268,7 +268,7 @@ static uint16_t get_first_language(libusb_device_handle *dev)
 			sizeof(buf));
 	if (len < 4)
 		return 0x0;
-	
+
 	return buf[1]; // First two bytes are len and descriptor type.
 }
 
@@ -277,7 +277,7 @@ static int is_language_supported(libusb_device_handle *dev, uint16_t lang)
 	uint16_t buf[32];
 	int len;
 	int i;
-	
+
 	/* Get the string from libusb. */
 	len = libusb_get_string_descriptor(dev,
 			0x0, /* String ID */
@@ -286,8 +286,8 @@ static int is_language_supported(libusb_device_handle *dev, uint16_t lang)
 			sizeof(buf));
 	if (len < 4)
 		return 0x0;
-	
-	
+
+
 	len /= 2; /* language IDs are two-bytes each. */
 	/* Start at index 1 because there are two bytes of protocol data. */
 	for (i = 1; i < len; i++) {
@@ -305,7 +305,7 @@ static int is_language_supported(libusb_device_handle *dev, uint16_t lang)
 static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 {
 	char buf[512];
-	int len;
+	size_t len;
 	wchar_t *str = NULL;
 	wchar_t wbuf[256];
 
@@ -322,7 +322,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	lang = get_usb_code_for_current_locale();
 	if (!is_language_supported(dev, lang))
 		lang = get_first_language(dev);
-		
+
 	/* Get the string from libusb. */
 	len = libusb_get_string_descriptor(dev,
 			idx,
@@ -331,17 +331,17 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 			sizeof(buf));
 	if (len < 0)
 		return NULL;
-	
+
 	buf[sizeof(buf)-1] = '\0';
-	
+
 	if (len+1 < sizeof(buf))
 		buf[len+1] = '\0';
-	
+
 	/* Initialize iconv. */
 	ic = iconv_open("UTF-32", "UTF-16");
 	if (ic == (iconv_t)-1)
 		return NULL;
-	
+
 	/* Convert to UTF-32 (wchar_t on glibc systems).
 	   Skip the first character (2-bytes). */
 	inptr = buf+2;
@@ -356,13 +356,13 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	wbuf[sizeof(wbuf)/sizeof(wbuf[0])-1] = 0x00000000;
 	if (outbytes >= sizeof(wbuf[0]))
 		*((wchar_t*)outptr) = 0x00000000;
-	
+
 	/* Allocate and copy the string. */
 	str = wcsdup(wbuf+1);
 
 err:
 	iconv_close(ic);
-	
+
 	return str;
 }
 
@@ -374,7 +374,7 @@ static char *make_path(libusb_device *dev, int interface_number)
 		libusb_get_device_address(dev),
 		interface_number);
 	str[sizeof(str)-1] = '\0';
-	
+
 	return strdup(str);
 }
 
@@ -408,12 +408,12 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	libusb_device_handle *handle;
 	ssize_t num_devs;
 	int i = 0;
-	
+
 	struct hid_device_info *root = NULL; // return object
 	struct hid_device_info *cur_dev = NULL;
-	
+
 	setlocale(LC_ALL,"");
-	
+
 	if (!initialized)
 		hid_init();
 
@@ -429,7 +429,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 		int res = libusb_get_device_descriptor(dev, &desc);
 		unsigned short dev_vid = desc.idVendor;
 		unsigned short dev_pid = desc.idProduct;
-		
+
 		/* HID's are defined at the interface level. */
 		if (desc.bDeviceClass != LIBUSB_CLASS_PER_INTERFACE)
 			continue;
@@ -452,7 +452,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 							struct hid_device_info *tmp;
 
 							/* VID/PID match. Create the record. */
-							tmp = calloc(1, sizeof(struct hid_device_info));
+							tmp = (struct hid_device_info *)calloc(1, sizeof(struct hid_device_info));
 							if (cur_dev) {
 								cur_dev->next = tmp;
 							}
@@ -460,11 +460,11 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 								root = tmp;
 							}
 							cur_dev = tmp;
-							
+
 							/* Fill out the record */
 							cur_dev->next = NULL;
 							cur_dev->path = make_path(dev, interface_num);
-							
+
 							res = libusb_open(dev, &handle);
 
 							if (res >= 0) {
@@ -499,7 +499,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 							between interfaces. */
 								int detached = 0;
 								unsigned char data[256];
-							
+
 								/* Usage Page and Usage */
 								res = libusb_kernel_driver_active(handle, interface_num);
 								if (res == 1) {
@@ -548,7 +548,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 
 							/* Release Number */
 							cur_dev->release_number = desc.bcdDevice;
-							
+
 							/* Interface Number */
 							cur_dev->interface_number = interface_num;
 						}
@@ -583,7 +583,7 @@ hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, wchar
 	struct hid_device_info *devs, *cur_dev;
 	const char *path_to_open = NULL;
 	hid_device *handle = NULL;
-	
+
 	devs = hid_enumerate(vendor_id, product_id);
 	cur_dev = devs;
 	while (cur_dev) {
@@ -609,18 +609,18 @@ hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, wchar
 	}
 
 	hid_free_enumeration(devs);
-	
+
 	return handle;
 }
 
 static void read_callback(struct libusb_transfer *transfer)
 {
-	hid_device *dev = transfer->user_data;
-	
+	hid_device *dev = (hid_device *)transfer->user_data;
+
 	if (transfer->status == LIBUSB_TRANSFER_COMPLETED) {
 
-		struct input_report *rpt = malloc(sizeof(*rpt));
-		rpt->data = malloc(transfer->actual_length);
+		struct input_report *rpt = (struct input_report *)malloc(sizeof(*rpt));
+		rpt->data = (uint8_t*)malloc(transfer->actual_length);
 		memcpy(rpt->data, transfer->buffer, transfer->actual_length);
 		rpt->len = transfer->actual_length;
 		rpt->next = NULL;
@@ -642,13 +642,13 @@ static void read_callback(struct libusb_transfer *transfer)
 				num_queued++;
 			}
 			cur->next = rpt;
-			
+
 			/* Pop one off if we've reached 30 in the queue. This
 			   way we don't grow forever if the user never reads
 			   anything from the device. */
 			if (num_queued > 30) {
 				return_data(dev, NULL, 0);
-			}			
+			}
 		}
 		pthread_mutex_unlock(&dev->mutex);
 	}
@@ -666,7 +666,7 @@ static void read_callback(struct libusb_transfer *transfer)
 	else {
 		LOG("Unknown transfer code: %d\n", transfer->status);
 	}
-	
+
 	/* Re-submit the transfer object. */
 	libusb_submit_transfer(transfer);
 }
@@ -674,12 +674,12 @@ static void read_callback(struct libusb_transfer *transfer)
 
 static void *read_thread(void *param)
 {
-	hid_device *dev = param;
+	hid_device *dev = (hid_device *)param;
 	unsigned char *buf;
 	const size_t length = dev->input_ep_max_packet_size;
 
 	/* Set up the transfer object. */
-	buf = malloc(length);
+	buf = (unsigned char *)malloc(length);
 	dev->transfer = libusb_alloc_transfer(0);
 	libusb_fill_interrupt_transfer(dev->transfer,
 		dev->device_handle,
@@ -689,14 +689,14 @@ static void *read_thread(void *param)
 		read_callback,
 		dev,
 		5000/*timeout*/);
-	
+
 	/* Make the first submission. Further submissions are made
 	   from inside read_callback() */
 	libusb_submit_transfer(dev->transfer);
 
 	// Notify the main thread that the read thread is up and running.
 	pthread_barrier_wait(&dev->barrier);
-	
+
 	/* Handle all the events. */
 	while (!dev->shutdown_thread) {
 		int res;
@@ -706,14 +706,14 @@ static void *read_thread(void *param)
 			break;
 		}
 	}
-	
+
 	/* Cancel any transfer that may be pending. This call will fail
 	   if no transfers are pending, but that's OK. */
 	if (libusb_cancel_transfer(dev->transfer) == 0) {
 		/* The transfer was cancelled, so wait for its completion. */
 		libusb_handle_events(NULL);
 	}
-	
+
 	/* Now that the read thread is stopping, Wake any threads which are
 	   waiting on data (in hid_read_timeout()). Do this under a mutex to
 	   make sure that a thread which is about to go to sleep waiting on
@@ -730,7 +730,7 @@ static void *read_thread(void *param)
 	   cleaned up after the call to pthread_join() (in hid_close()), but
 	   since hid_close() calls libusb_cancel_transfer(), on these objects,
 	   they can not be cleaned up here. */
-	
+
 	return NULL;
 }
 
@@ -747,9 +747,9 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 	int res;
 	int d = 0;
 	int good_open = 0;
-	
+
 	setlocale(LC_ALL,"");
-	
+
 	if (!initialized)
 		hid_init();
 
@@ -780,7 +780,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
  							break;
 						}
 						good_open = 1;
-						
+
 						/* Detach the kernel driver, but only if the
 						   device is managed by the kernel */
 						if (libusb_kernel_driver_active(dev->device_handle, intf_desc->bInterfaceNumber) == 1) {
@@ -793,7 +793,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 								break;
 							}
 						}
-						
+
 						res = libusb_claim_interface(dev->device_handle, intf_desc->bInterfaceNumber);
 						if (res < 0) {
 							LOG("can't claim interface %d: %d\n", intf_desc->bInterfaceNumber, res);
@@ -810,7 +810,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 
 						/* Store off the interface number */
 						dev->interface = intf_desc->bInterfaceNumber;
-												
+
 						/* Find the INPUT and OUTPUT endpoints. An
 						   OUTPUT endpoint is not required. */
 						for (i = 0; i < intf_desc->bNumEndpoints; i++) {
@@ -822,10 +822,10 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 							int is_interrupt =
 								(ep->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK)
 							      == LIBUSB_TRANSFER_TYPE_INTERRUPT;
-							int is_output = 
+							int is_output =
 								(ep->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK)
 							      == LIBUSB_ENDPOINT_OUT;
-							int is_input = 
+							int is_input =
 								(ep->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK)
 							      == LIBUSB_ENDPOINT_IN;
 
@@ -842,12 +842,12 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 								dev->output_endpoint = ep->bEndpointAddress;
 							}
 						}
-						
+
 						pthread_create(&dev->thread, NULL, read_thread, dev);
-						
+
 						// Wait here for the read thread to be initialized.
 						pthread_barrier_wait(&dev->barrier);
-						
+
 					}
 					free(dev_path);
 				}
@@ -858,7 +858,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 	}
 
 	libusb_free_device_list(devs, 1);
-	
+
 	// If we have a good handle, return it.
 	if (good_open) {
 		return dev;
@@ -893,13 +893,13 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 			dev->interface,
 			(unsigned char *)data, length,
 			1000/*timeout millis*/);
-		
+
 		if (res < 0)
 			return -1;
-		
+
 		if (skipped_report_id)
 			length++;
-		
+
 		return length;
 	}
 	else {
@@ -910,13 +910,13 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 			(unsigned char*)data,
 			length,
 			&actual_length, 1000);
-		
+
 		if (res < 0)
 			return -1;
-		
+
 		if (skipped_report_id)
 			actual_length++;
-		
+
 		return actual_length;
 	}
 }
@@ -939,7 +939,7 @@ static int return_data(hid_device *dev, unsigned char *data, size_t length)
 
 static void cleanup_mutex(void *param)
 {
-	hid_device *dev = param;
+	hid_device *dev = (hid_device *)param;
 	pthread_mutex_unlock(&dev->mutex);
 }
 
@@ -964,14 +964,14 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 		bytes_read = return_data(dev, data, length);
 		goto ret;
 	}
-	
+
 	if (dev->shutdown_thread) {
 		/* This means the device has been disconnected.
 		   An error code of -1 should be returned. */
 		bytes_read = -1;
 		goto ret;
 	}
-	
+
 	if (milliseconds == -1) {
 		/* Blocking */
 		while (!dev->input_reports && !dev->shutdown_thread) {
@@ -992,7 +992,7 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 			ts.tv_sec++;
 			ts.tv_nsec -= 1000000000L;
 		}
-		
+
 		while (!dev->input_reports && !dev->shutdown_thread) {
 			res = pthread_cond_timedwait(&dev->condition, &dev->mutex, &ts);
 			if (res == 0) {
@@ -1000,7 +1000,7 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 					bytes_read = return_data(dev, data, length);
 					break;
 				}
-				
+
 				/* If we're here, there was a spurious wake up
 				   or the read thread was shutdown. Run the
 				   loop again (ie: don't break). */
@@ -1037,7 +1037,7 @@ int HID_API_EXPORT hid_read(hid_device *dev, unsigned char *data, size_t length)
 int HID_API_EXPORT hid_set_nonblocking(hid_device *dev, int nonblock)
 {
 	dev->blocking = !nonblock;
-	
+
 	return 0;
 }
 
@@ -1061,14 +1061,14 @@ int HID_API_EXPORT hid_send_feature_report(hid_device *dev, const unsigned char 
 		dev->interface,
 		(unsigned char *)data, length,
 		1000/*timeout millis*/);
-	
+
 	if (res < 0)
 		return -1;
-	
+
 	/* Account for the report ID */
 	if (skipped_report_id)
 		length++;
-	
+
 	return length;
 }
 
@@ -1092,13 +1092,13 @@ int HID_API_EXPORT hid_get_feature_report(hid_device *dev, unsigned char *data, 
 		dev->interface,
 		(unsigned char *)data, length,
 		1000/*timeout millis*/);
-	
+
 	if (res < 0)
 		return -1;
 
 	if (skipped_report_id)
 		res++;
-	
+
 	return res;
 }
 
@@ -1107,31 +1107,31 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 {
 	if (!dev)
 		return;
-	
+
 	/* Cause read_thread() to stop. */
 	dev->shutdown_thread = 1;
 //    libusb_cancel_transfer(dev->transfer);
 
 	/* Wait for read_thread() to end. */
 	pthread_join(dev->thread, NULL);
-	
+
 	/* Clean up the Transfer objects allocated in read_thread(). */
 	free(dev->transfer->buffer);
 	libusb_free_transfer(dev->transfer);
-	
+
 	/* release the interface */
 	libusb_release_interface(dev->device_handle, dev->interface);
-	
+
 	/* Close the handle */
 	libusb_close(dev->device_handle);
-	
+
 	/* Clear out the queue of received reports. */
 	pthread_mutex_lock(&dev->mutex);
 	while (dev->input_reports) {
 		return_data(dev, NULL, 0);
 	}
 	pthread_mutex_unlock(&dev->mutex);
-	
+
 	free_hid_device(dev);
     dev = NULL;
 }
@@ -1315,7 +1315,7 @@ static struct lang_map_entry lang_map[] = {
 	LANG("Xhosa", "xh", 0x0434),
 	LANG("Yiddish", "yi", 0x043D),
 	LANG("Zulu", "zu", 0x0435),
-	LANG(NULL, NULL, 0x0),	
+	LANG(NULL, NULL, 0x0),
 };
 
 uint16_t get_usb_code_for_current_locale(void)
@@ -1323,16 +1323,16 @@ uint16_t get_usb_code_for_current_locale(void)
 	char *locale;
 	char search_string[64];
 	char *ptr;
-	
+
 	/* Get the current locale. */
 	locale = setlocale(0, NULL);
 	if (!locale)
 		return 0x0;
-	
+
 	/* Make a copy of the current locale string. */
 	strncpy(search_string, locale, sizeof(search_string));
 	search_string[sizeof(search_string)-1] = '\0';
-	
+
 	/* Chop off the encoding part, and make it lower case. */
 	ptr = search_string;
 	while (*ptr) {
@@ -1349,10 +1349,10 @@ uint16_t get_usb_code_for_current_locale(void)
 	while (lang->string_code) {
 		if (!strcmp(lang->string_code, search_string)) {
 			return lang->usb_code;
-		}	
+		}
 		lang++;
 	}
-	
+
 	/* There was no match. Find with just the language only. */
 	/* Chop off the variant. Chop it off at the '_'. */
 	ptr = search_string;
@@ -1364,18 +1364,18 @@ uint16_t get_usb_code_for_current_locale(void)
 		}
 		ptr++;
 	}
-	
+
 #if 0 // TODO: Do we need this?
 	/* Find the entry which matches the string code of our language. */
 	lang = lang_map;
 	while (lang->string_code) {
 		if (!strcmp(lang->string_code, search_string)) {
 			return lang->usb_code;
-		}	
+		}
 		lang++;
 	}
 #endif
-	
+
 	/* Found nothing. */
 	return 0x0;
 }

--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -55,11 +55,11 @@ using namespace std;
 unsigned g_debugLevel = SettingsScope::Main::DebugLevelDefault;
 
 QString getApplicationDirectoryPath(const char * firstCmdArgument)
-{	
+{
 	QFileInfo fileInfo(firstCmdArgument);
 	QString appDirPath = fileInfo.absoluteDir().absolutePath();
 
-	QString lightpackMainConfPath = appDirPath + "/main.conf";
+	QString lightpackMainConfPath = appDirPath + QStringLiteral("/main.conf");
 
 	cout << lightpackMainConfPath.toStdString() << endl;
 
@@ -78,12 +78,12 @@ QString getApplicationDirectoryPath(const char * firstCmdArgument)
 		cout << "Unportable version" << endl;
 
 		QString home = QDir::homePath();
-		QString normalizedHome = home.endsWith("/") ? home.left(home.size() - 1) : home;
+		QString normalizedHome = home.endsWith(QStringLiteral("/")) ? home.left(home.size() - 1) : home;
 
 #		ifdef Q_OS_WIN
-		appDirPath = normalizedHome	+ "/Prismatik";
+		appDirPath = normalizedHome	+ QStringLiteral("/Prismatik");
 #		else
-		appDirPath = normalizedHome + "/.Prismatik";
+		appDirPath = normalizedHome + QStringLiteral("/.Prismatik");
 #		endif
 
 		QDir dir(appDirPath);
@@ -139,9 +139,9 @@ int main(int argc, char **argv)
 	Q_UNUSED(messageHandlerGuard);
 
 	LightpackApplication lightpackApp(argc, argv);
-	lightpackApp.setLibraryPaths(QStringList(appDirPath + "/plugins"));
+	lightpackApp.setLibraryPaths(QStringList(appDirPath + QStringLiteral("/plugins")));
 	lightpackApp.initializeAll(appDirPath);
-	
+
 	// init the logger after initializeAll to know the configured debugLevel
 	if (g_debugLevel > 0) {
 		const int logInitResult = logWriter.initWith(appDirPath + "/Logs");
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
 
 	if (lightpackApp.isRunning())
 	{
-		lightpackApp.sendMessage("alreadyRunning");
+		lightpackApp.sendMessage(QStringLiteral("alreadyRunning"));
 
 		qWarning() << "Application already running";
 		exit(0);

--- a/Software/src/qtsingleapplication/src/qtlocalpeer.cpp
+++ b/Software/src/qtsingleapplication/src/qtlocalpeer.cpp
@@ -89,7 +89,11 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
 	prefix.truncate(6);
 
 	QByteArray idc = id.toUtf8();
+	#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+	quint16 idNum = qChecksum(QByteArrayView(idc));
+	#else
 	quint16 idNum = qChecksum(idc.constData(), idc.size());
+	#endif
 	socketName = QLatin1String("qtsingleapp-") + prefix
 					+ QLatin1Char('-') + QString::number(idNum, 16);
 

--- a/Software/src/qtsingleapplication/src/qtlocalpeer.cpp
+++ b/Software/src/qtsingleapplication/src/qtlocalpeer.cpp
@@ -128,7 +128,7 @@ bool QtLocalPeer::isClient()
 #endif
 	if (!res)
 		qWarning("QtSingleCoreApplication: listen on local socket failed, %s", qPrintable(server->errorString()));
-	QObject::connect(server, SIGNAL(newConnection()), SLOT(receiveConnection()));
+	QObject::connect(server, &QLocalServer::newConnection, this, &QtLocalPeer::receiveConnection);
 	return false;
 }
 

--- a/Software/src/qtsingleapplication/src/qtlocalpeer.cpp
+++ b/Software/src/qtsingleapplication/src/qtlocalpeer.cpp
@@ -43,6 +43,9 @@
 #include <QCoreApplication>
 #include <QDataStream>
 #include <QTime>
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QRegularExpression>
+#endif
 
 #if defined(Q_OS_WIN)
 #include <QLibrary>
@@ -78,7 +81,11 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
 #endif
 		prefix = id.section(QLatin1Char('/'), -1);
 	}
+	#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+	prefix.remove(QRegularExpression("[^a-zA-Z]"));
+	#else
 	prefix.remove(QRegExp("[^a-zA-Z]"));
+	#endif
 	prefix.truncate(6);
 
 	QByteArray idc = id.toUtf8();

--- a/Software/src/qtsingleapplication/src/qtsingleapplication.cpp
+++ b/Software/src/qtsingleapplication/src/qtsingleapplication.cpp
@@ -137,7 +137,7 @@ void QtSingleApplication::sysInit(const QString &appId)
 {
 	actWin = 0;
 	peer = new QtLocalPeer(this, appId);
-	connect(peer, SIGNAL(messageReceived(const QString&)), SIGNAL(messageReceived(const QString&)));
+	connect(peer, &QtLocalPeer::messageReceived, this, &QtSingleApplication::messageReceived);
 }
 
 
@@ -288,9 +288,9 @@ void QtSingleApplication::setActivationWindow(QWidget* aw, bool activateOnMessag
 {
 	actWin = aw;
 	if (activateOnMessage)
-		connect(peer, SIGNAL(messageReceived(const QString&)), this, SLOT(activateWindow()));
+		connect(peer, &QtLocalPeer::messageReceived, this, qOverload<>(&QtSingleApplication::activateWindow));
 	else
-		disconnect(peer, SIGNAL(messageReceived(const QString&)), this, SLOT(activateWindow()));
+		disconnect(peer, &QtLocalPeer::messageReceived, this, qOverload<>(&QtSingleApplication::activateWindow));
 }
 
 

--- a/Software/src/qtsingleapplication/src/qtsingleapplication.h
+++ b/Software/src/qtsingleapplication/src/qtsingleapplication.h
@@ -90,6 +90,7 @@ public:
 public Q_SLOTS:
 	bool sendMessage(const QString &message, int timeout = 5000);
 	void activateWindow();
+	void activateWindow(const QString& message) { Q_UNUSED(message); activateWindow(); };
 
 
 Q_SIGNALS:

--- a/Software/src/qtsingleapplication/src/qtsinglecoreapplication.cpp
+++ b/Software/src/qtsingleapplication/src/qtsinglecoreapplication.cpp
@@ -74,7 +74,7 @@ QtSingleCoreApplication::QtSingleCoreApplication(int &argc, char **argv)
     : QCoreApplication(argc, argv)
 {
     peer = new QtLocalPeer(this);
-    connect(peer, SIGNAL(messageReceived(const QString&)), SIGNAL(messageReceived(const QString&)));
+    connect(peer, &QtLocalPeer::messageReceived, this, &QtSingleCoreApplication::messageReceived);
 }
 
 
@@ -87,7 +87,7 @@ QtSingleCoreApplication::QtSingleCoreApplication(const QString &appId, int &argc
     : QCoreApplication(argc, argv)
 {
     peer = new QtLocalPeer(this, appId);
-    connect(peer, SIGNAL(messageReceived(const QString&)), SIGNAL(messageReceived(const QString&)));
+    connect(peer, &QtLocalPeer::messageReceived, this, &QtSingleCoreApplication::messageReceived);
 }
 
 

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -15,6 +15,7 @@ CONFIG(msvc) {
 DESTDIR     = ../bin
 TEMPLATE    = app
 QT         += network widgets
+CONFIG += c++17
 win32 {
 	QT += serialport
 }
@@ -62,9 +63,8 @@ QMAKE_CFLAGS = $$(CFLAGS)
 QMAKE_CXXFLAGS = $$(CXXFLAGS)
 QMAKE_LFLAGS = $$(LDFLAGS)
 
-CONFIG(gcc):QMAKE_CXXFLAGS += -std=c++17
 CONFIG(clang) {
-	QMAKE_CXXFLAGS += -std=c++17 -stdlib=libc++
+	QMAKE_CXXFLAGS += -stdlib=libc++
 	LIBS += -stdlib=libc++
 }
 
@@ -181,7 +181,6 @@ unix:!macx{
 	# For X11 grabber
 	LIBS +=-lXext -lX11
 
-	QMAKE_CXXFLAGS += -std=c++17
 	contains(DEFINES,PULSEAUDIO_SUPPORT) {
 		INCLUDEPATH += $${PULSEAUDIO_INC_DIR} \
 			$${FFTW3_INC_DIR}

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -62,9 +62,9 @@ QMAKE_CFLAGS = $$(CFLAGS)
 QMAKE_CXXFLAGS = $$(CXXFLAGS)
 QMAKE_LFLAGS = $$(LDFLAGS)
 
-CONFIG(gcc):QMAKE_CXXFLAGS += -std=c++11
+CONFIG(gcc):QMAKE_CXXFLAGS += -std=c++17
 CONFIG(clang) {
-	QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++
+	QMAKE_CXXFLAGS += -std=c++17 -stdlib=libc++
 	LIBS += -stdlib=libc++
 }
 
@@ -181,7 +181,7 @@ unix:!macx{
 	# For X11 grabber
 	LIBS +=-lXext -lX11
 
-	QMAKE_CXXFLAGS += -std=c++11
+	QMAKE_CXXFLAGS += -std=c++17
 	contains(DEFINES,PULSEAUDIO_SUPPORT) {
 		INCLUDEPATH += $${PULSEAUDIO_INC_DIR} \
 			$${FFTW3_INC_DIR}

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -8,18 +8,18 @@
 
 TARGET      = Prismatik
 CONFIG(msvc) {
-    PRE_TARGETDEPS += ../lib/grab.lib
+	PRE_TARGETDEPS += ../lib/grab.lib
 } else {
-    PRE_TARGETDEPS += ../lib/libgrab.a
+	PRE_TARGETDEPS += ../lib/libgrab.a
 }
 DESTDIR     = ../bin
 TEMPLATE    = app
 QT         += network widgets
 win32 {
-    QT += serialport
+	QT += serialport
 }
 macx {
-    QT += serialport
+	QT += serialport
 }
 # QMake and GCC produce a lot of stuff
 OBJECTS_DIR = stuff
@@ -37,16 +37,16 @@ GIT_REVISION = $$system(git show -s --format="%h")
 # for cause to call qmake) and re-build project
 
 isEmpty( GIT_REVISION ){
-    # In code uses #ifdef GIT_REVISION ... #endif
-    message( "GIT not found, GIT_REVISION will be undefined" )
+	# In code uses #ifdef GIT_REVISION ... #endif
+	message( "GIT not found, GIT_REVISION will be undefined" )
 } else {
-    # Define current mercurial revision id
-    # It will be show in about dialog and --help output
-    DEFINES += GIT_REVISION=\\\"$${GIT_REVISION}\\\"
+	# Define current mercurial revision id
+	# It will be show in about dialog and --help output
+	DEFINES += GIT_REVISION=\\\"$${GIT_REVISION}\\\"
 }
 
 TRANSLATIONS += ../res/translations/ru_RU.ts \
-       ../res/translations/uk_UA.ts
+	   ../res/translations/uk_UA.ts
 RESOURCES    = ../res/LightpackResources.qrc
 RC_FILE      = ../res/Lightpack.rc
 
@@ -64,67 +64,67 @@ QMAKE_LFLAGS = $$(LDFLAGS)
 
 CONFIG(gcc):QMAKE_CXXFLAGS += -std=c++11
 CONFIG(clang) {
-    QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++
-    LIBS += -stdlib=libc++
+	QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++
+	LIBS += -stdlib=libc++
 }
 
 unix:!macx{
-    CONFIG    += link_pkgconfig
-    PKGCONFIG += libusb-1.0
+	CONFIG    += link_pkgconfig
+	PKGCONFIG += libusb-1.0
 
-    DESKTOP = $$(XDG_CURRENT_DESKTOP)
+	DESKTOP = $$(XDG_CURRENT_DESKTOP)
 
-    equals(DESKTOP, "Unity") {
-        DEFINES += UNITY_DESKTOP
-        PKGCONFIG += gtk+-2.0 appindicator-0.1 libnotify
-    }
+	equals(DESKTOP, "Unity") {
+		DEFINES += UNITY_DESKTOP
+		PKGCONFIG += gtk+-2.0 appindicator-0.1 libnotify
+	}
 
-    LIBS += -L../qtserialport/lib -lQt5SerialPort
-    QMAKE_LFLAGS += -Wl,-rpath=/usr/lib/prismatik
+	LIBS += -L../qtserialport/lib -lQt5SerialPort
+	QMAKE_LFLAGS += -Wl,-rpath=/usr/lib/prismatik
 }
 
 win32 {
-    CONFIG(msvc) {
-        # This will suppress many MSVC warnings about 'unsecure' CRT functions.
-        DEFINES += _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE
-        # Parallel build
-        QMAKE_CXXFLAGS += /MP
-        # Place *.lib and *.exp files in ../lib
-        QMAKE_LFLAGS += /IMPLIB:..\\lib\\$(TargetName).lib
-    }
+	CONFIG(msvc) {
+		# This will suppress many MSVC warnings about 'unsecure' CRT functions.
+		DEFINES += _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE
+		# Parallel build
+		QMAKE_CXXFLAGS += /MP
+		# Place *.lib and *.exp files in ../lib
+		QMAKE_LFLAGS += /IMPLIB:..\\lib\\$(TargetName).lib
+	}
 
-    # Windows version using WinAPI for HID
-    LIBS    += -lsetupapi
-    # For QSerialDevice
-    LIBS    += -luuid -ladvapi32
+	# Windows version using WinAPI for HID
+	LIBS    += -lsetupapi
+	# For QSerialDevice
+	LIBS    += -luuid -ladvapi32
 
-    !isEmpty( DIRECTX_SDK_DIR ) {
-        LIBS += -L$${DIRECTX_SDK_DIR}/Lib/x86
-    }
-    LIBS    += -lwsock32 -lshlwapi -lole32 -ldxguid
+	!isEmpty( DIRECTX_SDK_DIR ) {
+		LIBS += -L$${DIRECTX_SDK_DIR}/Lib/x86
+	}
+	LIBS    += -lwsock32 -lshlwapi -lole32 -ldxguid
 
-    SOURCES += hidapi/windows/hid.c
+	SOURCES += hidapi/windows/hid.c
 
-    #DX9 grab
-    LIBS    += -lgdi32 -ld3d9
+	#DX9 grab
+	LIBS    += -lgdi32 -ld3d9
 
-    QMAKE_CFLAGS += -O2 -ggdb
-    # Windows version using WinAPI + GDI + DirectX for grab colors
+	QMAKE_CFLAGS += -O2 -ggdb
+	# Windows version using WinAPI + GDI + DirectX for grab colors
 
-    LIBS    += -lwsock32 -lshlwapi -lole32
+	LIBS    += -lwsock32 -lshlwapi -lole32
 
-    LIBS    += -lpsapi
-    LIBS    += -lwtsapi32
+	LIBS    += -lpsapi
+	LIBS    += -lwtsapi32
 
-    CONFIG(msvc) {
-        QMAKE_POST_LINK = cd $(TargetDir) $$escape_expand(\r\n)\
-            $$[QT_INSTALL_BINS]/windeployqt --no-angle --no-svg --no-translations --no-compiler-runtime \"$(TargetName)$(TargetExt)\" $$escape_expand(\r\n)\
-            if $(PlatformToolsetVersion) LEQ 140 copy /y \"$(VcInstallDir)redist\\$(PlatformTarget)\\Microsoft.VC$(PlatformToolsetVersion).CRT\\msvcp$(PlatformToolsetVersion).dll\" .\ $$escape_expand(\r\n)\
-            if $(PlatformToolsetVersion) GTR 140 copy /y \"$(VcInstallDir)Redist\\MSVC\\$(VCToolsRedistVersion)\\$(PlatformTarget)\\Microsoft.VC$(PlatformToolsetVersion).CRT\\msvcp*.dll\" .\ $$escape_expand(\r\n)\
-            if $(PlatformToolsetVersion) LSS 140 copy /y \"$(VcInstallDir)redist\\$(PlatformTarget)\\Microsoft.VC$(PlatformToolsetVersion).CRT\\msvcr$(PlatformToolsetVersion).dll\" .\ $$escape_expand(\r\n)\
-            if $(PlatformToolsetVersion) EQU 140 copy /y \"$(VcInstallDir)redist\\$(PlatformTarget)\\Microsoft.VC$(PlatformToolsetVersion).CRT\\vcruntime$(PlatformToolsetVersion).dll\" .\ $$escape_expand(\r\n)\
-            if $(PlatformToolsetVersion) GTR 140 copy /y \"$(VcInstallDir)Redist\\MSVC\\$(VCToolsRedistVersion)\\$(PlatformTarget)\\Microsoft.VC$(PlatformToolsetVersion).CRT\\vcruntime*.dll\" .\ $$escape_expand(\r\n)
-        !contains(DEFINES, NO_OPENSSL) {
+	CONFIG(msvc) {
+		QMAKE_POST_LINK = cd $(TargetDir) $$escape_expand(\r\n)\
+			$$[QT_INSTALL_BINS]/windeployqt --no-angle --no-svg --no-translations --no-compiler-runtime \"$(TargetName)$(TargetExt)\" $$escape_expand(\r\n)\
+			if $(PlatformToolsetVersion) LEQ 140 copy /y \"$(VcInstallDir)redist\\$(PlatformTarget)\\Microsoft.VC$(PlatformToolsetVersion).CRT\\msvcp$(PlatformToolsetVersion).dll\" .\ $$escape_expand(\r\n)\
+			if $(PlatformToolsetVersion) GTR 140 copy /y \"$(VcInstallDir)Redist\\MSVC\\$(VCToolsRedistVersion)\\$(PlatformTarget)\\Microsoft.VC$(PlatformToolsetVersion).CRT\\msvcp*.dll\" .\ $$escape_expand(\r\n)\
+			if $(PlatformToolsetVersion) LSS 140 copy /y \"$(VcInstallDir)redist\\$(PlatformTarget)\\Microsoft.VC$(PlatformToolsetVersion).CRT\\msvcr$(PlatformToolsetVersion).dll\" .\ $$escape_expand(\r\n)\
+			if $(PlatformToolsetVersion) EQU 140 copy /y \"$(VcInstallDir)redist\\$(PlatformTarget)\\Microsoft.VC$(PlatformToolsetVersion).CRT\\vcruntime$(PlatformToolsetVersion).dll\" .\ $$escape_expand(\r\n)\
+			if $(PlatformToolsetVersion) GTR 140 copy /y \"$(VcInstallDir)Redist\\MSVC\\$(VCToolsRedistVersion)\\$(PlatformTarget)\\Microsoft.VC$(PlatformToolsetVersion).CRT\\vcruntime*.dll\" .\ $$escape_expand(\r\n)
+		!contains(DEFINES, NO_OPENSSL) {
 			# QT switched to OpenSSL 1.1 in 5.12.4, which has different binary names
 			versionAtLeast(QT_VERSION, "5.12.4") {
 				QMAKE_POST_LINK += copy /y \"$${OPENSSL_DIR}\\libcrypto-1_1-x64.dll\" .\ $$escape_expand(\r\n)\
@@ -135,11 +135,11 @@ win32 {
 					copy /y \"$${OPENSSL_DIR}\\libeay32.dll\" .\ $$escape_expand(\r\n)\
 					IF EXIST  \"$${OPENSSL_DIR}\\msvcr*.dll\" copy /y \"$${OPENSSL_DIR}\\msvcr*.dll\" .\ $$escape_expand(\r\n)
 			}
-        }
+		}
 
-    } else {
-        warning("unsupported setup - update src.pro to copy dependencies")
-    }
+	} else {
+		warning("unsupported setup - update src.pro to copy dependencies")
+	}
 
 	contains(DEFINES,BASS_SOUND_SUPPORT) {
 		INCLUDEPATH += $${BASS_DIR}/c/ \
@@ -176,239 +176,240 @@ win32 {
 }
 
 unix:!macx{
-    # Linux version using libusb and hidapi codes
-    SOURCES += hidapi/linux/hid-libusb.c
-    # For X11 grabber
-    LIBS +=-lXext -lX11
+	# Linux version using libusb and hidapi codes
+	SOURCES += hidapi/linux/hid-libusb.c
+	# For X11 grabber
+	LIBS +=-lXext -lX11
 
-    QMAKE_CXXFLAGS += -std=c++11
-    contains(DEFINES,PULSEAUDIO_SUPPORT) {
-        INCLUDEPATH += $${PULSEAUDIO_INC_DIR} \
-            $${FFTW3_INC_DIR}
+	QMAKE_CXXFLAGS += -std=c++11
+	contains(DEFINES,PULSEAUDIO_SUPPORT) {
+		INCLUDEPATH += $${PULSEAUDIO_INC_DIR} \
+			$${FFTW3_INC_DIR}
 
-        defined(PULSEAUDIO_LIB_DIR, var) {
-            LIBS += -L$${PULSEAUDIO_LIB_DIR}
-            QMAKE_POST_LINK += $(INSTALL_PROGRAM) \"$${PULSEAUDIO_LIB_DIR}/libpulse.so.0\" $(DESTDIR) $$escape_expand(\n\t)\
-				$(INSTALL_PROGRAM) \"$${PULSEAUDIO_LIB_DIR}/libpulsecommon-13.0.so\" $(DESTDIR) $$escape_expand(\n\t)
-        }
+		defined(PULSEAUDIO_LIB_DIR, var) {
+			LIBS += -L$${PULSEAUDIO_LIB_DIR}
+			QMAKE_POST_LINK += $(INSTALL_PROGRAM) "$${PULSEAUDIO_LIB_DIR}/libpulse.so.0" $(DESTDIR)
+			QMAKE_POST_LINK += $(INSTALL_PROGRAM) "$${PULSEAUDIO_LIB_DIR}/libpulsecommon-13.0.so" $(DESTDIR)
+		}
 
-        defined(PULSEAUDIO_LIB_DIR, var) {
-            LIBS += -L$${FFTW3_LIB_DIR}
-            QMAKE_POST_LINK += $(INSTALL_PROGRAM) \"$${FFTW3_LIB_DIR}/libfftw3f.so.3\" $(DESTDIR) $$escape_expand(\n)
-        }
+		defined(PULSEAUDIO_LIB_DIR, var) {
+			LIBS += -L$${FFTW3_LIB_DIR}
+			QMAKE_POST_LINK += $(INSTALL_PROGRAM) "$${FFTW3_LIB_DIR}/libfftw3f.so.3" $(DESTDIR)
+		}
 
-        LIBS += -lpulse -lfftw3f
-        DEFINES += SOUNDVIZ_SUPPORT
+		LIBS += -lpulse -lfftw3f
+		DEFINES += SOUNDVIZ_SUPPORT
 	}
 }
 
 macx{
-    QMAKE_LFLAGS += -F/System/Library/Frameworks -F"/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/PrivateFrameworks"
-    # MacOS version using libusb and hidapi codes
-    SOURCES += hidapi/mac/hid.c \
-    MacOSSession.mm
+	QMAKE_LFLAGS += -F/System/Library/Frameworks -F"/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/PrivateFrameworks"
+	# MacOS version using libusb and hidapi codes
+	SOURCES += hidapi/mac/hid.c \
+	MacOSSession.mm
 
-    HEADERS += \
-    MacOSSession.h
+	HEADERS += \
+	MacOSSession.h
 
-    contains(DEFINES,SOUNDVIZ_SUPPORT) {
-        SOURCES += MacOSSoundManager.mm
-        HEADERS += MacOSSoundManager.h
-    }
+	contains(DEFINES,SOUNDVIZ_SUPPORT) {
+		SOURCES += MacOSSoundManager.mm
+		HEADERS += MacOSSoundManager.h
+	}
 
-    LIBS += \
-            -framework Cocoa \
-            -framework Carbon \
-            -framework CoreFoundation \
-            #-framework CoreServices \
-            -framework Foundation \
+	LIBS += \
+			-framework Cocoa \
+			-framework Carbon \
+			-framework CoreFoundation \
+			#-framework CoreServices \
+			-framework Foundation \
  #           -framework CoreGraphics \
-            -framework ApplicationServices \
-            -framework OpenGL \
-            -framework IOKit \
-            # private framework
-            -weak_framework CoreBrightness \
-            -framework AppKit \
-            -framework Accelerate \
-            -framework CoreMedia \
-            -framework AVFoundation \
-            -framework CoreVideo \
+			-framework ApplicationServices \
+			-framework OpenGL \
+			-framework IOKit \
+			# private framework
+			-weak_framework CoreBrightness \
+			-framework AppKit \
+			-framework Accelerate \
+			-framework CoreMedia \
+			-framework AVFoundation \
+			-framework CoreVideo \
 
-    ICON = ../res/icons/Prismatik.icns
+	ICON = ../res/icons/Prismatik.icns
 
-    QMAKE_INFO_PLIST = ./Info.plist
+	QMAKE_INFO_PLIST = ./Info.plist
 
 	#see build-vars.prf
-    #isEmpty( QMAKE_MAC_SDK_OVERRIDE ) {
-    #    # Default value
-    #    # For build universal binaries (native on Intel and PowerPC)
-    #    QMAKE_MAC_SDK = macosx10.9
-    #} else {
-    #    message( "Overriding default QMAKE_MAC_SDK with value $${QMAKE_MAC_SDK_OVERRIDE}" )
-    #    QMAKE_MAC_SDK = $${QMAKE_MAC_SDK_OVERRIDE}
-    #}
+	#isEmpty( QMAKE_MAC_SDK_OVERRIDE ) {
+	#    # Default value
+	#    # For build universal binaries (native on Intel and PowerPC)
+	#    QMAKE_MAC_SDK = macosx10.9
+	#} else {
+	#    message( "Overriding default QMAKE_MAC_SDK with value $${QMAKE_MAC_SDK_OVERRIDE}" )
+	#    QMAKE_MAC_SDK = $${QMAKE_MAC_SDK_OVERRIDE}
+	#}
 
-    CONFIG(clang) {
-        QMAKE_CXXFLAGS += -x objective-c++
-    }
+	CONFIG(clang) {
+		QMAKE_CXXFLAGS += -x objective-c++
+	}
 }
 
 # Generate .qm language files
 QMAKE_MAC_SDK = macosx
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+# Qt sets this to its own minimum
+# QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.13
 system($$[QT_INSTALL_BINS]/lrelease src.pro)
 
 INCLUDEPATH += . \
-               .. \
-               ./hidapi \
-               ../grab \
-               ../alienfx \
-               ../grab/include \
-               ../math/include \
-               ./stuff \
+			   .. \
+			   ./hidapi \
+			   ../grab \
+			   ../alienfx \
+			   ../grab/include \
+			   ../math/include \
+			   ./stuff \
 
 SOURCES += \
-    LightpackApplication.cpp  main.cpp   SettingsWindow.cpp  Settings.cpp \
-    GrabWidget.cpp  GrabConfigWidget.cpp \
-    LogWriter.cpp \
-    LedDeviceLightpack.cpp \
-    LedDeviceAdalight.cpp \
-    LedDeviceArdulight.cpp \
-    LedDeviceVirtual.cpp \
-    AbstractLedDeviceUdp.cpp \
-    LedDeviceDrgb.cpp \
-    LedDeviceDnrgb.cpp \
-    LedDeviceWarls.cpp \
-    ColorButton.cpp \
-    ApiServer.cpp \
-    ApiServerSetColorTask.cpp \
-    MoodLampManager.cpp \
-    MoodLamp.cpp \
+	LightpackApplication.cpp  main.cpp   SettingsWindow.cpp  Settings.cpp \
+	GrabWidget.cpp  GrabConfigWidget.cpp \
+	LogWriter.cpp \
+	LedDeviceLightpack.cpp \
+	LedDeviceAdalight.cpp \
+	LedDeviceArdulight.cpp \
+	LedDeviceVirtual.cpp \
+	AbstractLedDeviceUdp.cpp \
+	LedDeviceDrgb.cpp \
+	LedDeviceDnrgb.cpp \
+	LedDeviceWarls.cpp \
+	ColorButton.cpp \
+	ApiServer.cpp \
+	ApiServerSetColorTask.cpp \
+	MoodLampManager.cpp \
+	MoodLamp.cpp \
 	LiquidColorGenerator.cpp \
-    LedDeviceManager.cpp \
-    SelectWidget.cpp \
-    GrabManager.cpp \
-    AbstractLedDevice.cpp \
-    PluginsManager.cpp \
-    Plugin.cpp \
-    LightpackPluginInterface.cpp \
-    TimeEvaluations.cpp \
-    SystemSession.cpp \
-    wizard/ZonePlacementPage.cpp \
-    wizard/Wizard.cpp \
-    wizard/WizardPageUsingDevice.cpp \
-    wizard/SelectProfilePage.cpp \
-    wizard/MonitorIdForm.cpp \
-    wizard/MonitorConfigurationPage.cpp \
-    wizard/LightpackDiscoveryPage.cpp \
-    wizard/ConfigureDevicePage.cpp \
-    wizard/ConfigureUdpDevicePage.cpp \
-    wizard/ConfigureDevicePowerPage.cpp \
-    wizard/SelectDevicePage.cpp \
-    wizard/GlobalColorCoefPage.cpp \
-    wizard/CustomDistributor.cpp \
-    systrayicon/SysTrayIcon.cpp \
-    UpdatesProcessor.cpp \
-    LightpackCommandLineParser.cpp
+	LedDeviceManager.cpp \
+	SelectWidget.cpp \
+	GrabManager.cpp \
+	AbstractLedDevice.cpp \
+	PluginsManager.cpp \
+	Plugin.cpp \
+	LightpackPluginInterface.cpp \
+	TimeEvaluations.cpp \
+	SystemSession.cpp \
+	wizard/ZonePlacementPage.cpp \
+	wizard/Wizard.cpp \
+	wizard/WizardPageUsingDevice.cpp \
+	wizard/SelectProfilePage.cpp \
+	wizard/MonitorIdForm.cpp \
+	wizard/MonitorConfigurationPage.cpp \
+	wizard/LightpackDiscoveryPage.cpp \
+	wizard/ConfigureDevicePage.cpp \
+	wizard/ConfigureUdpDevicePage.cpp \
+	wizard/ConfigureDevicePowerPage.cpp \
+	wizard/SelectDevicePage.cpp \
+	wizard/GlobalColorCoefPage.cpp \
+	wizard/CustomDistributor.cpp \
+	systrayicon/SysTrayIcon.cpp \
+	UpdatesProcessor.cpp \
+	LightpackCommandLineParser.cpp
 
 HEADERS += \
-    LightpackApplication.hpp \
-    SettingsWindow.hpp \
-    Settings.hpp \
-    SettingsDefaults.hpp \
-    version.h \
-    TimeEvaluations.hpp \
-    GrabManager.hpp \
-    GrabWidget.hpp \
-    GrabConfigWidget.hpp \
-    debug.h \
-    LogWriter.hpp \
-    alienfx/LFXDecl.h \
-    alienfx/LFX2.h \
-    LedDeviceLightpack.hpp \
-    LedDeviceAdalight.hpp \
-    LedDeviceArdulight.hpp \
-    AbstractLedDeviceUdp.hpp \
-    LedDeviceDrgb.hpp \
-    LedDeviceDnrgb.hpp \
-    LedDeviceWarls.hpp \
-    LedDeviceVirtual.hpp \
-    ColorButton.hpp \
-    ../common/defs.h \
-    enums.hpp         ApiServer.hpp     ApiServerSetColorTask.hpp \
-    hidapi/hidapi.h \
-    ../../CommonHeaders/COMMANDS.h \
-    ../../CommonHeaders/USB_ID.h \
-    MoodLampManager.hpp \
-    MoodLamp.hpp \
+	LightpackApplication.hpp \
+	SettingsWindow.hpp \
+	Settings.hpp \
+	SettingsDefaults.hpp \
+	version.h \
+	TimeEvaluations.hpp \
+	GrabManager.hpp \
+	GrabWidget.hpp \
+	GrabConfigWidget.hpp \
+	debug.h \
+	LogWriter.hpp \
+	alienfx/LFXDecl.h \
+	alienfx/LFX2.h \
+	LedDeviceLightpack.hpp \
+	LedDeviceAdalight.hpp \
+	LedDeviceArdulight.hpp \
+	AbstractLedDeviceUdp.hpp \
+	LedDeviceDrgb.hpp \
+	LedDeviceDnrgb.hpp \
+	LedDeviceWarls.hpp \
+	LedDeviceVirtual.hpp \
+	ColorButton.hpp \
+	../common/defs.h \
+	enums.hpp         ApiServer.hpp     ApiServerSetColorTask.hpp \
+	hidapi/hidapi.h \
+	../../CommonHeaders/COMMANDS.h \
+	../../CommonHeaders/USB_ID.h \
+	MoodLampManager.hpp \
+	MoodLamp.hpp \
 	LiquidColorGenerator.hpp \
-    LedDeviceManager.hpp \
-    SelectWidget.hpp \
-    ../common/D3D10GrabberDefs.hpp \
-    AbstractLedDevice.hpp \
-    PluginsManager.hpp \
-    Plugin.hpp \
-    LightpackPluginInterface.hpp \
-    SystemSession.hpp \
-    wizard/ZonePlacementPage.hpp \
-    wizard/Wizard.hpp \
-    wizard/WizardPageUsingDevice.hpp \
-    wizard/SettingsAwareTrait.hpp \
-    wizard/SelectProfilePage.hpp \
-    wizard/MonitorIdForm.hpp \
-    wizard/MonitorConfigurationPage.hpp \
-    wizard/LightpackDiscoveryPage.hpp \
-    wizard/ConfigureDevicePage.hpp \
-    wizard/ConfigureUdpDevicePage.hpp \
-    wizard/ConfigureDevicePowerPage.hpp \
-    wizard/SelectDevicePage.hpp \
-    wizard/GlobalColorCoefPage.hpp \
-    types.h \
-    wizard/AreaDistributor.hpp \
-    wizard/CustomDistributor.hpp \
-    systrayicon/SysTrayIcon.hpp \
-    UpdatesProcessor.hpp \
-    LightpackCommandLineParser.hpp
+	LedDeviceManager.hpp \
+	SelectWidget.hpp \
+	../common/D3D10GrabberDefs.hpp \
+	AbstractLedDevice.hpp \
+	PluginsManager.hpp \
+	Plugin.hpp \
+	LightpackPluginInterface.hpp \
+	SystemSession.hpp \
+	wizard/ZonePlacementPage.hpp \
+	wizard/Wizard.hpp \
+	wizard/WizardPageUsingDevice.hpp \
+	wizard/SettingsAwareTrait.hpp \
+	wizard/SelectProfilePage.hpp \
+	wizard/MonitorIdForm.hpp \
+	wizard/MonitorConfigurationPage.hpp \
+	wizard/LightpackDiscoveryPage.hpp \
+	wizard/ConfigureDevicePage.hpp \
+	wizard/ConfigureUdpDevicePage.hpp \
+	wizard/ConfigureDevicePowerPage.hpp \
+	wizard/SelectDevicePage.hpp \
+	wizard/GlobalColorCoefPage.hpp \
+	types.h \
+	wizard/AreaDistributor.hpp \
+	wizard/CustomDistributor.hpp \
+	systrayicon/SysTrayIcon.hpp \
+	UpdatesProcessor.hpp \
+	LightpackCommandLineParser.hpp
 
 contains(DEFINES,SOUNDVIZ_SUPPORT) {
-    SOURCES += SoundManagerBase.cpp SoundVisualizer.cpp
-    HEADERS += SoundManagerBase.hpp SoundVisualizer.hpp
+	SOURCES += SoundManagerBase.cpp SoundVisualizer.cpp
+	HEADERS += SoundManagerBase.hpp SoundVisualizer.hpp
 }
 
 win32 {
-    SOURCES += LedDeviceAlienFx.cpp \
-    WindowsSession.cpp
+	SOURCES += LedDeviceAlienFx.cpp \
+	WindowsSession.cpp
 
-    HEADERS += LedDeviceAlienFx.hpp \
-    WindowsSession.hpp
+	HEADERS += LedDeviceAlienFx.hpp \
+	WindowsSession.hpp
 
-    contains(DEFINES,SOUNDVIZ_SUPPORT) {
-        SOURCES += WindowsSoundManager.cpp
-        HEADERS += WindowsSoundManager.hpp
-    }
+	contains(DEFINES,SOUNDVIZ_SUPPORT) {
+		SOURCES += WindowsSoundManager.cpp
+		HEADERS += WindowsSoundManager.hpp
+	}
 }
 
 unix:!macx {
-    contains(DEFINES,SOUNDVIZ_SUPPORT) {
-        SOURCES += PulseAudioSoundManager.cpp
-        HEADERS += PulseAudioSoundManager.hpp
-    }
+	contains(DEFINES,SOUNDVIZ_SUPPORT) {
+		SOURCES += PulseAudioSoundManager.cpp
+		HEADERS += PulseAudioSoundManager.hpp
+	}
 }
 
 FORMS += SettingsWindow.ui \
-    GrabWidget.ui \
-    GrabConfigWidget.ui \
-    wizard/ZonePlacementPage.ui \
-    wizard/Wizard.ui \
-    wizard/SelectProfilePage.ui \
-    wizard/MonitorIdForm.ui \
-    wizard/MonitorConfigurationPage.ui \
-    wizard/LightpackDiscoveryPage.ui \
-    wizard/ConfigureDevicePage.ui \
-    wizard/ConfigureUdpDevicePage.ui \
-    wizard/ConfigureDevicePowerPage.ui \
-    wizard/SelectDevicePage.ui \
-    wizard/GlobalColorCoefPage.ui
+	GrabWidget.ui \
+	GrabConfigWidget.ui \
+	wizard/ZonePlacementPage.ui \
+	wizard/Wizard.ui \
+	wizard/SelectProfilePage.ui \
+	wizard/MonitorIdForm.ui \
+	wizard/MonitorConfigurationPage.ui \
+	wizard/LightpackDiscoveryPage.ui \
+	wizard/ConfigureDevicePage.ui \
+	wizard/ConfigureUdpDevicePage.ui \
+	wizard/ConfigureDevicePowerPage.ui \
+	wizard/SelectDevicePage.ui \
+	wizard/GlobalColorCoefPage.ui
 
 #
 # QtSingleApplication
@@ -416,4 +417,4 @@ FORMS += SettingsWindow.ui \
 include(qtsingleapplication/src/qtsingleapplication.pri)
 
 OTHER_FILES += \
-    Info.plist
+	Info.plist

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -69,6 +69,10 @@ CONFIG(clang) {
 }
 
 unix:!macx{
+	PKGCONFIG_BIN = $$system(which pkg-config)
+	isEmpty(PKGCONFIG_BIN) {
+		error("pkg-config not found")
+	}
 	CONFIG    += link_pkgconfig
 	PKGCONFIG += libusb-1.0
 

--- a/Software/src/systrayicon/SysTrayIcon.cpp
+++ b/Software/src/systrayicon/SysTrayIcon.cpp
@@ -62,12 +62,10 @@ SysTrayIcon::~SysTrayIcon()
 
 void SysTrayIcon::init()
 {
-	connect(_qsystray, SIGNAL(activated(QSystemTrayIcon::ActivationReason))
-		, this, SLOT(onTrayIcon_Activated(QSystemTrayIcon::ActivationReason)));
-	connect(_qsystray, SIGNAL(messageClicked())
-		, this, SLOT(onTrayIcon_MessageClicked()));
+	connect(_qsystray, &QSystemTrayIcon::activated, this, &SysTrayIcon::onTrayIcon_Activated);
+	connect(_qsystray, &QSystemTrayIcon::messageClicked, this, &SysTrayIcon::onTrayIcon_MessageClicked);
 
-	connect(&_updatesProcessor, SIGNAL(readyRead()), this, SLOT(onCheckUpdate_Finished()));
+	connect(&_updatesProcessor, &UpdatesProcessor::readyRead, this, &SysTrayIcon::onCheckUpdate_Finished);
 
 	_pixmapCache.insert("lock32", new QPixmap(QPixmap(":/icons/lock.png").scaledToWidth(32, Qt::SmoothTransformation)));
 	_pixmapCache.insert("on32", new QPixmap(QPixmap(":/icons/on.png").scaledToWidth(32, Qt::SmoothTransformation)));
@@ -325,11 +323,11 @@ void SysTrayIcon::createActions()
 
 	_switchOnBacklightAction = new QAction(QIcon(":/icons/on.png"), tr("&Turn on"), this);
 	_switchOnBacklightAction->setIconVisibleInMenu(true);
-	connect(_switchOnBacklightAction, SIGNAL(triggered()), this, SIGNAL(backlightOn()));
+	connect(_switchOnBacklightAction, &QAction::triggered, this, &SysTrayIcon::backlightOn);
 
 	_switchOffBacklightAction = new QAction(QIcon(":/icons/off.png"), tr("&Turn off"), this);
 	_switchOffBacklightAction->setIconVisibleInMenu(true);
-	connect(_switchOffBacklightAction, SIGNAL(triggered()), this, SIGNAL(backlightOff()));
+	connect(_switchOffBacklightAction, &QAction::triggered, this, &SysTrayIcon::backlightOff);
 
 
 	_profilesMenu = new QMenu(tr("&Profiles"));
@@ -338,10 +336,10 @@ void SysTrayIcon::createActions()
 
 	_settingsAction = new QAction(QIcon(":/icons/settings.png"), tr("&Settings"), this);
 	_settingsAction->setIconVisibleInMenu(true);
-	connect(_settingsAction, SIGNAL(triggered()), this, SIGNAL(showSettings()));
+	connect(_settingsAction, &QAction::triggered, this, &SysTrayIcon::showSettings);
 
 	_quitAction = new QAction(tr("&Quit"), this);
-	connect(_quitAction, SIGNAL(triggered()), this, SIGNAL(quit()));
+	connect(_quitAction, &QAction::triggered, this, &SysTrayIcon::quit);
 }
 
 void SysTrayIcon::fillProfilesFromSettings()
@@ -360,6 +358,6 @@ void SysTrayIcon::fillProfilesFromSettings()
 			profileAction->setChecked(true);
 		}
 		_profilesMenu->addAction(profileAction);
-		connect(profileAction, SIGNAL(triggered()), this, SLOT(onProfileAction_Triggered()));
+		connect(profileAction, &QAction::triggered, this, &SysTrayIcon::onProfileAction_Triggered);
 	}
 }

--- a/Software/src/wizard/AreaDistributor.hpp
+++ b/Software/src/wizard/AreaDistributor.hpp
@@ -61,6 +61,7 @@ inline int cmp(T x, T y, double e) {
 }
 
 class AreaDistributor {
+	Q_DISABLE_COPY(AreaDistributor)
 public:
 	AreaDistributor(QRect screen, int areaCount) :
 		_areaCount(areaCount),

--- a/Software/src/wizard/AreaDistributor.hpp
+++ b/Software/src/wizard/AreaDistributor.hpp
@@ -28,7 +28,7 @@
 #define AREADISTRIBUTOR_HPP
 #include <QList>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QRect>
 #include <math.h>
 
 class ScreenArea {

--- a/Software/src/wizard/ConfigureDevicePage.cpp
+++ b/Software/src/wizard/ConfigureDevicePage.cpp
@@ -24,7 +24,6 @@
  *
  */
 
-#include <QDesktopWidget>
 #include <QMessageBox>
 
 #include "ConfigureDevicePage.hpp"

--- a/Software/src/wizard/ConfigureDevicePowerPage.cpp
+++ b/Software/src/wizard/ConfigureDevicePowerPage.cpp
@@ -24,7 +24,6 @@
  *
  */
 
-#include <QDesktopWidget>
 #include <QMessageBox>
 
 #include "ConfigureDevicePowerPage.hpp"

--- a/Software/src/wizard/ConfigureDevicePowerPage.cpp
+++ b/Software/src/wizard/ConfigureDevicePowerPage.cpp
@@ -47,21 +47,21 @@ ConfigureDevicePowerPage::ConfigureDevicePowerPage(bool isInitFromSettings, Tran
 void ConfigureDevicePowerPage::initializePage()
 {
 	SupportedDevices::DeviceType device = SupportedDevices::DefaultDeviceType;
-	if (field("isDrgb").toBool())
+	if (field(QStringLiteral("isDrgb")).toBool())
 		device = SupportedDevices::DeviceTypeDrgb;
-	else if (field("isDnrgb").toBool())
+	else if (field(QStringLiteral("isDnrgb")).toBool())
 		device = SupportedDevices::DeviceTypeDnrgb;
-	else if (field("isWarls").toBool())
+	else if (field(QStringLiteral("isWarls")).toBool())
 		device = SupportedDevices::DeviceTypeWarls;
-	else if (field("isLightpack").toBool())
+	else if (field(QStringLiteral("isLightpack")).toBool())
 		device = SupportedDevices::DeviceTypeLightpack;
-	else if (field("isAdalight").toBool())
+	else if (field(QStringLiteral("isAdalight")).toBool())
 		device = SupportedDevices::DeviceTypeAdalight;
-	else if (field("isArdulight").toBool())
+	else if (field(QStringLiteral("isArdulight")).toBool())
 		device = SupportedDevices::DeviceTypeArdulight;
-	else if (field("isVirtual").toBool())
+	else if (field(QStringLiteral("isVirtual")).toBool())
 		device = SupportedDevices::DeviceTypeVirtual;
-	else if (field("isAlienFx").toBool())
+	else if (field(QStringLiteral("isAlienFx")).toBool())
 		device = SupportedDevices::DeviceTypeAlienFx;
 
 	ui->sbLedMilliAmps->setValue(Settings::getDeviceLedMilliAmps(device));
@@ -72,21 +72,21 @@ void ConfigureDevicePowerPage::initializePage()
 bool ConfigureDevicePowerPage::validatePage()
 {
 	SupportedDevices::DeviceType device = SupportedDevices::DefaultDeviceType;
-	if (field("isDrgb").toBool())
+	if (field(QStringLiteral("isDrgb")).toBool())
 		device = SupportedDevices::DeviceTypeDrgb;
-	else if (field("isDnrgb").toBool())
+	else if (field(QStringLiteral("isDnrgb")).toBool())
 		device = SupportedDevices::DeviceTypeDnrgb;
-	else if (field("isWarls").toBool())
+	else if (field(QStringLiteral("isWarls")).toBool())
 		device = SupportedDevices::DeviceTypeWarls;
-	else if (field("isLightpack").toBool())
+	else if (field(QStringLiteral("isLightpack")).toBool())
 		device = SupportedDevices::DeviceTypeLightpack;
-	else if (field("isAdalight").toBool())
+	else if (field(QStringLiteral("isAdalight")).toBool())
 		device = SupportedDevices::DeviceTypeAdalight;
-	else if (field("isArdulight").toBool())
+	else if (field(QStringLiteral("isArdulight")).toBool())
 		device = SupportedDevices::DeviceTypeArdulight;
-	else if (field("isVirtual").toBool())
+	else if (field(QStringLiteral("isVirtual")).toBool())
 		device = SupportedDevices::DeviceTypeVirtual;
-	else if (field("isAlienFx").toBool())
+	else if (field(QStringLiteral("isAlienFx")).toBool())
 		device = SupportedDevices::DeviceTypeAlienFx;
 
 	const int ledMilliAmps = ui->sbLedMilliAmps->value();

--- a/Software/src/wizard/ConfigureUdpDevicePage.cpp
+++ b/Software/src/wizard/ConfigureUdpDevicePage.cpp
@@ -24,7 +24,6 @@
  *
  */
 
-#include <QDesktopWidget>
 #include <QMessageBox>
 
 #include "ConfigureUdpDevicePage.hpp"

--- a/Software/src/wizard/ConfigureUdpDevicePage.cpp
+++ b/Software/src/wizard/ConfigureUdpDevicePage.cpp
@@ -49,7 +49,7 @@ void ConfigureUdpDevicePage::initializePage()
 {
 	QString currentAddress = NULL;
 	QString currentPort = NULL;
-	int currentTimeout = NULL;
+	int currentTimeout = 0;
 
 	if (field("isDrgb").toBool()) {
 		currentAddress = Settings::getDrgbAddress();
@@ -71,7 +71,7 @@ void ConfigureUdpDevicePage::initializePage()
 		ui->leAddress->setText(currentAddress);
 	if (currentPort != NULL && currentPort.isEmpty() == false)
 		ui->lePort->setText(currentPort);
-	if (currentTimeout != NULL)
+	if (currentTimeout != 0)
 		ui->sbTimeout->setValue(currentTimeout);
 
 	registerField("address", ui->leAddress);
@@ -94,7 +94,7 @@ bool ConfigureUdpDevicePage::validatePage()
 
 	if (field("isDrgb").toBool()) {
 		_transSettings->ledDevice.reset(new LedDeviceDrgb(address, port, timeout));
-	} 
+	}
 	else if (field("isDnrgb").toBool()) {
 		_transSettings->ledDevice.reset(new LedDeviceDnrgb(address, port, timeout));
 	}

--- a/Software/src/wizard/GlobalColorCoefPage.cpp
+++ b/Software/src/wizard/GlobalColorCoefPage.cpp
@@ -24,7 +24,6 @@
  *
  */
 
-#include <QDesktopWidget>
 #include <QRadioButton>
 #include "GlobalColorCoefPage.hpp"
 #include "ui_GlobalColorCoefPage.h"

--- a/Software/src/wizard/LightpackDiscoveryPage.cpp
+++ b/Software/src/wizard/LightpackDiscoveryPage.cpp
@@ -29,7 +29,6 @@
 #include "LedDeviceLightpack.hpp"
 #include "Settings.hpp"
 #include "Wizard.hpp"
-#include "QDesktopWidget"
 
 LightpackDiscoveryPage::LightpackDiscoveryPage(bool isInitFromSettings, TransientSettings *ts, QWidget *parent) :
 	QWizardPage(parent),

--- a/Software/src/wizard/MonitorConfigurationPage.cpp
+++ b/Software/src/wizard/MonitorConfigurationPage.cpp
@@ -24,7 +24,6 @@
  *
  */
 
-#include <QDesktopWidget>
 #include <QRadioButton>
 #include <QScreen>
 #include "MonitorConfigurationPage.hpp"

--- a/Software/src/wizard/SelectDevicePage.cpp
+++ b/Software/src/wizard/SelectDevicePage.cpp
@@ -29,7 +29,6 @@
 #include "Wizard.hpp"
 #include "LedDeviceVirtual.hpp"
 #include "LedDeviceDrgb.hpp"
-#include "QDesktopWidget"
 
 SelectDevicePage::SelectDevicePage(bool isInitFromSettings, TransientSettings *ts, QWidget *parent):
 	QWizardPage(parent),

--- a/Software/src/wizard/SelectProfilePage.cpp
+++ b/Software/src/wizard/SelectProfilePage.cpp
@@ -49,7 +49,11 @@ void SelectProfilePage::initializePage()
 	QStringList profiles = Settings::findAllProfiles();
 	ui->cbProfile->addItems(profiles);
 
+	#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+	QRegularExpressionValidator *validatorProfileName = new QRegularExpressionValidator(QRegularExpression("[^<>:\"/\\|?*]*"), this);
+	#else
 	QRegExpValidator *validatorProfileName = new QRegExpValidator(QRegExp("[^<>:\"/\\|?*]*"), this);
+	#endif
 	ui->cbProfile->lineEdit()->setValidator(validatorProfileName);
 	connect(ui->cbProfile->lineEdit(), SIGNAL(editingFinished()) /* or returnPressed() */, this, SLOT(profileRename()));
 	ui->cbProfile->setCurrentText(Settings::getCurrentProfileName());

--- a/Software/src/wizard/ZonePlacementPage.cpp
+++ b/Software/src/wizard/ZonePlacementPage.cpp
@@ -26,7 +26,6 @@
 
 #include "ZonePlacementPage.hpp"
 #include "ui_ZonePlacementPage.h"
-#include "QDesktopWidget"
 #include "AbstractLedDevice.hpp"
 #include "Settings.hpp"
 #include "CustomDistributor.hpp"

--- a/Software/tests/AppVersionTest.cpp
+++ b/Software/tests/AppVersionTest.cpp
@@ -25,7 +25,7 @@
  */
 
 #include "AppVersionTest.hpp"
-#include <QtTest/QtTest>
+#include <QtTest>
 #include "../src/UpdatesProcessor.hpp"
 
 AppVersionTest::AppVersionTest()

--- a/Software/tests/GrabCalculationTest.hpp
+++ b/Software/tests/GrabCalculationTest.hpp
@@ -24,8 +24,8 @@
  */
 
 
-#include <QtCore/QString>
-#include <QtTest/QtTest>
+#include <QString>
+#include <QtTest>
 #include <QRgb>
 #include <QRect>
 #include "enums.hpp"

--- a/Software/tests/HooksTest.cpp
+++ b/Software/tests/HooksTest.cpp
@@ -2,7 +2,7 @@
 #include "ProxyFuncVFTable.hpp"
 #include "HooksTest.h"
 #include "hooksutils.h"
-#include <QtTest/QtTest>
+#include <QtTest>
 
 HooksTest::HooksTest(QObject *parent) :
 	QObject(parent)

--- a/Software/tests/LightpackApiTest.cpp
+++ b/Software/tests/LightpackApiTest.cpp
@@ -24,7 +24,7 @@
  */
 
 #include <QString>
-#include <QtWidgets/QApplication>
+#include <QApplication>
 #include <QTest>
 
 #include "debug.h"

--- a/Software/tests/LightpackCommandLineParserTest.cpp
+++ b/Software/tests/LightpackCommandLineParserTest.cpp
@@ -1,6 +1,6 @@
 #include "LightpackCommandLineParserTest.hpp"
 #include "LightpackCommandLineParser.hpp"
-#include <QtTest/QtTest>
+#include <QtTest>
 
 LightpackCommandLineParserTest::LightpackCommandLineParserTest(QObject *parent)
 	: QObject(parent)

--- a/Software/tests/LightpackCommandLineParserTest.hpp
+++ b/Software/tests/LightpackCommandLineParserTest.hpp
@@ -26,7 +26,7 @@
 #ifndef LIGHTPACKCOMMANDLINEPARSERTEST_H
 #define LIGHTPACKCOMMANDLINEPARSERTEST_H
 
-#include <QtTest/QtTest>
+#include <QtTest>
 
 class LightpackCommandLineParserTest : public QObject
 {

--- a/Software/tests/TestsMain.cpp
+++ b/Software/tests/TestsMain.cpp
@@ -1,4 +1,4 @@
-#include <QtTest/QtTest>
+#include <QtTest>
 #include "LightpackApiTest.hpp"
 #include "GrabCalculationTest.hpp"
 #include "lightpackmathtest.hpp"

--- a/Software/tests/tests.pro
+++ b/Software/tests/tests.pro
@@ -9,14 +9,13 @@ QT         += widgets network testlib
 TARGET      = LightpackTests
 DESTDIR     = bin
 
-CONFIG     += console
+CONFIG     += console c++17
 CONFIG     -= app_bundle
 
 include(../build-config.prf)
 
-CONFIG(gcc):QMAKE_CXXFLAGS += -std=c++17
 CONFIG(clang) {
-    QMAKE_CXXFLAGS += -std=c++17 -stdlib=libc++
+    QMAKE_CXXFLAGS += -stdlib=libc++
     LIBS += -stdlib=libc++
 }
 

--- a/Software/tests/tests.pro
+++ b/Software/tests/tests.pro
@@ -14,9 +14,9 @@ CONFIG     -= app_bundle
 
 include(../build-config.prf)
 
-CONFIG(gcc):QMAKE_CXXFLAGS += -std=c++11
+CONFIG(gcc):QMAKE_CXXFLAGS += -std=c++17
 CONFIG(clang) {
-    QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++
+    QMAKE_CXXFLAGS += -std=c++17 -stdlib=libc++
     LIBS += -stdlib=libc++
 }
 

--- a/Software/unhook/unhook.pro
+++ b/Software/unhook/unhook.pro
@@ -30,7 +30,7 @@ CONFIG(msvc) {
     # Place *.lib and *.exp files in ../lib
     QMAKE_LFLAGS += /IMPLIB:..\\lib\\$(TargetName).lib
 } else {
-    QMAKE_CXXFLAGS += -std=c++11
+    QMAKE_CXXFLAGS += -std=c++17
     QMAKE_LFLAGS += -static
 }
 

--- a/Software/unhook/unhook.pro
+++ b/Software/unhook/unhook.pro
@@ -18,6 +18,7 @@ LIBS += -lshlwapi -ladvapi32 -luser32
 QMAKE_LFLAGS_EXCEPTIONS_ON -= -mthreads
 QMAKE_CXXFLAGS_EXCEPTIONS_ON -= -mthreads
 
+CONFIG += c++17
 CONFIG -= rtti
 
 DEFINES += HOOKSDLL_EXPORTS UNICODE
@@ -30,7 +31,6 @@ CONFIG(msvc) {
     # Place *.lib and *.exp files in ../lib
     QMAKE_LFLAGS += /IMPLIB:..\\lib\\$(TargetName).lib
 } else {
-    QMAKE_CXXFLAGS += -std=c++17
     QMAKE_LFLAGS += -static
 }
 

--- a/Software/unhook/unhook32.pro
+++ b/Software/unhook/unhook32.pro
@@ -24,6 +24,7 @@ Debug:OBJECTS_DIR = debug/32
 QMAKE_LFLAGS_EXCEPTIONS_ON -= -mthreads
 QMAKE_CXXFLAGS_EXCEPTIONS_ON -= -mthreads
 
+CONFIG += c++17
 CONFIG -= rtti
 
 DEFINES += HOOKSDLL_EXPORTS UNICODE
@@ -36,7 +37,6 @@ CONFIG(msvc) {
     # Place *.lib and *.exp files in ../lib
     QMAKE_LFLAGS += /IMPLIB:..\\lib\\$(TargetName).lib
 } else {
-    QMAKE_CXXFLAGS += -std=c++17
     QMAKE_LFLAGS += -static
 }
 

--- a/Software/unhook/unhook32.pro
+++ b/Software/unhook/unhook32.pro
@@ -36,7 +36,7 @@ CONFIG(msvc) {
     # Place *.lib and *.exp files in ../lib
     QMAKE_LFLAGS += /IMPLIB:..\\lib\\$(TargetName).lib
 } else {
-    QMAKE_CXXFLAGS += -std=c++11
+    QMAKE_CXXFLAGS += -std=c++17
     QMAKE_LFLAGS += -static
 }
 


### PR DESCRIPTION
I ran the build through [clazy](https://github.com/KDE/clazy) and it highlighted a lot of small things (still does) to improve
here are most of those things:
- `QStringLiteral` (compile time `QString` basically)
- [new connect syntax](https://wiki.qt.io/New_Signal_Slot_Syntax) so slots/signals are checked at build time (found few loose things this way)
  - which in some cases needs c++14, so I bumped everything to 17
also apparently doing this through `FLAGS` does not work well because `qmake` would still append whatever the default is from `mkspec`, so changing this via `CONFIG` solves that
- some missing `const`s
- `std::chrono_literals` for `QTimer`s
- `QList::reserve()` where possible
- random normal gcc/clang warnings (casts etc)

After that I tried building with Qt6 RC, and after some minor massaging it worked
- `QSettings` assumes utf-8 now, so no need for `setIniCodec()` (which is dropped from core anyway)
- `QRegExp*` is `QRegularExpression*` now
- `QList` [works slightly differently now](https://doc-snapshots.qt.io/qt6-dev/qtcore-changes-qt6.html#memory-layout) and does not like forward declarations for item types
I'm not sure if there's more to be done for this part given what they say (like is it leaking as is or...)
- couple other minor things

but just by itself this PR has like 95% of the above (so just this would not build with Qt6 for ex)
- #408 takes care of it's own problematic parts (they were removed there so I tried to not overstep too much)
- #363 got some of the clazy treatment too, but there's nothing blocking iirc

once all 3 are merged, another quick pass would be needed (this one should probably go first)

while dealing with slots and signals I did some device refactoring, mostly de-copypasta'd UDP, and fixed couple of small things on the way
there's a lot more to do there, but that'll wait another time

and finally, removed remaining `QDekstopWidget` usage which I started doing a while ago with some deprecations, but at the time they were saying "use these other classes/methods" which themselves used `QDekstopWidget` but were not flagged as deprecated for some reason and now [everything gets removed in Qt6](https://doc-snapshots.qt.io/qt6-dev/widgets-changes-qt6.html#qdesktopwidget-and-qapplication-desktop)...
these changes seem to work, but I can't test multiple displays

otherwise this builds and runs on all 3 platforms