### PR TITLE
disconnect / recreate device on sleep/resume

### DIFF
--- a/Software/grab/DDuplGrabber.cpp
+++ b/Software/grab/DDuplGrabber.cpp
@@ -284,7 +284,7 @@ QList< ScreenInfo > * DDuplGrabber::__screensWithWidgets(QList< ScreenInfo > * r
 	return result;
 }
 
-void DDuplGrabber::onSessionChange(int change)
+void DDuplGrabber::onSessionChange(SystemSession::Status change)
 {
 	if (change == SystemSession::Status::Locking)
 	{

--- a/Software/grab/include/DDuplGrabber.hpp
+++ b/Software/grab/include/DDuplGrabber.hpp
@@ -41,7 +41,9 @@
 #include <comdef.h>
 MIDL_INTERFACE("29038f61-3839-4626-91fd-086879011a05") IDXGIAdapter1;
 _COM_SMARTPTR_TYPEDEF(IDXGIAdapter1, __uuidof(IDXGIAdapter1));
-
+namespace SystemSession {
+	enum Status;
+};
 enum DDuplGrabberState
 {
 	Uninitialized,
@@ -69,7 +71,7 @@ public:
 	DECLARE_GRABBER_NAME("DDuplGrabber")
 
 public slots:
-	void onSessionChange(int change);
+	void onSessionChange(SystemSession::Status change);
 
 protected slots:
 	virtual GrabResult grabScreens();

--- a/Software/src/GrabManager.hpp
+++ b/Software/src/GrabManager.hpp
@@ -35,6 +35,7 @@ class TimeEvaluations;
 class D3D10Grabber;
 
 namespace BlueLightReduction { class Client; };
+namespace SystemSession { enum Status; };
 
 class GrabManager : public QObject
 {
@@ -48,7 +49,7 @@ signals:
 	void updateLedsColors(const QList<QRgb> & colors);
 	void ambilightTimeOfUpdatingColors(double ms);
 	void changeScreen();
-	void onSessionChange(int change);
+	void onSessionChange(SystemSession::Status change);
 
 public:
 

--- a/Software/src/LedDeviceManager.cpp
+++ b/Software/src/LedDeviceManager.cpp
@@ -40,6 +40,7 @@
 #include "LedDeviceDnrgb.hpp"
 #include "LedDeviceWarls.hpp"
 #include "Settings.hpp"
+#include "SystemSession.hpp"
 
 using namespace SettingsScope;
 
@@ -696,4 +697,12 @@ void LedDeviceManager::ledDeviceCommandTimedOut()
 	emit ioDeviceSuccess(false);
 }
 
+void LedDeviceManager::onSessionChange(SystemSession::Status status)
+{
+	DEBUG_LOW_LEVEL << Q_FUNC_INFO << "status:" << status;
 
+	if (status == SystemSession::Status::Sleeping)
+		m_ledDevice->close();
+	else if (status == SystemSession::Status::Resuming)
+		recreateLedDevice();
+}

--- a/Software/src/LedDeviceManager.hpp
+++ b/Software/src/LedDeviceManager.hpp
@@ -30,7 +30,9 @@
 #include "AbstractLedDevice.hpp"
 
 class QTimer;
-
+namespace SystemSession {
+	enum Status;
+};
 /*!
 	This class creates \a ILedDevice implementations and manages them after.
 	It is always better way to interact with ILedDevice through \code LedDeviceManager \endcode.
@@ -92,6 +94,7 @@ public slots:
 	void requestFirmwareVersion();
 	void updateWBAdjustments();
 	void updateDeviceSettings();
+	void onSessionChange(SystemSession::Status status);
 
 private slots:
 	void ledDeviceCommandCompleted(bool ok);

--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -179,6 +179,7 @@ void LightpackApplication::initializeAll(const QString & appDirPath)
         QSharedPointer<SystemSession::EventFilter> sessionChangeDetector(eventFilter);
         connect(sessionChangeDetector.data(), &SystemSession::EventFilter::sessionChangeDetected, this, &LightpackApplication::onSessionChange);
         connect(sessionChangeDetector.data(), &SystemSession::EventFilter::sessionChangeDetected, m_grabManager, &GrabManager::onSessionChange);
+        connect(sessionChangeDetector.data(), &SystemSession::EventFilter::sessionChangeDetected, m_ledDeviceManager, &LedDeviceManager::onSessionChange);
         m_EventFilters.push_back(sessionChangeDetector);
     }
 	for (EventFilters::const_iterator it = m_EventFilters.cbegin(); it != m_EventFilters.cend(); ++it)
@@ -337,7 +338,7 @@ void LightpackApplication::quitFromWizard(int result)
 	quit();
 }
 
-void LightpackApplication::onSessionChange(int change)
+void LightpackApplication::onSessionChange(SystemSession::Status change)
 {
 	switch (change)
 	{

--- a/Software/src/LightpackApplication.hpp
+++ b/Software/src/LightpackApplication.hpp
@@ -83,7 +83,7 @@ private slots:
 //	void handleConnectedDeviceChange(const SupportedDevices::DeviceType);
 	void onFocusChanged(QWidget *, QWidget *);
 	void quitFromWizard(int result);
-	void onSessionChange(int change);
+	void onSessionChange(SystemSession::Status change);
 
 private:
 	void processCommandLineArguments();

--- a/Software/src/SystemSession.hpp
+++ b/Software/src/SystemSession.hpp
@@ -36,7 +36,7 @@ namespace SystemSession {
         static EventFilter* create();
 
     signals:
-        void sessionChangeDetected(int status);
+        void sessionChangeDetected(Status status);
     };
 }
 


### PR DESCRIPTION
since there's no reliable way of knowing if serial/udp socket is actually connected and doing ok, maybe explicitly resetting the connection on sleep/resume could work
something to try
(I can't test this use case for now)