### PR TITLE
Send ioDeviceSuccess from non-Lightpack devices

### DIFF
--- a/Software/src/AbstractLedDeviceUdp.cpp
+++ b/Software/src/AbstractLedDeviceUdp.cpp
@@ -148,8 +148,10 @@ bool AbstractLedDeviceUdp::writeBuffer(const QByteArray& buff)
 	if (bytesWritten != buff.count())
 	{
 		qWarning() << Q_FUNC_INFO << "bytesWritten != buff.count():" << bytesWritten << buff.count() << " " << m_Socket->errorString();
+		emit ioDeviceSuccess(false);
 		return false;
 	}
 
+	emit ioDeviceSuccess(true);
 	return true;
 }

--- a/Software/src/LedDeviceAdalight.cpp
+++ b/Software/src/LedDeviceAdalight.cpp
@@ -290,9 +290,11 @@ bool LedDeviceAdalight::writeBuffer(const QByteArray & buff)
 	if (bytesWritten != buff.count())
 	{
 		qWarning() << Q_FUNC_INFO << "bytesWritten != buff.count():" << bytesWritten << buff.count() << " " << m_AdalightDevice->errorString();
+		emit ioDeviceSuccess(false);
 		return false;
 	}
 
+	emit ioDeviceSuccess(true);
 	return true;
 }
 

--- a/Software/src/LedDeviceArdulight.cpp
+++ b/Software/src/LedDeviceArdulight.cpp
@@ -297,9 +297,11 @@ bool LedDeviceArdulight::writeBuffer(const QByteArray & buff)
 	if (bytesWritten != buff.count())
 	{
 		qWarning() << Q_FUNC_INFO << "bytesWritten != buff.count():" << bytesWritten << buff.count() << " " << m_ArdulightDevice->errorString();
+		emit ioDeviceSuccess(false);
 		return false;
 	}
 
+	emit ioDeviceSuccess(true);
 	return true;
 }
 


### PR DESCRIPTION
This should trigger the recovery mechanics in LedDeviceManager (#331)