### PR TITLE
udp led devices: allow bypassing color modifications

### DIFF
--- a/Software/src/AbstractLedDevice.cpp
+++ b/Software/src/AbstractLedDevice.cpp
@@ -112,7 +112,7 @@ void AbstractLedDevice::updateDeviceSettings()
 	All modifications are made over extended 12bit RGB, so \code outColors \endcode will contain 12bit
 	RGB instead of 8bit.
 */
-void AbstractLedDevice::applyColorModifications(const QList<QRgb> &inColors, QList<StructRgb> &outColors) {
+void AbstractLedDevice::applyColorModifications(const QList<QRgb> &inColors, QList<StructRgb> &outColors, const bool rawColors) {
 
 	const bool isApplyWBAdjustments = m_wbAdjustments.count() == inColors.count();
 
@@ -124,8 +124,13 @@ void AbstractLedDevice::applyColorModifications(const QList<QRgb> &inColors, QLi
 		outColors[i].g = qGreen(inColors[i]) * k;
 		outColors[i].b = qBlue(inColors[i]) * k;
 
-		PrismatikMath::gammaCorrection(m_gamma, outColors[i]);
+		if (!rawColors)
+			PrismatikMath::gammaCorrection(m_gamma, outColors[i]);
 	}
+
+	// we can't completely bypass this function because of the Qrgb / StructRgb conversion above
+	if (rawColors)
+		return;
 
 	const StructLab avgColor = PrismatikMath::toLab(PrismatikMath::avgColor(outColors));
 

--- a/Software/src/AbstractLedDevice.hpp
+++ b/Software/src/AbstractLedDevice.hpp
@@ -96,7 +96,7 @@ public slots:
 	virtual void setUsbPowerLedDisabled(bool isDisabled);
 
 protected:
-	virtual void applyColorModifications(const QList<QRgb> & inColors, QList<StructRgb> & outColors);
+	virtual void applyColorModifications(const QList<QRgb> & inColors, QList<StructRgb> & outColors, const bool rawColors = false);
 	virtual void applyDithering(QList<StructRgb>& colors, int colorDepth);
 
 protected:

--- a/Software/src/AbstractLedDeviceUdp.cpp
+++ b/Software/src/AbstractLedDeviceUdp.cpp
@@ -110,7 +110,7 @@ void AbstractLedDeviceUdp::switchOffLeds()
 	blackFrame.reserve(count);
 	for (int i = 0; i < count; i++)
 		blackFrame << 0;
-	setColors(blackFrame);
+	setColors(blackFrame, true);
 }
 
 void AbstractLedDeviceUdp::resizeColorsBuffer(int buffSize)

--- a/Software/src/AbstractLedDeviceUdp.hpp
+++ b/Software/src/AbstractLedDeviceUdp.hpp
@@ -47,6 +47,8 @@ public slots:
 	virtual void setColorDepth(int value);
 	virtual void requestFirmwareVersion();
 	void switchOffLeds();
+	virtual void setColors(const QList<QRgb> & colors, const bool rawColors) = 0;
+	void setColors(const QList<QRgb> & colors) {setColors(colors, false);};
 
 protected:
 	QByteArray m_writeBufferHeader;

--- a/Software/src/LedDeviceDnrgb.cpp
+++ b/Software/src/LedDeviceDnrgb.cpp
@@ -41,15 +41,16 @@ int LedDeviceDnrgb::maxLedsCount()
 	return MaximumNumberOfLeds::Dnrgb;
 }
 
-void LedDeviceDnrgb::setColors(const QList<QRgb> & colors)
+void LedDeviceDnrgb::setColors(const QList<QRgb> & colors, const bool rawColors)
 {
 	bool ok = true;
 	bool sentPackets = false;
 
 	resizeColorsBuffer(colors.count());
 
-	applyColorModifications(colors, m_colorsBuffer);
-	applyDithering(m_colorsBuffer, 8);
+	applyColorModifications(colors, m_colorsBuffer, rawColors);
+	if (!rawColors)
+		applyDithering(m_colorsBuffer, 8);
 
 	// Send multiple buffers
 	const int totalColorsSaved = m_processedColorsSaved.count();

--- a/Software/src/LedDeviceDnrgb.hpp
+++ b/Software/src/LedDeviceDnrgb.hpp
@@ -37,7 +37,7 @@ public:
 	int maxLedsCount();
 
 public slots:
-	void setColors(const QList<QRgb> & colors);
+	void setColors(const QList<QRgb> & colors, const bool rawColors);
 
 protected:
 	virtual void reinitBufferHeader();

--- a/Software/src/LedDeviceDrgb.cpp
+++ b/Software/src/LedDeviceDrgb.cpp
@@ -41,14 +41,15 @@ int LedDeviceDrgb::maxLedsCount()
 	return MaximumNumberOfLeds::Drgb;
 }
 
-void LedDeviceDrgb::setColors(const QList<QRgb> & colors)
+void LedDeviceDrgb::setColors(const QList<QRgb> & colors, const bool rawColors)
 {
 	m_colorsSaved = colors;
 
 	resizeColorsBuffer(colors.count());
 
-	applyColorModifications(colors, m_colorsBuffer);
-	applyDithering(m_colorsBuffer, 8);
+	applyColorModifications(colors, m_colorsBuffer, rawColors);
+	if (!rawColors)
+		applyDithering(m_colorsBuffer, 8);
 
 	m_writeBuffer.clear();
 	m_writeBuffer.reserve(m_writeBuffer.count() + m_colorsBuffer.count() * sizeof(char));

--- a/Software/src/LedDeviceDrgb.hpp
+++ b/Software/src/LedDeviceDrgb.hpp
@@ -37,7 +37,7 @@ public:
 	int maxLedsCount();
 
 public slots:
-	void setColors(const QList<QRgb> & colors);
+	void setColors(const QList<QRgb> & colors, const bool rawColors);
 
 protected:
 	virtual void reinitBufferHeader();

--- a/Software/src/LedDeviceWarls.cpp
+++ b/Software/src/LedDeviceWarls.cpp
@@ -41,12 +41,13 @@ int LedDeviceWarls::maxLedsCount()
 	return MaximumNumberOfLeds::Warls;
 }
 
-void LedDeviceWarls::setColors(const QList<QRgb> & colors)
+void LedDeviceWarls::setColors(const QList<QRgb> & colors, const bool rawColors)
 {
 	resizeColorsBuffer(colors.count());
 
-	applyColorModifications(colors, m_colorsBuffer);
-	applyDithering(m_colorsBuffer, 8);
+	applyColorModifications(colors, m_colorsBuffer, rawColors);
+	if (!rawColors)
+		applyDithering(m_colorsBuffer, 8);
 
 	const int totalColorsSaved = m_processedColorsSaved.count();
 	m_writeBuffer.clear();

--- a/Software/src/LedDeviceWarls.hpp
+++ b/Software/src/LedDeviceWarls.hpp
@@ -37,7 +37,7 @@ public:
 	int maxLedsCount();
 
 public slots:
-	void setColors(const QList<QRgb> & colors);
+	void setColors(const QList<QRgb> & colors, const bool rawColors);
 
 protected:
 	virtual void reinitBufferHeader();


### PR DESCRIPTION
in UDP refactor I made `switchOffLeds()` use `setColors()` which resulted in OFF-frames getting altered by filters #472