### PR TITLE
Fix issues regarding the Linux flatpak package

### DIFF
--- a/Software/dist_linux/flatpak/launch_prismatik.sh
+++ b/Software/dist_linux/flatpak/launch_prismatik.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+my_args=( "$@" )
+
+has_config_dir=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --config-dir)
+      has_config_dir=true
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ "$has_config_dir" = true ] ; then
+    prismatik "${my_args[@]}"
+else
+    prismatik --config-dir "$XDG_CONFIG_HOME/prismatik" "${my_args[@]}"
+fi

--- a/Software/dist_linux/flatpak/manifest.yml.template
+++ b/Software/dist_linux/flatpak/manifest.yml.template
@@ -9,7 +9,7 @@ finish-args:
 
   - --share=network
   - --socket=pulseaudio
-  - --filesystem=~/.Prismatik:rw
+  #- --filesystem=~/.Prismatik:rw
   - --device=all
 
   # needed for tray

--- a/Software/dist_linux/flatpak/manifest.yml.template
+++ b/Software/dist_linux/flatpak/manifest.yml.template
@@ -9,7 +9,6 @@ finish-args:
 
   - --share=network
   - --socket=pulseaudio
-  #- --filesystem=~/.Prismatik:rw
   - --device=all
 
   # needed for tray

--- a/Software/dist_linux/flatpak/manifest.yml.template
+++ b/Software/dist_linux/flatpak/manifest.yml.template
@@ -53,10 +53,12 @@ modules:
       - cd Software && make -j$FLATPAK_BUILDER_N_JOBS
       - sed -E 's#(Exec|Icon)=.+#\1=de.psieg.Prismatik#' $PKG_TEMPLATE_DIR/usr/share/applications/prismatik.desktop > _prismatik.desktop
       - install -Dm644 _prismatik.desktop $FLATPAK_DEST/usr/share/applications/$FLATPAK_ID.desktop
+      - install -Dm644 _prismatik.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop
       - install -Dm644 $PKG_TEMPLATE_DIR/etc/udev/rules.d/93-lightpack.rules $FLATPAK_DEST/etc/udev/rules.d/93-lightpack.rules
       - install -Dm644 $PKG_TEMPLATE_DIR/usr/share/icons/hicolor/22x22/apps/prismatik-on.png $FLATPAK_DEST/usr/share/icons/hicolor/22x22/apps/$FLATPAK_ID.png
       - install -Dm644 $PKG_TEMPLATE_DIR/usr/share/icons/Prismatik.png $FLATPAK_DEST/usr/share/icons/$FLATPAK_ID.png
       - install -Dm644 $PKG_TEMPLATE_DIR/usr/share/pixmaps/Prismatik.png $FLATPAK_DEST/usr/share/pixmaps/$FLATPAK_ID.png
+      - install -Dm644 $PKG_TEMPLATE_DIR/usr/share/icons/Prismatik.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps/$FLATPAK_ID.png
       - install -Dm755 -s Software/bin/Prismatik $FLATPAK_DEST/bin/prismatik
     sources:
       - type: dir

--- a/Software/dist_linux/flatpak/manifest.yml.template
+++ b/Software/dist_linux/flatpak/manifest.yml.template
@@ -18,7 +18,7 @@ finish-args:
   - --own-name=org.kde.*
 build-options:
   strip: true
-command: prismatik
+command: launch_prismatik.sh
 modules:
   - name: libusb
     buildsystem: autotools
@@ -51,7 +51,7 @@ modules:
       - qmake -v
       - cd Software && qmake -r
       - cd Software && make -j$FLATPAK_BUILDER_N_JOBS
-      - sed -E 's#(Exec|Icon)=.+#\1=de.psieg.Prismatik#' $PKG_TEMPLATE_DIR/usr/share/applications/prismatik.desktop > _prismatik.desktop
+      - sed -E 's#(Icon)=.+#\1=de.psieg.Prismatik#;s#(Exec)=.+#\1=launch_prismatik.sh#' $PKG_TEMPLATE_DIR/usr/share/applications/prismatik.desktop > _prismatik.desktop
       - install -Dm644 _prismatik.desktop $FLATPAK_DEST/usr/share/applications/$FLATPAK_ID.desktop
       - install -Dm644 _prismatik.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop
       - install -Dm644 $PKG_TEMPLATE_DIR/etc/udev/rules.d/93-lightpack.rules $FLATPAK_DEST/etc/udev/rules.d/93-lightpack.rules
@@ -63,3 +63,11 @@ modules:
     sources:
       - type: dir
         path: ../../..
+        
+  - name: launcher
+    buildsystem: simple
+    build-commands:
+      - install -D launch_prismatik.sh /app/bin/launch_prismatik.sh
+    sources:
+      - type: file
+        path: launch_prismatik.sh


### PR DESCRIPTION
This PR fixes #541 

Changes done:

1. Put the app icon and .desktop file to the standard paths according to https://docs.flatpak.org/en/latest/conventions.html
2. Add and use a wrapper script to launch Prismatik. The wrapper script basically launches Prismatik with all arguments passed through. However, if `--config-dir` is not defined, use `$XDG_CONFIG_HOME/prismatik` with reference to https://docs.flatpak.org/en/latest/conventions.html#xdg-base-directories
3. No need to export `~/.prismatik` as the configuration is now placed in the flatpak-specific directory as controlled by the wrapper script by default. If user still wants to use `~/.prismatik` or other non-standard directory, they need to allow the flatpak to access those directory manually by `flatpak override` or using Flatseal