### PR TITLE
Skip action-docker-layer-caching on Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
       - run: echo "DOCKER_CACHE_PREFIX=$(echo ${{ matrix.os }} | tr -d ' ')-" >> $GITHUB_ENV
-      - uses: satackey/action-docker-layer-caching@v0.0.10
+      - if: matrix.os != 'ubuntu 20.04'
+        uses: satackey/action-docker-layer-caching@v0.0.10
         continue-on-error: true
         with:
           key: ${{ env.DOCKER_CACHE_PREFIX }}{hash}


### PR DESCRIPTION
it seems to lead to the runner running out of disk space (satackey/action-docker-layer-caching/issues/78)